### PR TITLE
update the Traditional Chinese translation

### DIFF
--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -5,12 +5,12 @@
     <message>
         <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Dogecoin</source>
-        <translation>關於莱特幣</translation>
+        <translation>關於狗狗幣</translation>
     </message>
     <message>
         <location line="+39"/>
         <source>&lt;b&gt;Dogecoin&lt;/b&gt; version</source>
-        <translation>&lt;b&gt;莱特幣&lt;/b&gt;版本</translation>
+        <translation>&lt;b&gt;狗狗幣&lt;/b&gt;版本</translation>
     </message>
     <message>
         <location line="+57"/>
@@ -45,7 +45,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+0"/>
         <source>2013-%1 The Dogecoin developers</source>
-        <translation>2013-%1 莱特幣開發人員</translation>
+        <translation>2013-%1 狗狗幣開發人員</translation>
     </message>
 </context>
 <context>
@@ -53,37 +53,37 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location filename="../forms/addressbookpage.ui" line="+14"/>
         <source>Address Book</source>
-        <translation>位址簿</translation>
+        <translation>地址簿</translation>
     </message>
     <message>
         <location line="+19"/>
         <source>Double-click to edit address or label</source>
-        <translation>點兩下來修改位址或標記</translation>
+        <translation>點兩下來修改地址或標籤</translation>
     </message>
     <message>
         <location line="+27"/>
         <source>Create a new address</source>
-        <translation>產生新位址</translation>
+        <translation>產生新地址</translation>
     </message>
     <message>
         <location line="+14"/>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>複製目前選取的位址到系統剪貼簿</translation>
+        <translation>複製目前選取的地址到系統剪貼簿</translation>
     </message>
     <message>
         <location line="-11"/>
         <source>&amp;New Address</source>
-        <translation>新增位址</translation>
+        <translation>新增地址</translation>
     </message>
     <message>
         <location filename="../addressbookpage.cpp" line="+63"/>
         <source>These are your Dogecoin addresses for receiving payments. You may want to give a different one to each sender so you can keep track of who is paying you.</source>
-        <translation>這些是你用來收款的莱特幣位址. 你可以提供不同的位址給不同的付款人, 來追蹤是誰支付給你.</translation>
+        <translation>這些是你用來收款的狗狗幣地址. 你可以提供不同的地址給不同的付款人, 來追蹤是誰支付給你.</translation>
     </message>
     <message>
         <location filename="../forms/addressbookpage.ui" line="+14"/>
         <source>&amp;Copy Address</source>
-        <translation>複製位址</translation>
+        <translation>複製地址</translation>
     </message>
     <message>
         <location line="+11"/>
@@ -93,7 +93,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+11"/>
         <source>Sign a message to prove you own a Dogecoin address</source>
-        <translation>簽署訊息是用來證明莱特幣位址是你的</translation>
+        <translation>簽署訊息是用來證明狗狗幣地址是你的</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -103,7 +103,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+25"/>
         <source>Delete the currently selected address from the list</source>
-        <translation>從列表中刪除目前選取的位址</translation>
+        <translation>從列表中刪除目前選取的地址</translation>
     </message>
     <message>
         <location line="+27"/>
@@ -118,7 +118,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="-44"/>
         <source>Verify a message to ensure it was signed with a specified Dogecoin address</source>
-        <translation>驗證訊息是用來確認訊息是用指定的莱特幣位址簽署的</translation>
+        <translation>驗證訊息是用來確認訊息是用指定的狗狗幣地址簽署的</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -133,12 +133,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location filename="../addressbookpage.cpp" line="-5"/>
         <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>這是你用來付款的莱特幣位址. 在付錢之前, 務必要檢查金額和收款位址是否正確.</translation>
+        <translation>這是你用來付款的狗狗幣地址. 在付錢之前, 務必要檢查金額和收款地址是否正確.</translation>
     </message>
     <message>
         <location line="+13"/>
         <source>Copy &amp;Label</source>
-        <translation>複製標記</translation>
+        <translation>複製標籤</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -153,7 +153,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+260"/>
         <source>Export Address Book Data</source>
