### PR TITLE
warning and documentation changes to match dogecoin fees

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -555,7 +555,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     {
         if (!ParseMoney(mapArgs["-paytxfee"], nTransactionFee))
             return InitError(strprintf(_("Invalid amount for -paytxfee=<amount>: '%s'"), mapArgs["-paytxfee"]));
-        if (nTransactionFee > 0.25 * COIN)
+        if (nTransactionFee > 25 * COIN)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
     bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1875,8 +1875,8 @@ Value settxfee(const Array& params, bool fHelp)
             "\nResult\n"
             "true|false        (boolean) Returns true if successful\n"
             "\nExamples:\n"
-            + HelpExampleCli("settxfee", "0.00001")
-            + HelpExampleRpc("settxfee", "0.00001")
+            + HelpExampleCli("settxfee", "5")
+            + HelpExampleRpc("settxfee", "5")
         );
 
     // Amount


### PR DESCRIPTION
25 for the warning threshold matches Dogecoin 1.6. Since that's per kb that might actually be a good value.
