### PR TITLE
Add Dogechain to DNS seeds

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -71,6 +71,7 @@ public:
         vSeeds.push_back(CDNSSeedData("dogecoin.com", "seed.dogecoin.com"));
         vSeeds.push_back(CDNSSeedData("mophides.com", "seed.mophides.com"));
         vSeeds.push_back(CDNSSeedData("dglibrary.org", "seed.dglibrary.org"));
+	vSeeds.push_back(CDNSSeedData("dogechain.info", "seed.dogechain.info"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(30);
         base58Prefixes[SCRIPT_ADDRESS] = list_of(22);


### PR DESCRIPTION
Add Dogechain to DNS seeds. Resolves https://github.com/dogecoin/dogecoin/issues/390