-        <translation>匯出位址簿資料</translation>
+        <translation>匯出地址簿資料</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -176,17 +176,17 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location filename="../addresstablemodel.cpp" line="+144"/>
         <source>Label</source>
-        <translation>標記</translation>
+        <translation>標籤</translation>
     </message>
     <message>
         <location line="+0"/>
         <source>Address</source>
-        <translation>位址</translation>
+        <translation>地址</translation>
     </message>
     <message>
         <location line="+36"/>
         <source>(no label)</source>
-        <translation>(沒有標記)</translation>
+        <translation>(沒有標籤)</translation>
     </message>
 </context>
 <context>
@@ -259,7 +259,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR DOGECOINS&lt;/b&gt;!</source>
-        <translation>警告: 如果將錢包加密後忘記密碼, 你會&lt;b&gt;失去其中所有的莱特幣&lt;/b&gt;!</translation>
+        <translation>警告: 如果將錢包加密後忘記密碼, 你會&lt;b&gt;失去其中所有的狗狗幣&lt;/b&gt;!</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -286,7 +286,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="-56"/>
         <source>Dogecoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your dogecoins from being stolen by malware infecting your computer.</source>
-        <translation>莱特幣現在要關閉以完成加密程序. 請記住, 加密錢包無法完全防止入侵電腦的惡意程式偷取你的莱特幣.</translation>
+        <translation>狗狗幣現在要關閉以完成加密程序. 請記住, 加密錢包無法完全防止入侵電腦的惡意程式偷取你的狗狗幣.</translation>
     </message>
     <message>
         <location line="+13"/>
@@ -365,12 +365,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+7"/>
         <source>Edit the list of stored addresses and labels for sending</source>
-        <translation>編輯位址與標記的儲存列表</translation>
+        <translation>編輯地址與標籤的儲存列表</translation>
     </message>
     <message>
         <location line="-14"/>
         <source>Show the list of addresses for receiving payments</source>
-        <translation>顯示收款位址的列表</translation>
+        <translation>顯示收款地址的列表</translation>
     </message>
     <message>
         <location line="+31"/>
@@ -385,7 +385,7 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+4"/>
         <source>Show information about Dogecoin</source>
-        <translation>顯示莱特幣相關資訊</translation>
+        <translation>顯示狗狗幣相關資訊</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -430,12 +430,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="-347"/>
         <source>Send coins to a Dogecoin address</source>
-        <translation>付錢到莱特幣位址</translation>
+        <translation>付錢到狗狗幣地址</translation>
     </message>
     <message>
         <location line="+49"/>
         <source>Modify configuration options for Dogecoin</source>
-        <translation>修改莱特幣的設定選項</translation>
+        <translation>修改狗狗幣的設定選項</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -466,7 +466,7 @@ This product includes software developed by the OpenSSL Project for use in the O
         <location line="-165"/>
         <location line="+530"/>
         <source>Dogecoin</source>
-        <translation>莱特幣</translation>
+        <translation>狗狗幣</translation>
     </message>
     <message>
         <location line="-530"/>
@@ -486,12 +486,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+14"/>
         <source>&amp;Addresses</source>
-        <translation>位址</translation>
+        <translation>地址</translation>
     </message>
     <message>
         <location line="+22"/>
         <source>&amp;About Dogecoin</source>
-        <translation>關於莱特幣</translation>
+        <translation>關於狗狗幣</translation>
     </message>
     <message>
         <location line="+9"/>
@@ -511,12 +511,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+7"/>
         <source>Sign messages with your Dogecoin addresses to prove you own them</source>
-        <translation>用莱特幣位址簽署訊息來證明那是你的</translation>
+        <translation>用狗狗幣地址簽署訊息來證明那是你的</translation>
     </message>
     <message>
         <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Dogecoin addresses</source>
-        <translation>驗證訊息來確認是用指定的莱特幣位址簽署的</translation>
+        <translation>驗證訊息來確認是用指定的狗狗幣地址簽署的</translation>
     </message>
     <message>
         <location line="+28"/>
