### PR TITLE
Improve handling of unknown commands in CInv::ToString

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -141,7 +141,10 @@ const char* CInv::GetCommand() const
 
 std::string CInv::ToString() const
 {
-    return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
+    if(IsKnownType())
+        return strprintf("%s %s", GetCommand(), hash.ToString().substr(0,20).c_str());
+    else
+        return strprintf("type=%d %s", type, hash.ToString().substr(0,20).c_str()); 
 }
 
 void CInv::print() const


### PR DESCRIPTION
CInv::GetCommand throws an exception if the command type is unknown. Consequently, CInv::ToString fails with an exception if the command type is unknown. 1.5 introduces such a new command type with filtered blocks. A ToString method throwing an exception on a valid object encoding unknown data does not look like expected behaviour and is the likely cause of #65.

Since I can't find any mention of a release of 1.4.3 I haven't incremented the version number. This fix applies equally to the current version and depending on the feedback here I will open a matching PR for the develop-branch.
