### PR TITLE
Fixes for building dogecoind on OSX 10.8.4 with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Special reward system: Random block rewards
 
 ### Wow plz make dogecoind
 
+#### Linux:
+
     sudo apt-get install build-essential \
                          libssl-dev \
                          libdb5.1++-dev \
@@ -52,6 +54,16 @@ Special reward system: Random block rewards
 
     cd src/
     make -f makefile.unix USE_UPNP=1 USE_IPV6=1 USE_QRCODE=1
+
+#### Mac OSX:
+
+    brew install boost miniupnpc openssl berkeley-db
+    openssl version # should be OpenSSL 1.0.1e
+                    # if not, then do `brew link openssl --force`
+
+    git apply contrib/homebrew/makefile.osx.patch
+    cd src/
+    make -f makefile.osx USE_UPNP=1 USE_IPV6=1 USE_QRCODE=1
 
 ### Such ports
 RPC 22555

--- a/contrib/homebrew/makefile.osx.patch
+++ b/contrib/homebrew/makefile.osx.patch
@@ -1,0 +1,43 @@
+diff --git a/src/makefile.osx b/src/makefile.osx
+index 1c56866..69a967d 100644
+--- a/src/makefile.osx
++++ b/src/makefile.osx
+@@ -7,17 +7,15 @@
+ # Originally by Laszlo Hanyecz (solar@heliacal.net)
+ 
+ CXX=llvm-g++
+-DEPSDIR=/opt/local
++DEPSDIR=/usr/local
+ 
+ INCLUDEPATHS= \
+  -I"$(CURDIR)" \
+  -I"$(CURDIR)"/obj \
+- -I"$(DEPSDIR)/include" \
+- -I"$(DEPSDIR)/include/db48"
++ -I"$(DEPSDIR)/include"
+ 
+ LIBPATHS= \
+- -L"$(DEPSDIR)/lib" \
+- -L"$(DEPSDIR)/lib/db48"
++ -L"$(DEPSDIR)/lib"
+ 
+ USE_UPNP:=1
+ 
+@@ -30,7 +28,7 @@ ifdef STATIC
+ TESTLIBS += \
+  $(DEPSDIR)/lib/libboost_unit_test_framework-mt.a
+ LIBS += \
+- $(DEPSDIR)/lib/db48/libdb_cxx-4.8.a \
++ $(DEPSDIR)/lib/libdb_cxx.a \
+  $(DEPSDIR)/lib/libboost_system-mt.a \
+  $(DEPSDIR)/lib/libboost_filesystem-mt.a \
+  $(DEPSDIR)/lib/libboost_program_options-mt.a \
+@@ -42,7 +40,7 @@ else
+ TESTLIBS += \
+  -lboost_unit_test_framework-mt
+ LIBS += \
+- -ldb_cxx-4.8 \
++ -ldb_cxx \
+  -lboost_system-mt \
+  -lboost_filesystem-mt \
+  -lboost_program_options-mt \


### PR DESCRIPTION
Cleaned up everything that was in [this previous pull request](https://github.com/dogecoin/dogecoin/pull/124). @somegeekintn and @shrx were helping on the previous request.

I am running OSX 10.8.4. There were some issues building on OSX 10.9. It is suspected that the issues are caused by different `g++` versions. Specifically:

on 10.8.4:

```
clang --version
Apple LLVM version 4.2 (clang-425.0.28) (based on LLVM 3.2svn)
Target: x86_64-apple-darwin12.4.1
Thread model: posix
```

on 10.9.1:

```
clang --version
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.0
Thread model: posix
```

Original pull request comment is below:

When building dogecoind on OSX I get this error with the [dogecoin](github.com/dogecoin/dogecoin) codebase:

```
ld: warning: directory not found for option '-L/opt/local/lib'
ld: warning: directory not found for option '-L/opt/local/lib/db48'
ld: library not found for -ldb_cxx-4.8
collect2: ld returned 1 exit status
make: *** [dogecoind] Error 1
```

The version of berkeley db that brew installs is 5.3 so I've made changes to support it. I'd be happy to make modifications if this isn't quite the ideal solution. I'm not extremely familiar with make so there might be some issues with this approach.