@@ -547,12 +547,12 @@ This product includes software developed by the OpenSSL Project for use in the O
     <message>
         <location line="+47"/>
         <source>Dogecoin client</source>
-        <translation>莱特幣客戶端軟體</translation>
+        <translation>狗狗幣客戶端軟體</translation>
     </message>
     <message numerus="yes">
         <location line="+141"/>
         <source>%n active connection(s) to Dogecoin network</source>
-        <translation><numerusform>與莱特幣網路有 %n 個連線在使用中</numerusform></translation>
+        <translation><numerusform>與狗狗幣網路有 %n 個連線在使用中</numerusform></translation>
     </message>
     <message>
         <location line="+22"/>
@@ -654,7 +654,7 @@ Address: %4
         <translation>日期: %1
 金額: %2
 類別: %3
-位址: %4</translation>
+地址: %4</translation>
     </message>
     <message>
         <location line="+33"/>
@@ -666,7 +666,7 @@ Address: %4
         <location line="-23"/>
         <location line="+23"/>
         <source>URI can not be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters.</source>
-        <translation>無法解析 URI! 也許莱特幣位址無效或 URI 參數有誤.</translation>
+        <translation>無法解析 URI! 也許狗狗幣地址無效或 URI 參數有誤.</translation>
     </message>
     <message>
         <location line="+17"/>
@@ -681,7 +681,7 @@ Address: %4
     <message>
         <location filename="../bitcoin.cpp" line="+111"/>
         <source>A fatal error occurred. Dogecoin can no longer continue safely and will quit.</source>
-        <translation>發生了致命的錯誤. 莱特幣程式無法再繼續安全執行, 只好結束.</translation>
+        <translation>發生了致命的錯誤. 狗狗幣程式無法再繼續安全執行, 只好結束.</translation>
     </message>
 </context>
 <context>
@@ -697,57 +697,57 @@ Address: %4
     <message>
         <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
-        <translation>編輯位址</translation>
+        <translation>編輯地址</translation>
     </message>
     <message>
         <location line="+11"/>
         <source>&amp;Label</source>
-        <translation>標記</translation>
+        <translation>標籤</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>The label associated with this address book entry</source>
-        <translation>與這個位址簿項目關聯的標記</translation>
+        <translation>與這個地址簿項目關聯的標籤</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>&amp;Address</source>
-        <translation>位址</translation>
+        <translation>地址</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>The address associated with this address book entry. This can only be modified for sending addresses.</source>
-        <translation>與這個位址簿項目關聯的位址. 付款位址才能被更改.</translation>
+        <translation>與這個地址簿項目關聯的地址. 付款地址才能被更改.</translation>
     </message>
     <message>
         <location filename="../editaddressdialog.cpp" line="+21"/>
         <source>New receiving address</source>
-        <translation>新收款位址</translation>
+        <translation>新收款地址</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>New sending address</source>
-        <translation>新增付款位址</translation>
+        <translation>新增付款地址</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Edit receiving address</source>
-        <translation>編輯收款位址</translation>
+        <translation>編輯收款地址</translation>
     </message>
     <message>
         <location line="+4"/>
         <source>Edit sending address</source>
-        <translation>編輯付款位址</translation>
+        <translation>編輯付款地址</translation>
     </message>
     <message>
         <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
-        <translation>輸入的位址&quot;%1&quot;已存在於位址簿中.</translation>
+        <translation>輸入的地址&quot;%1&quot;已存在於地址簿中.</translation>
     </message>
     <message>
         <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Dogecoin address.</source>
-        <translation>輸入的位址 &quot;%1&quot; 並不是有效的莱特幣位址.</translation>
+        <translation>輸入的地址 &quot;%1&quot; 並不是有效的狗狗幣地址.</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -766,7 +766,7 @@ Address: %4
         <location filename="../guiutil.cpp" line="+424"/>
         <location line="+12"/>
         <source>Dogecoin-Qt</source>
-        <translation>莱特幣-Qt</translation>
+        <translation>狗狗幣-Qt</translation>
     </message>
     <message>
         <location line="-12"/>
