### PR TITLE
Aim for whole coin change, not just cent change to avoid fees if possible

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1074,7 +1074,7 @@ bool CWallet::SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfThe
             nValueRet += coin.first;
             return true;
         }
-        else if (n < nTargetValue + CENT)
+        else if (n < nTargetValue + COIN)
         {
             vValue.push_back(coin);
             nTotalLower += n;
@@ -1110,13 +1110,13 @@ bool CWallet::SelectCoinsMinConf(int64 nTargetValue, int nConfMine, int nConfThe
     int64 nBest;
 
     ApproximateBestSubset(vValue, nTotalLower, nTargetValue, vfBest, nBest, 1000);
-    if (nBest != nTargetValue && nTotalLower >= nTargetValue + CENT)
-        ApproximateBestSubset(vValue, nTotalLower, nTargetValue + CENT, vfBest, nBest, 1000);
+    if (nBest != nTargetValue && nTotalLower >= nTargetValue + COIN)
+        ApproximateBestSubset(vValue, nTotalLower, nTargetValue + COIN, vfBest, nBest, 1000);
 
     // If we have a bigger coin and (either the stochastic approximation didn't find a good solution,
     //                                   or the next bigger coin is closer), return the bigger coin
     if (coinLowestLarger.second.first &&
-        ((nBest != nTargetValue && nBest < nTargetValue + CENT) || coinLowestLarger.first <= nBest))
+        ((nBest != nTargetValue && nBest < nTargetValue + COIN) || coinLowestLarger.first <= nBest))
     {
         setCoinsRet.insert(coinLowestLarger.second);
         nValueRet += coinLowestLarger.first;


### PR DESCRIPTION
Fix #127.

v1.2 and onwards charges a fee if any output is less than 1 whole coin.  Previously the threshold was 0.01 coins.  This change changes the coin selection code to attempt to avoid creating change less than 1 whole coin.

The code is running on my live system, and made its first transaction here, making change of 1.00762073 DOGE:

http://dogechain.info/tx/bd0784287c779518abe2288883184b5cfe48d99686c76cf1adcf5c9f449d704d

The 4th input to that transaction (index 3) for 0.01164325 DOGE is an example of the change that was being created until now.
