### PR TITLE
Replace references to litecoin with dogecoin.

### DIFF
--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -84,6 +84,6 @@ Litecoin
 -------
 DOS prompt:
 
-	cd \litecoin\src
+	cd \dogecoin\src
 	mingw32-make -f makefile.mingw
-	strip litecoind.exe
+	strip dogecoind.exe

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -12,7 +12,7 @@ To Build
 ---------------------
 
 	cd src/
-	make -f makefile.unix		# Headless litecoin
+	make -f makefile.unix		# Headless dogecoin
 
 See readme-qt.rst for instructions on building Litecoin-Qt, the graphical user interface.
 
@@ -131,7 +131,7 @@ Optional:
 
 Security
 --------
-To help make your litecoin installation more secure by making certain attacks impossible to
+To help make your dogecoin installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, you can take the following measures:
 
 * Position Independent Executable
@@ -149,7 +149,7 @@ exploit even if a vulnerability is found, you can take the following measures:
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-    	scanelf -e ./litecoin
+    	scanelf -e ./dogecoin
 
     The output should contain:
      TYPE
@@ -163,7 +163,7 @@ exploit even if a vulnerability is found, you can take the following measures:
     executable without the non-executable stack protection.
 
     To verify that the stack is non-executable after compiling use:
-    `scanelf -e ./litecoin`
+    `scanelf -e ./dogecoin`
 
     the output should contain:
 	STK/REL/PTL

--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -150,7 +150,7 @@ Ubuntu 11.10 warning
 ====================
 
 Ubuntu 11.10 has a package called 'qt-at-spi' installed by default.  At the time of writing, having that package
-installed causes litecoin-qt to crash intermittently.  The issue has been reported as `launchpad bug 857790`_, but
+installed causes dogecoin-qt to crash intermittently.  The issue has been reported as `launchpad bug 857790`_, but
 isn't yet fixed.
 
 Until the bug is fixed, you can remove the qt-at-spi package to work around the problem, though this will presumably

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -6,7 +6,7 @@ Release Process
 ###update (commit) version in sources
 
 
-	litecoin-qt.pro
+	dogecoin-qt.pro
 	contrib/verifysfbinaries/verify.sh
 	doc/README*
 	share/setup.nsi
@@ -24,7 +24,7 @@ Release Process
 
 ##perform gitian builds
 
- From a directory containing the litecoin source, gitian-builder and gitian.sigs
+ From a directory containing the dogecoin source, gitian-builder and gitian.sigs
   
 	export SIGNER=(your gitian key, ie bluematt, sipa, etc)
 	export VERSION=0.8.0
@@ -42,54 +42,54 @@ Release Process
 	wget 'http://downloads.sourceforge.net/project/boost/boost/1.50.0/boost_1_50_0.tar.bz2'
 	wget 'http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-4.8.3.tar.gz'
 	cd ..
-	./bin/gbuild ../litecoin/contrib/gitian-descriptors/boost-win32.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/boost-win32.yml
 	mv build/out/boost-win32-1.50.0-gitian2.zip inputs/
-	./bin/gbuild ../litecoin/contrib/gitian-descriptors/qt-win32.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/qt-win32.yml
 	mv build/out/qt-win32-4.8.3-gitian-r1.zip inputs/
-	./bin/gbuild ../litecoin/contrib/gitian-descriptors/deps-win32.yml
-	mv build/out/litecoin-deps-0.0.5.zip inputs/
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/deps-win32.yml
+	mv build/out/dogecoin-deps-0.0.5.zip inputs/
 
- Build litecoind and litecoin-qt on Linux32, Linux64, and Win32:
+ Build dogecoind and dogecoin-qt on Linux32, Linux64, and Win32:
   
-	./bin/gbuild --commit litecoin=v${VERSION} ../litecoin/contrib/gitian-descriptors/gitian.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../litecoin/contrib/gitian-descriptors/gitian.yml
+	./bin/gbuild --commit dogecoin=v${VERSION} ../dogecoin/contrib/gitian-descriptors/gitian.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../dogecoin/contrib/gitian-descriptors/gitian.yml
 	pushd build/out
-	zip -r litecoin-${VERSION}-linux-gitian.zip *
-	mv litecoin-${VERSION}-linux-gitian.zip ../../
+	zip -r dogecoin-${VERSION}-linux-gitian.zip *
+	mv dogecoin-${VERSION}-linux-gitian.zip ../../
 	popd
