### PR TITLE
fix appname, influences registry location on windows

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -41,9 +41,9 @@ static const int MAX_PAYMENT_REQUEST_SIZE = 50000; // bytes
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 35
 
-#define QAPP_ORG_NAME "Bitcoin"
-#define QAPP_ORG_DOMAIN "bitcoin.org"
-#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_ORG_NAME "Dogecoin"
+#define QAPP_ORG_DOMAIN "dogecoin.com"
+#define QAPP_APP_NAME_DEFAULT "Dogecoin-Qt"
+#define QAPP_APP_NAME_TESTNET "Dogecoin-Qt-testnet"
 
 #endif // GUICONSTANTS_H


### PR DESCRIPTION
This causes dogecoin to look at the correct registry keys. Might fix stuff on Mac too.