@@ -830,12 +830,12 @@ Address: %4
     <message>
         <location line="+31"/>
         <source>Automatically start Dogecoin after logging in to the system.</source>
-        <translation>在登入系統後自動啓動莱特幣.</translation>
+        <translation>在登入系統後自動啓動狗狗幣.</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>&amp;Start Dogecoin on system login</source>
-        <translation>系統登入時啟動莱特幣</translation>
+        <translation>系統登入時啟動狗狗幣</translation>
     </message>
     <message>
         <location line="+35"/>
@@ -865,7 +865,7 @@ Address: %4
     <message>
         <location line="+7"/>
         <source>Connect to the Dogecoin network through a SOCKS proxy (e.g. when connecting through Tor).</source>
-        <translation>透過 SOCKS 代理伺服器連線至莱特幣網路 (比如說要透過 Tor 連線).</translation>
+        <translation>透過 SOCKS 代理伺服器連線至狗狗幣網路 (比如說要透過 Tor 連線).</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -875,12 +875,12 @@ Address: %4
     <message>
         <location line="+9"/>
         <source>Proxy &amp;IP:</source>
-        <translation>代理伺服器位址:</translation>
+        <translation>代理伺服器地址:</translation>
     </message>
     <message>
         <location line="+19"/>
         <source>IP address of the proxy (e.g. 127.0.0.1)</source>
-        <translation>代理伺服器的網際網路位址 (比如說 127.0.0.1)</translation>
+        <translation>代理伺服器的網際網路地址 (比如說 127.0.0.1)</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -940,7 +940,7 @@ Address: %4
     <message>
         <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Dogecoin.</source>
-        <translation>可以在這裡設定使用者介面的語言. 這個設定在莱特幣程式重啓後才會生效.</translation>
+        <translation>可以在這裡設定使用者介面的語言. 這個設定在狗狗幣程式重啓後才會生效.</translation>
     </message>
     <message>
         <location line="+11"/>
@@ -955,17 +955,17 @@ Address: %4
     <message>
         <location line="+9"/>
         <source>Whether to show Dogecoin addresses in the transaction list or not.</source>
-        <translation>是否要在交易列表中顯示莱特幣位址.</translation>
+        <translation>是否要在交易列表中顯示狗狗幣地址.</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
-        <translation>在交易列表顯示位址</translation>
+        <translation>在交易列表顯示地址</translation>
     </message>
     <message>
         <location line="+71"/>
         <source>&amp;OK</source>
-        <translation>好</translation>
+        <translation>確定</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -995,7 +995,7 @@ Address: %4
     <message>
         <location line="+0"/>
         <source>Do you want to proceed?</source>
-        <translation>你想要就做下去嗎?</translation>
+        <translation>你想要繼續進行嗎?</translation>
     </message>
     <message>
         <location line="+42"/>
@@ -1007,12 +1007,12 @@ Address: %4
         <location line="-9"/>
         <location line="+9"/>
         <source>This setting will take effect after restarting Dogecoin.</source>
-        <translation>這個設定會在莱特幣程式重啓後生效.</translation>
+        <translation>這個設定會在狗狗幣程式重啓後生效.</translation>
     </message>
     <message>
         <location line="+29"/>
         <source>The supplied proxy address is invalid.</source>
-        <translation>提供的代理伺服器位址無效</translation>
+        <translation>提供的代理伺服器地址無效</translation>
     </message>
 </context>
 <context>
@@ -1026,7 +1026,7 @@ Address: %4
         <location line="+50"/>
         <location line="+166"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>顯示的資訊可能是過期的. 與莱特幣網路的連線建立後, 你的錢包會自動和網路同步, 但這個步驟還沒完成.</translation>
+        <translation>顯示的資訊可能是過期的. 與狗狗幣網路的連線建立後, 你的錢包會自動和網路同步, 但這個步驟還沒完成.</translation>
     </message>
     <message>
         <location line="-124"/>
@@ -1103,7 +1103,7 @@ Address: %4
     <message>
         <location line="-44"/>
         <source>Label:</source>
