### PR TITLE
Add application category for OSX

### DIFF
--- a/src/mac/Info.plist
+++ b/src/mac/Info.plist
@@ -33,5 +33,7 @@
 	<string>com.dogecoin.wallet-qt</string>
 	<key>CFBundleName</key>
 	<string>Dogecoin-Qt</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.finance</string>
 </dict>
 </plist>


### PR DESCRIPTION
If someone views their Applications folder arranged by Application Category, without LSApplicationCategoryType it gets sorted into "Other" at the bottom.
