### PR TITLE
make capitalization consistient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # DogeCoin [DOGE, Ð]
 http://dogecoin.com/
 
-![Dogecoin](http://static.tumblr.com/ppdj5y9/Ae9mxmxtp/300coin.png)
+![DogeCoin](http://static.tumblr.com/ppdj5y9/Ae9mxmxtp/300coin.png)
 
-## What is Dogecoin? - Such coin
+## What is DogeCoin? - Such coin
 Dogecoin is like Bitcoin, but based on Litecoin, and also much more wow.
 http://dogecoin.com/
 
 ## License - Much license
-Dogecoin is released under the terms of the MIT license. See [COPYING](COPYING)
+DogeCoin is released under the terms of the MIT license. See [COPYING](COPYING)
 for more information or see http://opensource.org/licenses/MIT.
 
 ## Development and contributions - omg developers


### PR DESCRIPTION
Dogecoin-Qt uses "DogeCoin" but some parts of this README used "Dogecoin" - I fixed this.