-        <translation>標記:</translation>
+        <translation>標籤:</translation>
     </message>
     <message>
         <location line="+19"/>
@@ -1230,7 +1230,7 @@ Address: %4
     <message>
         <location line="+7"/>
         <source>Show the Dogecoin-Qt help message to get a list with possible Dogecoin command-line options.</source>
-        <translation>顯示莱特幣-Qt的求助訊息, 來取得可用的命令列選項列表.</translation>
+        <translation>顯示狗狗幣-Qt的求助訊息, 來取得可用的命令列選項列表.</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -1250,12 +1250,12 @@ Address: %4
     <message>
         <location line="-104"/>
         <source>Dogecoin - Debug window</source>
-        <translation>莱特幣 - 除錯視窗</translation>
+        <translation>狗狗幣 - 除錯視窗</translation>
     </message>
     <message>
         <location line="+25"/>
         <source>Dogecoin Core</source>
-        <translation>莱特幣核心</translation>
+        <translation>狗狗幣核心</translation>
     </message>
     <message>
         <location line="+279"/>
@@ -1265,7 +1265,7 @@ Address: %4
     <message>
         <location line="+7"/>
         <source>Open the Dogecoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation>從目前的資料目錄下開啓莱特幣的除錯紀錄檔. 當紀錄檔很大時可能要花好幾秒的時間.</translation>
+        <translation>從目前的資料目錄下開啓狗狗幣的除錯紀錄檔. 當紀錄檔很大時可能要花好幾秒的時間.</translation>
     </message>
     <message>
         <location line="+102"/>
@@ -1275,7 +1275,7 @@ Address: %4
     <message>
         <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Dogecoin RPC console.</source>
-        <translation>歡迎使用莱特幣 RPC 主控台.</translation>
+        <translation>歡迎使用狗狗幣 RPC 主控台.</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -1365,7 +1365,7 @@ Address: %4
     <message>
         <location line="+23"/>
         <source>The recipient address is not valid, please recheck.</source>
-        <translation>無效的收款位址, 請再檢查看看.</translation>
+        <translation>無效的收款地址, 請再檢查看看.</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -1385,7 +1385,7 @@ Address: %4
     <message>
         <location line="+6"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
-        <translation>發現有重複的位址. 每個付款動作中, 只能付給個別的位址一次.</translation>
+        <translation>發現有重複的地址. 每個付款動作中, 只能付給個別的地址一次.</translation>
     </message>
     <message>
         <location line="+5"/>
