### PR TITLE
Back out caching changes in CWalletTx::GetAmounts (fix #341)

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -664,27 +664,13 @@ void CWalletTx::GetAmounts(list<pair<CTxDestination, int64> >& listReceived,
         nFee = nDebit - nValueOut;
     }
 
-	if (!fMineCached)
-		vfMine.resize(vout.size());
-		
     // Sent/received.
 	for (unsigned int i = 0; i < vout.size(); i++) {
 		const CTxOut	&txout = vout[i];
 		bool			isMine = false;
 		bool			warnUnkownTX = false;
 		
-		if (!fMineCached) {
-			address = CNoDestination();
-			warnUnkownTX = !ExtractDestinationAndMine(*pwallet, txout.scriptPubKey, address, &isMine);
-			vfMine[i] = isMine;
-		}
-		else {
-			if (vfMine[i]) {
-				isMine = true;	// already know this is ours, just fetch address
-				address = CNoDestination();
-				warnUnkownTX = !ExtractDestination(txout.scriptPubKey, address);
-			}
-		}
+		warnUnkownTX = !ExtractDestinationAndMine(*pwallet, txout.scriptPubKey, address, &isMine);
 		if (warnUnkownTX) {
             printf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", this->GetHash().ToString().c_str());
         }
@@ -699,8 +685,6 @@ void CWalletTx::GetAmounts(list<pair<CTxDestination, int64> >& listReceived,
         if (isMine)
             listReceived.push_back(make_pair(address, txout.nValue));
     }
-
-	fMineCached = true;
 }
 
 void CWalletTx::GetAccountAmounts(const string& strAccount, int64& nReceived,

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -384,8 +384,6 @@ public:
     int64 nOrderPos;  // position in ordered transaction list
 
     // memory only
-    mutable std::vector<char> vfMine;	// which outputs are mine
-    mutable bool fMineCached;
     mutable bool fDebitCached;
     mutable bool fCreditCached;
     mutable bool fImmatureCreditCached;
@@ -429,8 +427,6 @@ public:
         fFromMe = false;
         strFromAccount.clear();
         vfSpent.clear();
-        vfMine.clear();
-        fMineCached = false;
         fDebitCached = false;
         fCreditCached = false;
         fImmatureCreditCached = false;
@@ -524,8 +520,6 @@ public:
     // make sure balances are recalculated
     void MarkDirty()
     {
-        vfMine.clear();
-		fMineCached = false;
         fCreditCached = false;
         fAvailableCreditCached = false;
         fDebitCached = false;


### PR DESCRIPTION
Dropped the ball on this one. Backing out caching changes for now. Fixes #341.

Note: PR submitted against master branch as develop is missing some commits from most recent master.
