### PR TITLE
Hardfork Dogecoin with static block rewards and a modified difficulty readjustment

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1124,7 +1124,15 @@ int64 static GetBlockValue(int nHeight, int64 nFees, uint256 prevHash)
     return nSubsidy + nFees;
 }
 
-static const int64 nTargetTimespan = 2 * 60; // DogeCoin: every 2 minutes
+// New target time
+static const int64 nTargetTimespan = 2 * 60; // Retarget every 2 minutes
+
+// Old targetting time for blocks below height 175K
+if(nHeight < 175000)
+{
+    static const int64 nTargetTimespan = 4 * 60 * 60 ; // Retarget every 4 hours
+}
+
 static const int64 nTargetSpacing = 60; // DogeCoin: 1 minutes
 static const int64 nInterval = nTargetTimespan / nTargetSpacing;
 


### PR DESCRIPTION
UPDATE 2: Changed Difficulty retargeting at block 175K
UPDATE: Block Reward change confirmed working. Still would like a couple others to test.

I've edited the code to set static block rewards after block 175,000. This number can be changed and it can be pushed right now without affecting current mining for blocks below 175K (However don't do it yet, we still need testing)

I'm currently testing this with multiple testnet nodes and a reward change at block 100. I'll update this post when I finish my testing

Todo: 
Better difficulty readjustment (The solution that DigiByte implemented looks interesting http://redd.it/1yn6t1)
Decide at which block height we should change the rewards to static values, current vote is height 160K

Here are some of the values I've been using for my testnets, halving every 10 blocks with random rewards for block 0-17 with a switch to static after 17:

```
int64 static GetBlockValue(int nHeight, int64 nFees, uint256 prevHash)
{
    int64 nSubsidy = 500000 * COIN;

    std::string cseed_str = prevHash.ToString().substr(7,7);
    const char* cseed = cseed_str.c_str();
    long seed = hex2long(cseed);
    int rand = generateMTRandom(seed, 999999);
    int rand1 = 0;

    // Blocks at height 0-10 cointain 0-999999 coins
    if(nHeight < 10)
    {
        nSubsidy = (1 + rand) * COIN;
    }
    // Blocks at height 10-17 contain 0-499999 coins
    else if(nHeight < 17)
    {
        cseed_str = prevHash.ToString().substr(7,7);
        cseed = cseed_str.c_str();
        seed = hex2long(cseed);
        rand1 = generateMTRandom(seed, 499999);
        nSubsidy = (1 + rand1) * COIN;
    }
    // Blocks at height 17-60 contain a statically halved reward
    else if(nHeight < 60)
    {
        nSubsidy >>= (nHeight / 10);
    }
    // Blocks at or above height 60 will contain a static 10000 coins
    else if(nHeight >= 60)
    {
        nSubsidy = 10000 * COIN;
    }

    return nSubsidy + nFees;
}
```

Update on my testing:

I used 3 nodes. Node #1 and #2 running the modified code below, node #3 was running original unmodified code. The end result was that nodes #1 & #2 ended up forking off the public dogecoin testnet network with their static rewards and node #3 stopped synching with them. This was the desired result.

So it looks like the static rewards are done, now we just need to choosing and implementing a different difficulty retarget method.

Blocks mined on node #1 with bitshifted halving and 10K reward
http://i.imgur.com/YRbQX1T.png

Blocks mined on node #2 with static 10K reward
http://i.imgur.com/QNWAouQ.png

Old Node without static reward changes stops synching after reward were changed at block #23490
http://i.imgur.com/dgpBxO4.png

```
 int64 static GetBlockValue(int nHeight, int64 nFees, uint256 prevHash)
 {
     int64 nSubsidy = 500000 * COIN;

     std::string cseed_str = prevHash.ToString().substr(7,7);
     const char* cseed = cseed_str.c_str();
     long seed = hex2long(cseed);
     int rand = generateMTRandom(seed, 999999);
     int rand1 = 0;

     // Blocks at height 0-100K cointain 0-999999 coins
     if(nHeight < 23490)
     {
         nSubsidy = (1 + rand) * COIN;
     }
     // Blocks at height 175K-600K contain a statically halved reward
     else if(nHeight < 23500)
     {
         nSubsidy >>= (nHeight / 23500);
     }
     // Blocks at or above height 600K will contain a static 10000 coins
     else if(nHeight >= 23510)
     {
         nSubsidy = 10000 * COIN;
     }

     return nSubsidy + nFees;
 }
```
