### PR TITLE
Actually change to "Herd Dig"

### DIFF
--- a/src/qt/forms/miningpage.ui
+++ b/src/qt/forms/miningpage.ui
@@ -202,12 +202,12 @@
      </property>
      <item>
       <property name="text">
-       <string>Herd Dig</string>
+       <string>Solo Dig</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Pool Dig</string>
+       <string>Herd Dig</string>
       </property>
      </item>
     </widget>


### PR DESCRIPTION
I incorrectly renamed Solo Dig to Herd Dig instead of Pool Dig. This patch fixes that error.
