### PR TITLE
Increase Default Block Max Size

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -31,7 +31,7 @@ static const unsigned int MAX_BLOCK_SIZE = 1000000;                      // 1000
 /** Obsolete: maximum size for mined blocks */
 static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;         // 500KB  block soft limit
 /** Default for -blockmaxsize, maximum size for mined blocks **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 250000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 500000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 17000;
 /** The maximum size for transactions we're willing to relay/mine */


### PR DESCRIPTION
Going off of @xnljfr's pull without the 1.4 Peer Ban

As stated earlier, since this value changed from 500K in 1.4 to 250K in 1.5, it is the root of the issue with the lagged transactions, orphaned blocks, and Chain Lag. 

Pools running 1.5 for payouts have issues with lag because their nodes wont transmit their Transactions into blocks larger than 250KB. 1.4 had a 500KB limit which is why it ran fine. As long as we don't set it above the 1MB network limit it will not fork

1.4 users should be fine as long as they apply the BDB fix to accept larger blocks

For now you can fix it quickly by setting `blockmaxsize` in `dogecoin.conf` to `500000`
