### PR TITLE
Fixed testnet crash by merging 1.4.1 genesis block generation code.

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -224,7 +224,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nTx            = diskindex.nTx;
 
                 // Watch for genesis block
-                if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == hashGenesisBlock)
+                if (pindexGenesisBlock == NULL && diskindex.GetBlockHash() == hashGenesisBlock || (fTestNet && pindexNew->nHeight == 0))
                     pindexGenesisBlock = pindexNew;
 
                 if (!pindexNew->CheckIndex())


### PR DESCRIPTION
Generates a genesis block on testnet. This was copied from version 1.4.1. I'm not sure we even need to do the generation though? It will deterministically generate the testnet genesis block with a nonce of 99943, which is the same as the main dogechain genesis block.

The litecoin codebase has a hard-coded testnet hashGenesisBlock (https://github.com/litecoin-project/litecoin/blob/master-0.8/src/main.cpp#L2726)

```
hashGenesisBlock = uint256("0xf5ae71e26c74beacc88382716aced69cddf3dffff24f384e1808905e0188f68f");
```

And nTime and nNonce different from the main litecoin blockchain.

```
    block.nVersion = 1;
    block.nTime    = 1317972665;
    block.nBits    = 0x1e0ffff0;
    block.nNonce   = 2084524493;

    if (fTestNet)
    {
        block.nTime    = 1317798646;
        block.nNonce   = 385270584;
    }
```

While dogecoin testnet has the genesis block set to zero

```
hashGenesisBlock = uint256("0x");
```

and the nTime the same as the main dogecoin blockchain (which will make the nonce the same)

```
    block.nVersion = 1;
    block.nTime    = 1386325540;
    block.nBits    = 0x1e0ffff0;
    block.nNonce   = 99943;

    if (fTestNet)
    {
        block.nTime    = 1386325540;
        block.nNonce   = 0;
    }
```

I'm not sure if we have an official testnet for dogecoin? Perhaps we should mine a gensis block with a different nTime and nNonce and hardcode that into the code going forward?

Fixes issue #167.
