### PR TITLE
Standardised capitalisation of Dogecoin

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -19,7 +19,7 @@
 class CTransaction;
 
 /** No amount larger than this (in satoshi) is valid */
-static const int64_t MAX_MONEY = 10000000000 * COIN; // DogeCoin: maximum of 100B coins (given some randomness), max transaction 10,000,000,000
+static const int64_t MAX_MONEY = 10000000000 * COIN; // Dogecoin: maximum of 100B coins (given some randomness), max transaction 10,000,000,000
 inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1159,9 +1159,9 @@ int64_t GetBlockValue(int nHeight, int64_t nFees, uint256 prevHash)
 }
 
 // New Difficulty adjustement and reward scheme by /u/lleti, rog1121, and DigiByte (DigiShield Developers).
-static const int64_t nTargetTimespan = 4 * 60 * 60; // DogeCoin: every 4 hours
-static const int64_t nTargetTimespanNEW = 60 ; // DogeCoin: every 1 minute
-static const int64_t nTargetSpacing = 60; // DogeCoin: 1 minute
+static const int64_t nTargetTimespan = 4 * 60 * 60; // Dogecoin: every 4 hours
+static const int64_t nTargetTimespanNEW = 60 ; // Dogecoin: every 1 minute
+static const int64_t nTargetSpacing = 60; // Dogecoin: 1 minute
 static const int64_t nInterval = nTargetTimespan / nTargetSpacing;
 
 static const int64_t nDiffChangeTarget = 145000; // Patch effective @ block 145000

--- a/src/main.h
+++ b/src/main.h
@@ -304,7 +304,7 @@ inline bool AllowFree(double dPriority)
 {
     // Large (in bytes) low-priority (new, small-coin) transactions
     // need a fee.
-        return dPriority > 100 * COIN * 1440 / 250; // DogeCoin: 1440 blocks found a day. Priority cutoff is 100 dogecoin day / 250 bytes.
+        return dPriority > 100 * COIN * 1440 / 250; // Dogecoin: 1440 blocks found a day. Priority cutoff is 100 dogecoin day / 250 bytes.
     }
 
 // Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)


### PR DESCRIPTION
Standardised capitalisation of Dogecoin in source code files, following spec from https://github.com/dogecoin/dogecoin/pull/79
