### PR TITLE
Change reference version of Berkeley DB to 5.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ case $host in
        if test x$BREW = xbrew; then
          dnl add default homebrew paths
          openssl_prefix=`$BREW --prefix openssl`
-         bdb_prefix=`$BREW --prefix berkeley-db4`
+         bdb_prefix=`$BREW --prefix berkeley-db5`
          export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
          CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
          LIBS="$LIBS -L$bdb_prefix/lib"
@@ -359,7 +359,7 @@ AC_SUBST(LIBMEMENV)
 
 if test x$enable_wallet != xno; then
     dnl Check for libdb_cxx only if wallet enabled
-    BITCOIN_FIND_BDB48
+    BITCOIN_FIND_BDB51
 fi
 
 dnl Check for libminiupnpc (optional)

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -15,7 +15,7 @@ Libraries you need to download separately and build:
 	name            default path               download
 	--------------------------------------------------------------------------------------------------------------------
 	OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
-	Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
+	Berkeley DB     \db-5.1.29.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 	Boost           \boost-1.50.0-mgw          http://www.boost.org/users/download/
 	miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
 
@@ -29,7 +29,7 @@ Their licenses:
 Versions used in this release:
 
 	OpenSSL      1.0.1c
-	Berkeley DB  4.8.30.NC
+	Berkeley DB  5.1.29.NC
 	Boost        1.50.0
 	miniupnpc    1.6
 
@@ -49,7 +49,7 @@ Berkeley DB
 -----------
 MSYS shell:
 
-	cd /c/db-4.8.30.NC-mgw/build_unix
+	cd /c/db-5.1.29.NC-mgw/build_unix
 	sh ../dist/configure --enable-mingw --enable-cxx
 	make
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -46,7 +46,7 @@ Instructions: MacPorts
 
 Installing the dependencies using MacPorts is very straightforward.
 
-    sudo port install boost db48@+no_java openssl miniupnpc autoconf pkgconfig automake
+    sudo port install boost db51@+no_java openssl miniupnpc autoconf pkgconfig automake
 
 Optional: install Qt4
 
@@ -74,7 +74,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 boost miniupnpc openssl pkg-config protobuf qt
+        brew install autoconf automake berkeley-db5 boost miniupnpc openssl pkg-config protobuf qt
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -17,7 +17,7 @@ Dependencies
  Library     | Purpose          | Description
  ------------|------------------|----------------------
  libssl      | SSL Support      | Secure communications
- libdb4.8    | Berkeley DB      | Wallet storage
+ libdb5.1    | Berkeley DB      | Wallet storage
  libboost    | Boost            | C++ Library
  miniupnpc   | UPnP Support     | Optional firewall-jumping support
  qt          | GUI              | GUI toolkit
@@ -45,7 +45,7 @@ Licenses of statically linked libraries:
 - Versions used in this release:
 -  GCC           4.3.3
 -  OpenSSL       1.0.1c
--  Berkeley DB   4.8.30.NC
+-  Berkeley DB   5.1.29.NC
 -  Boost         1.55
 -  miniupnpc     1.6
 -  qt            4.8.3
@@ -62,36 +62,16 @@ Build requirements:
 
 for Ubuntu 12.04 and later:
 
-	sudo apt-get install libboost-all-dev
-
- db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
- You can add the repository using the following command:
-
-        sudo add-apt-repository ppa:bitcoin/bitcoin
-        sudo apt-get update
-
- Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
- but using these will break binary wallet compatibility, and is not recommended.
+	sudo apt-get install libboost-all-dev libdb5.1-dev libdb5.1++-dev
 
 for Ubuntu 13.10:
 	libboost1.54 will not work,
 	remove libboost1.54-all-dev and install libboost1.53-all-dev instead.
 
-for Debian 7 (Wheezy) and later:
- The oldstable repository contains db4.8 packages.
- Add the following line to /etc/apt/sources.list,
- replacing [mirror] with any official debian mirror.
-
-	deb http://[mirror]/debian/ oldstable main
-
-To enable the change run
-
-	sudo apt-get update
-
 for other Ubuntu & Debian:
 
