### PR TITLE
Make GetAvailableCredit run GetHash() only once per transaction.

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -620,9 +620,10 @@ public:
             return nAvailableCreditCached;
 
         int64_t nCredit = 0;
+        uint256 hashTx = GetHash();
         for (unsigned int i = 0; i < vout.size(); i++)
         {
-            if (!pwallet->IsSpent(GetHash(), i))
+            if (!pwallet->IsSpent(hashTx, i))
             {
                 const CTxOut &txout = vout[i];
                 nCredit += pwallet->GetCredit(txout);


### PR DESCRIPTION
Backport bitcoin/bitcoin#3973 as it brings some nice performance improvements, even to the point where apparently some wallets seemed to be stuck before.
