### PR TITLE
Allow a fixed list of change addresses.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1248,6 +1248,19 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend,
                     if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
                         scriptChange.SetDestination(coinControl->destChange);
                         
+                    // send change to one of the specified change addresses
+                    else if (mapArgs.count("-change") && mapMultiArgs["-change"].size() > 0)
+                    {
+                        CBitcoinAddress address(mapMultiArgs["-change"][GetRandInt(mapMultiArgs["-change"].size())]);
+
+                        CKeyID keyID;
+                        if (!address.GetKeyID(keyID)) {
+                            strFailReason = _("Bad change address");
+                            return false;
+                        }
+
+                        scriptChange.SetDestination(keyID);
+                    }
                     // no coin control: send change to newly generated address
                     else
                     {


### PR DESCRIPTION
Almost every transaction out of a dogecoin wallet makes a new change address in the wallet for 'change'.  After a while a heavily used wallet gets very big and starts consuming all available CPU as it scans incoming transactions against an every-growing list of change addresses.

This pull request allows the user to specify a finite number of change addresses in dogecoin.conf and have transactions out of the wallet send change to one of the specified addresses at random.

In dogecoin.conf, specify 1 or more addresses, like this:

```
change=Daddress1
change=Daddress2
[etc.]
```

If no change addresses are specified, dogecoin-qt will fall back to the previous behaviour of making new change addresses per transaction.
