### PR TITLE
Fixed example address to match translation files

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -73,7 +73,7 @@
      <item>
       <widget class="QValidatedLineEdit" name="payTo">
        <property name="toolTip">
-        <string>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+        <string>The address to send the payment to (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</string>
        </property>
        <property name="maxLength">
         <number>34</number>


### PR DESCRIPTION
This string was not being translated due to not matching the string in the translation files (compare e.g. https://github.com/dogecoin/dogecoin/blob/develop/src/qt/locale/bitcoin_en.ts#L1422). The untranslated string with bitcoin address is the mouseover text for the "Pay-To" field of the "Pls Send" tab. This error was already present in the adopted litecoin base, which is why commit 5a97e1b03a2aa73 didn't change this example address. This seems to be the only instance of this happening.

I currently don't have a GUI build environment, so I would appreciate if somebody would verify this solution before merging.
