### PR TITLE
Remove reference to Bitcoin from French translation, correct shortcut key

### DIFF
--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -138,7 +138,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Send &amp;Coins</source>
-        <translation>Envoyer des Dogecoins</translation>
+        <translation>Envoyer des &amp;Dogecoins</translation>
     </message>
     <message>
         <location line="+260"/>


### PR DESCRIPTION
This resolves the translation issue raised in https://github.com/dogecoin/dogecoin/issues/275 and additionally changes the shortcut key to not collide with another menu option (which also uses 'c' as shortcut). Shortcut is now 'd'