-	./bin/gbuild --commit litecoin=v${VERSION} ../litecoin/contrib/gitian-descriptors/gitian-win32.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION}-win32 --destination ../gitian.sigs/ ../litecoin/contrib/gitian-descriptors/gitian-win32.yml
+	./bin/gbuild --commit dogecoin=v${VERSION} ../dogecoin/contrib/gitian-descriptors/gitian-win32.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION}-win32 --destination ../gitian.sigs/ ../dogecoin/contrib/gitian-descriptors/gitian-win32.yml
 	pushd build/out
-	zip -r litecoin-${VERSION}-win32-gitian.zip *
-	mv litecoin-${VERSION}-win32-gitian.zip ../../
+	zip -r dogecoin-${VERSION}-win32-gitian.zip *
+	mv dogecoin-${VERSION}-win32-gitian.zip ../../
 	popd
 
   Build output expected:
 
-  1. linux 32-bit and 64-bit binaries + source (litecoin-${VERSION}-linux-gitian.zip)
-  2. windows 32-bit binary, installer + source (litecoin-${VERSION}-win32-gitian.zip)
+  1. linux 32-bit and 64-bit binaries + source (dogecoin-${VERSION}-linux-gitian.zip)
+  2. windows 32-bit binary, installer + source (dogecoin-${VERSION}-win32-gitian.zip)
   3. Gitian signatures (in gitian.sigs/${VERSION}[-win32]/(your gitian key)/
 
 repackage gitian builds for release as stand-alone zip/tar/installer exe
 
 **Linux .tar.gz:**
 
-	unzip litecoin-${VERSION}-linux-gitian.zip -d litecoin-${VERSION}-linux
-	tar czvf litecoin-${VERSION}-linux.tar.gz litecoin-${VERSION}-linux
-	rm -rf litecoin-${VERSION}-linux
+	unzip dogecoin-${VERSION}-linux-gitian.zip -d dogecoin-${VERSION}-linux
+	tar czvf dogecoin-${VERSION}-linux.tar.gz dogecoin-${VERSION}-linux
+	rm -rf dogecoin-${VERSION}-linux
 
 **Windows .zip and setup.exe:**
 
-	unzip litecoin-${VERSION}-win32-gitian.zip -d litecoin-${VERSION}-win32
-	mv litecoin-${VERSION}-win32/litecoin-*-setup.exe .
-	zip -r litecoin-${VERSION}-win32.zip bitcoin-${VERSION}-win32
-	rm -rf litecoin-${VERSION}-win32
+	unzip dogecoin-${VERSION}-win32-gitian.zip -d dogecoin-${VERSION}-win32
+	mv dogecoin-${VERSION}-win32/dogecoin-*-setup.exe .
+	zip -r dogecoin-${VERSION}-win32.zip bitcoin-${VERSION}-win32
+	rm -rf dogecoin-${VERSION}-win32
 
 **Perform Mac build:**
 
   OSX binaries are created by Gavin Andresen on a 32-bit, OSX 10.6 machine.
 
-	qmake RELEASE=1 USE_UPNP=1 USE_QRCODE=1 litecoin-qt.pro
+	qmake RELEASE=1 USE_UPNP=1 USE_QRCODE=1 dogecoin-qt.pro
 	make
 	export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
 	T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
@@ -107,14 +107,10 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 
 * create SHA256SUMS for builds, and PGP-sign it
 
-* update litecoin.org version
+* update dogecoin.com version
   make sure all OS download links go to the right versions
 
 * update forum version
-
-* update wiki download links
-
-* update wiki changelog: [https://en.litecoin.it/wiki/Changelog](https://en.bitcoin.it/wiki/Changelog)
 
 Commit your signature to gitian.sigs:
 
@@ -129,32 +125,32 @@ Commit your signature to gitian.sigs:
 
 ### After 3 or more people have gitian-built, repackage gitian-signed zips:
 
-From a directory containing litecoin source, gitian.sigs and gitian zips
+From a directory containing dogecoin source, gitian.sigs and gitian zips
 
 	export VERSION=0.5.1
-	mkdir litecoin-${VERSION}-linux-gitian
-	pushd litecoin-${VERSION}-linux-gitian
-	unzip ../litecoin-${VERSION}-linux-gitian.zip
+	mkdir dogecoin-${VERSION}-linux-gitian
+	pushd dogecoin-${VERSION}-linux-gitian
+	unzip ../dogecoin-${VERSION}-linux-gitian.zip
 	mkdir gitian
-	cp ../litecoin/contrib/gitian-downloader/*.pgp ./gitian/
+	cp ../dogecoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}/); do
-	 cp ../gitian.sigs/${VERSION}/${signer}/litecoin-build.assert ./gitian/${signer}-build.assert
-	 cp ../gitian.sigs/${VERSION}/${signer}/litecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
+	 cp ../gitian.sigs/${VERSION}/${signer}/dogecoin-build.assert ./gitian/${signer}-build.assert
+	 cp ../gitian.sigs/${VERSION}/${signer}/dogecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r litecoin-${VERSION}-linux-gitian.zip *
-	cp litecoin-${VERSION}-linux-gitian.zip ../
+	zip -r dogecoin-${VERSION}-linux-gitian.zip *
+	cp dogecoin-${VERSION}-linux-gitian.zip ../
 	popd
-	mkdir litecoin-${VERSION}-win32-gitian
-	pushd litecoin-${VERSION}-win32-gitian
-	unzip ../litecoin-${VERSION}-win32-gitian.zip
+	mkdir dogecoin-${VERSION}-win32-gitian
+	pushd dogecoin-${VERSION}-win32-gitian
+	unzip ../dogecoin-${VERSION}-win32-gitian.zip
 	mkdir gitian
-	cp ../litecoin/contrib/gitian-downloader/*.pgp ./gitian/
+	cp ../dogecoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}-win32/); do
-	 cp ../gitian.sigs/${VERSION}-win32/${signer}/litecoin-build.assert ./gitian/${signer}-build.assert
-	 cp ../gitian.sigs/${VERSION}-win32/${signer}/litecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
+	 cp ../gitian.sigs/${VERSION}-win32/${signer}/dogecoin-build.assert ./gitian/${signer}-build.assert
+	 cp ../gitian.sigs/${VERSION}-win32/${signer}/dogecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r litecoin-${VERSION}-win32-gitian.zip *
-	cp litecoin-${VERSION}-win32-gitian.zip ../
+	zip -r dogecoin-${VERSION}-win32-gitian.zip *
+	cp dogecoin-${VERSION}-win32-gitian.zip ../
 	popd
 
 - Upload gitian zips to SourceForge

--- a/doc/unit-tests.md
+++ b/doc/unit-tests.md
@@ -1,14 +1,14 @@
-Compiling/running litecoind unit tests
+Compiling/running dogecoind unit tests
 ------------------------------------
 
-litecoind unit tests are in the `src/test/` directory; they
+dogecoind unit tests are in the `src/test/` directory; they
 use the Boost::Test unit-testing framework.
 
 To compile and run the tests:
 
 	cd src
-	make -f makefile.unix test_litecoin  # Replace makefile.unix if you're not on unix
-	./test_litecoin   # Runs the unit tests
+	make -f makefile.unix test_dogecoin  # Replace makefile.unix if you're not on unix
+	./test_dogecoin   # Runs the unit tests
 
 If all tests succeed the last line of output will be:
 `*** No errors detected`
@@ -16,7 +16,7 @@ If all tests succeed the last line of output will be:
 To add more tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
 .cpp files in the test/ directory or add new .cpp files that
 implement new BOOST_AUTO_TEST_SUITE sections (the makefiles are
-set up to add test/*.cpp to test_litecoin automatically).
+set up to add test/*.cpp to test_dogecoin automatically).
 
 
 Compiling/running Litecoin-Qt unit tests
@@ -29,7 +29,7 @@ To compile and run the tests:
 
 	qmake bitcoin-qt.pro BITCOIN_QT_TEST=1
 	make
-	./litecoin-qt_test
+	./dogecoin-qt_test
 
 To add more tests, add them to the `src/qt/test/` directory,
 the `src/qt/test/test_main.cpp` file, and bitcoin-qt.pro.


### PR DESCRIPTION
I've gone through the build docs, and replaced a lot of outstanding references to litecoin with references to dogecoin. Have also removed references to Bitcoin/Litecoin wiki in release process.

This is purely documentational improvements, with no code impact.