@@ -1418,23 +1418,23 @@ Address: %4
     <message>
         <location line="+34"/>
         <source>The address to send the payment to (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</source>
-        <translation>付款的目標位址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
+        <translation>付款的目標地址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
     </message>
     <message>
         <location line="+60"/>
         <location filename="../sendcoinsentry.cpp" line="+26"/>
         <source>Enter a label for this address to add it to your address book</source>
-        <translation>輸入一個標記給這個位址, 並加到位址簿中</translation>
+        <translation>輸入一個標籤給這個地址, 並加到地址簿中</translation>
     </message>
     <message>
         <location line="-78"/>
         <source>&amp;Label:</source>
-        <translation>標記:</translation>
+        <translation>標籤:</translation>
     </message>
     <message>
         <location line="+28"/>
         <source>Choose address from address book</source>
-        <translation>從位址簿中選一個位址</translation>
+        <translation>從地址簿中選一個地址</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -1444,7 +1444,7 @@ Address: %4
     <message>
         <location line="+7"/>
         <source>Paste address from clipboard</source>
-        <translation>從剪貼簿貼上位址</translation>
+        <translation>從剪貼簿貼上地址</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -1459,7 +1459,7 @@ Address: %4
     <message>
         <location filename="../sendcoinsentry.cpp" line="+1"/>
         <source>Enter a Dogecoin address (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</source>
-        <translation>輸入莱特幣位址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
+        <translation>輸入狗狗幣地址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
     </message>
 </context>
 <context>
@@ -1477,18 +1477,18 @@ Address: %4
     <message>
         <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>你可以用自己的位址來簽署訊息, 以證明你對它的所有權. 但是請小心, 不要簽署語意含糊不清的內容, 因為釣魚式詐騙可能會用騙你簽署的手法來冒充是你. 只有在語句中的細節你都同意時才簽署.</translation>
+        <translation>你可以用自己的地址來簽署訊息, 以證明你對它的所有權. 但是請小心, 不要簽署語意含糊不清的內容, 因為釣魚式詐騙可能會用騙你簽署的手法來冒充是你. 只有在語句中的細節你都同意時才簽署.</translation>
     </message>
     <message>
         <location line="+18"/>
         <source>The address to sign the message with (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</source>
-        <translation>用來簽署訊息的位址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
+        <translation>用來簽署訊息的地址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
     </message>
     <message>
         <location line="+10"/>
         <location line="+213"/>
         <source>Choose an address from the address book</source>
-        <translation>從位址簿選一個位址</translation>
+        <translation>從地址簿選一個地址</translation>
     </message>
     <message>
         <location line="-203"/>
@@ -1499,7 +1499,7 @@ Address: %4
     <message>
         <location line="-203"/>
         <source>Paste address from clipboard</source>
-        <translation>從剪貼簿貼上位址</translation>
+        <translation>從剪貼簿貼上地址</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -1524,7 +1524,7 @@ Address: %4
     <message>
         <location line="+21"/>
         <source>Sign the message to prove you own this Dogecoin address</source>
-        <translation>簽署訊息是用來證明這個莱特幣位址是你的</translation>
+        <translation>簽署訊息是用來證明這個狗狗幣地址是你的</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -1550,17 +1550,17 @@ Address: %4
     <message>
         <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
-        <translation>請在下面輸入簽署的位址, 訊息(請確認完整複製了所包含的換行, 空格, 跳位符號等等), 與簽章, 以驗證該訊息. 請小心, 除了訊息內容外, 不要對簽章本身過度解讀, 以避免被用&quot;中間人攻擊法&quot;詐騙.</translation>
+        <translation>請在下面輸入簽署的地址, 訊息(請確認完整複製了所包含的換行, 空格, 跳位符號等等), 與簽章, 以驗證該訊息. 請小心, 除了訊息內容外, 不要對簽章本身過度解讀, 以避免被用&quot;中間人攻擊法&quot;詐騙.</translation>
     </message>
     <message>
         <location line="+21"/>
         <source>The address the message was signed with (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</source>
-        <translation>簽署該訊息的位址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
+        <translation>簽署該訊息的地址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
     </message>
     <message>
         <location line="+40"/>
         <source>Verify the message to ensure it was signed with the specified Dogecoin address</source>
-        <translation>驗證訊息是用來確認訊息是用指定的莱特幣位址簽署的</translation>
+        <translation>驗證訊息是用來確認訊息是用指定的狗狗幣地址簽署的</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -1576,7 +1576,7 @@ Address: %4
         <location filename="../signverifymessagedialog.cpp" line="+27"/>
         <location line="+3"/>
         <source>Enter a Dogecoin address (e.g. DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</source>
-        <translation>輸入莱特幣位址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
+        <translation>輸入狗狗幣地址 (比如說 DJ7zB7c5BsB9UJLy1rKQtY7c6CQfGiaRLM)</translation>
     </message>
     <message>
         <location line="-2"/>
@@ -1586,13 +1586,13 @@ Address: %4
     <message>
         <location line="+3"/>
         <source>Enter Dogecoin signature</source>
-        <translation>輸入莱特幣簽章</translation>
+        <translation>輸入狗狗幣簽章</translation>
     </message>
     <message>
         <location line="+82"/>
         <location line="+81"/>
         <source>The entered address is invalid.</source>
-        <translation>輸入的位址無效.</translation>
+        <translation>輸入的地址無效.</translation>
     </message>
     <message>
         <location line="-81"/>
@@ -1600,13 +1600,13 @@ Address: %4
         <location line="+73"/>
         <location line="+8"/>
         <source>Please check the address and try again.</source>
-        <translation>請檢查位址是否正確後再試一次.</translation>
+        <translation>請檢查地址是否正確後再試一次.</translation>
     </message>
     <message>
         <location line="-81"/>
         <location line="+81"/>
         <source>The entered address does not refer to a key.</source>
-        <translation>輸入的位址沒有指到任何密鑰.</translation>
+        <translation>輸入的地址沒有指到任何密鑰.</translation>
     </message>
     <message>
         <location line="-73"/>
@@ -1616,7 +1616,7 @@ Address: %4
     <message>
         <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
-        <translation>沒有所輸入位址的密鑰.</translation>
+        <translation>沒有所輸入地址的密鑰.</translation>
     </message>
     <message>
         <location line="+12"/>
@@ -1660,7 +1660,7 @@ Address: %4
     <message>
         <location filename="../splashscreen.cpp" line="+22"/>
         <source>The Dogecoin developers</source>
-        <translation>莱特幣開發人員</translation>
+        <translation>狗狗幣開發人員</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -1732,7 +1732,7 @@ Address: %4
         <location line="-77"/>
         <location line="+2"/>
         <source>own address</source>
-        <translation>自己的位址</translation>
+        <translation>自己的地址</translation>
     </message>
     <message>
         <location line="-2"/>
@@ -1870,7 +1870,7 @@ Address: %4
     <message>
         <location line="+0"/>
         <source>Address</source>
-        <translation>位址</translation>
+        <translation>地址</translation>
     </message>
     <message>
         <location line="+0"/>
@@ -1965,7 +1965,7 @@ Address: %4
     <message>
         <location line="+2"/>
         <source>Destination address of transaction.</source>
-        <translation>交易的目標位址.</translation>
+        <translation>交易的目標地址.</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -2039,7 +2039,7 @@ Address: %4
     <message>
         <location line="+7"/>
         <source>Enter address or label to search</source>
-        <translation>輸入位址或標記來搜尋</translation>
+        <translation>輸入地址或標籤來搜尋</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -2049,12 +2049,12 @@ Address: %4
     <message>
         <location line="+34"/>
         <source>Copy address</source>
-        <translation>複製位址</translation>
+        <translation>複製地址</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Copy label</source>
-        <translation>複製標記</translation>
+        <translation>複製標籤</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2069,7 +2069,7 @@ Address: %4
     <message>
         <location line="+1"/>
         <source>Edit label</source>
-        <translation>編輯標記</translation>
+        <translation>編輯標籤</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2104,12 +2104,12 @@ Address: %4
     <message>
         <location line="+1"/>
         <source>Label</source>
-        <translation>標記</translation>
+        <translation>標籤</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Address</source>
-        <translation>位址</translation>
+        <translation>地址</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2198,7 +2198,7 @@ Address: %4
     <message>
         <location filename="../bitcoinstrings.cpp" line="+94"/>
         <source>Dogecoin version</source>
-        <translation>莱特幣版本</translation>
+        <translation>狗狗幣版本</translation>
     </message>
     <message>
         <location line="+102"/>
@@ -2265,12 +2265,12 @@ Address: %4
     <message>
         <location line="-48"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>連線到某個節點以取得其它節點的位址, 然後斷線</translation>
+        <translation>連線到某個節點以取得其它節點的地址, 然後斷線</translation>
     </message>
     <message>
         <location line="+82"/>
         <source>Specify your own public address</source>
-        <translation>指定自己公開的位址</translation>
+        <translation>指定自己公開的地址</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -2348,12 +2348,12 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>和指定的位址繫結, 並總是在該位址聽候連線. IPv6 請用 &quot;[主機]:通訊埠&quot; 這種格式</translation>
+        <translation>和指定的地址繫結, 並總是在該地址聽候連線. IPv6 請用 &quot;[主機]:通訊埠&quot; 這種格式</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Cannot obtain a lock on data directory %s. Dogecoin is probably already running.</source>
-        <translation>無法鎖定資料目錄 %s. 也許莱特幣已經在執行了.</translation>
+        <translation>無法鎖定資料目錄 %s. 也許狗狗幣已經在執行了.</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -2398,12 +2398,12 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Dogecoin will not work properly.</source>
-        <translation>警告: 請檢查電腦時間與日期是否正確! 莱特幣無法在時鐘不準的情況下正常運作.</translation>
+        <translation>警告: 請檢查電腦時間與日期是否正確! 狗狗幣無法在時鐘不準的情況下正常運作.</translation>
     </message>
     <message>
         <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation>警告: 讀取錢包檔 wallet.dat 失敗了! 所有的密鑰都正確讀取了, 但是交易資料或位址簿資料可能會缺少或不正確.</translation>
+        <translation>警告: 讀取錢包檔 wallet.dat 失敗了! 所有的密鑰都正確讀取了, 但是交易資料或地址簿資料可能會缺少或不正確.</translation>
     </message>
     <message>
         <location line="+3"/>
@@ -2433,7 +2433,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
-        <translation>找出自己的網際網路位址 (預設: 當有聽候連線且沒有 -externalip 時為 1)</translation>
+        <translation>找出自己的網際網路地址 (預設: 當有聽候連線且沒有 -externalip 時為 1)</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2518,7 +2518,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+1"/>
         <source>Failed to write to coin database</source>
-        <translation>寫入莱特幣資料庫失敗</translation>
+        <translation>寫入狗狗幣資料庫失敗</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2538,7 +2538,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+1"/>
         <source>Generate coins (default: 0)</source>
-        <translation>生產莱特幣 (預設值: 0)</translation>
+        <translation>生產狗狗幣 (預設值: 0)</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -2593,7 +2593,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+3"/>
         <source>Invalid -tor address: &apos;%s&apos;</source>
-        <translation>無效的 -tor 位址: &apos;%s&apos;</translation>
+        <translation>無效的 -tor 地址: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -2758,7 +2758,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="-67"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
-        <translation>只允許從指定網路位址來的 JSON-RPC 連線</translation>
+        <translation>只允許從指定網路地址來的 JSON-RPC 連線</translation>
     </message>
     <message>
         <location line="+76"/>
@@ -2835,7 +2835,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+55"/>
         <source>Loading addresses...</source>
-        <translation>載入位址中...</translation>
+        <translation>載入地址中...</translation>
     </message>
     <message>
         <location line="-35"/>
@@ -2850,7 +2850,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+93"/>
         <source>Wallet needed to be rewritten: restart Dogecoin to complete</source>
-        <translation>錢包需要重寫: 請重啟莱特幣來完成</translation>
+        <translation>錢包需要重寫: 請重啟狗狗幣來完成</translation>
     </message>
     <message>
         <location line="-95"/>
@@ -2860,7 +2860,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+28"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
-        <translation>無效的 -proxy 位址: &apos;%s&apos;</translation>
+        <translation>無效的 -proxy 地址: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+56"/>
@@ -2875,12 +2875,12 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="-96"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
-        <translation>無法解析 -bind 位址: &apos;%s&apos;</translation>
+        <translation>無法解析 -bind 地址: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
-        <translation>無法解析 -externalip 位址: &apos;%s&apos;</translation>
+        <translation>無法解析 -externalip 地址: &apos;%s&apos;</translation>
     </message>
     <message>
         <location line="+44"/>
@@ -2910,7 +2910,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="-25"/>
         <source>Unable to bind to %s on this computer. Dogecoin is probably already running.</source>
-        <translation>無法和這台電腦上的 %s 繫結. 也許莱特幣已經在執行了.</translation>
+        <translation>無法和這台電腦上的 %s 繫結. 也許狗狗幣已經在執行了.</translation>
     </message>
     <message>
         <location line="+64"/>
@@ -2930,7 +2930,7 @@ alertnotify=echo %%s | mail -s &quot;Dogecoin Alert&quot; admin@foo.com
     <message>
         <location line="+3"/>
         <source>Cannot write default address</source>
-        <translation>無法寫入預設位址</translation>
+        <translation>無法寫入預設地址</translation>
     </message>
     <message>
         <location line="+64"/>


### PR DESCRIPTION
update some obvious untranslated phrases (e.g. Litecoin->Dogecoin).

Reviewed by a native speaker.