-	sudo apt-get install libdb4.8-dev
-	sudo apt-get install libdb4.8++-dev
+	sudo apt-get install libdb5.1-dev
+	sudo apt-get install libdb5.1++-dev
 	sudo apt-get install libboost1.55-all-dev
 
 Optional:
@@ -138,7 +118,7 @@ miniupnpc
 
 Berkeley DB
 -----------
-You need Berkeley DB 4.8.  If you have to build Berkeley DB yourself:
+You need Berkeley DB 5.1.  If you have to build Berkeley DB yourself:
 
 	cd build_unix/
 	../dist/configure --enable-cxx
@@ -210,7 +190,7 @@ disable-wallet mode with:
 
     ./configure --disable-wallet
 
-In this case there is no dependency on Berkeley DB 4.8.
+In this case there is no dependency on Berkeley DB 5.1.
 
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call not `getwork`.

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -41,7 +41,7 @@ Release Process
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.8.tar.gz' -O miniupnpc-1.8.tar.gz
 	wget 'https://www.openssl.org/source/openssl-1.0.1e.tar.gz'
-	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+	wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'ftp://ftp.simplesystems.org/pub/png/src/history/libpng16/libpng-1.6.8.tar.gz'
 	wget 'https://fukuchi.org/works/qrencode/qrencode-3.4.3.tar.bz2'

--- a/src/m4/dogecoin_find_bdb51.m4
+++ b/src/m4/dogecoin_find_bdb51.m4
@@ -1,11 +1,11 @@
-AC_DEFUN([BITCOIN_FIND_BDB48],[
+AC_DEFUN([BITCOIN_FIND_BDB51],[
   AC_MSG_CHECKING([for Berkeley DB C++ headers])
   BDB_CPPFLAGS=
   BDB_LIBS=
   bdbpath=X
-  bdb48path=X
+  bdb51path=X
   bdbdirlist=
-  for _vn in 4.8 48 4 5 ''; do
+  for _vn in 5.1 51 5 ''; do
     for _pfx in b lib ''; do
       bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
     done
@@ -15,8 +15,8 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
     AC_TRY_COMPILE([
       #include <${searchpath}db_cxx.h>
     ],[
-      #if !((DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 8) || DB_VERSION_MAJOR > 4)
-        #error "failed to find bdb 4.8+"
+      #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 1) || DB_VERSION_MAJOR > 5)
+        #error "failed to find bdb 5.1+"
       #endif
     ],[
       if test "x$bdbpath" = "xX"; then
@@ -28,32 +28,32 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
     AC_TRY_COMPILE([
       #include <${searchpath}db_cxx.h>
     ],[
-      #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
-        #error "failed to find bdb 4.8"
+      #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 1)
+        #error "failed to find bdb 5.1"
       #endif
     ],[
-      bdb48path="${searchpath}"
+      bdb51path="${searchpath}"
       break
     ])
   done
   if test "x$bdbpath" = "xX"; then
     AC_MSG_RESULT([no])
     AC_MSG_ERROR(libdb_cxx headers missing)
-  elif test "x$bdb48path" = "xX"; then
+  elif test "x$bdb51path" = "xX"; then
     BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
-      AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
+    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.1])],[
+      AC_MSG_WARN([Found Berkeley DB other than 5.1; wallets opened by this build will not be portable!])
     ],[
-      AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore)])
+      AC_MSG_ERROR([Found Berkeley DB other than 5.1, required for portable wallets (--with-incompatible-bdb to ignore)])
     ])
   else
-    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
-    bdbpath="${bdb48path}"
+    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb51path}],db_cxx)
+    bdbpath="${bdb51path}"
   fi
   AC_SUBST(BDB_CPPFLAGS)
   
   # TODO: Ideally this could find the library version and make sure it matches the headers being used
-  for searchlib in db_cxx-4.8 db_cxx; do
+  for searchlib in db_cxx-5.1 db_cxx; do
     AC_CHECK_LIB([$searchlib],[main],[
       BDB_LIBS="-l${searchlib}"
       break


### PR DESCRIPTION
Change reference version of Berkeley DB to 5.1, to match available libraries in Ubuntu LTS and Debian 7.

This breaks forward compatibility of old clients, but given all previous versions have done so as well, it feels like that's a reasonable trade-off for the simplified build process.
