### PR TITLE
Re-add IRC random channel adding

### DIFF
--- a/src/irc.cpp
+++ b/src/irc.cpp
@@ -300,7 +300,7 @@ void ThreadIRCSeed2()
             // randomly join #dogecoin00-#dogecoin99
             // network is now over 3k peers , get them to join 50 random channels!
             //            channel_number = 0; 
-            int channel_number = 0; //GetRandInt(50);
+            int channel_number = GetRandInt(50);
 
             Send(hSocket, strprintf("JOIN #dogecoin%02d\r", channel_number).c_str());
             Send(hSocket, strprintf("WHO #dogecoin%02d\r", channel_number).c_str());


### PR DESCRIPTION
A change at some point made all clients go to the same IRC channel again -- with so many clients, that will cause a lot of flooding, so this pull sets it back to 50 random channels.
