### PR TITLE
Removed wallet upgrade code inherited from Bitcoin/Litecoin

### DIFF
--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -214,26 +214,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 return false;
             }
 
-            // Undo serialize changes in 31600
-            if (31404 <= wtx.fTimeReceivedIsTxTime && wtx.fTimeReceivedIsTxTime <= 31703)
-            {
-                if (!ssValue.empty())
-                {
-                    char fTmp;
-                    char fUnused;
-                    ssValue >> fTmp >> fUnused >> wtx.strFromAccount;
-                    strErr = strprintf("LoadWallet() upgrading tx ver=%d %d '%s' %s",
-                                       wtx.fTimeReceivedIsTxTime, fTmp, wtx.strFromAccount.c_str(), hash.ToString().c_str());
-                    wtx.fTimeReceivedIsTxTime = fTmp;
-                }
-                else
-                {
-                    strErr = strprintf("LoadWallet() repairing tx ver=%d %s", wtx.fTimeReceivedIsTxTime, hash.ToString().c_str());
-                    wtx.fTimeReceivedIsTxTime = 0;
-                }
-                vWalletUpgrade.push_back(hash);
-            }
-
             if (wtx.nOrderPos == -1)
                 fAnyUnordered = true;
 
@@ -453,10 +433,6 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
     BOOST_FOREACH(uint256 hash, vWalletUpgrade)
         WriteTx(hash, pwallet->mapWallet[hash]);
-
-    // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
-    if (fIsEncrypted && (nFileVersion == 40000 || nFileVersion == 50000))
-        return DB_NEED_REWRITE;
 
     if (nFileVersion < CLIENT_VERSION) // Update
         WriteVersion(CLIENT_VERSION);


### PR DESCRIPTION
Removed wallet upgrade code inherited from Bitcoin/Litecoin which does not apply to Dogecoin wallets. This should have no functional change, and merely eliminates dead code.
