### PR TITLE
add testnet seeds

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -145,7 +145,7 @@ public:
         vSeeds.push_back(CDNSSeedData("dogecoin.com", "seed.dogecoin.com"));
         vSeeds.push_back(CDNSSeedData("mophides.com", "seed.mophides.com"));
         vSeeds.push_back(CDNSSeedData("dglibrary.org", "seed.dglibrary.org"));
-	vSeeds.push_back(CDNSSeedData("dogechain.info", "seed.dogechain.info"));
+        vSeeds.push_back(CDNSSeedData("dogechain.info", "seed.dogechain.info"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(30);
         base58Prefixes[SCRIPT_ADDRESS] = list_of(22);
@@ -208,9 +208,8 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-        //vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
-        //vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
-        //TODO: create testnet seed
+        vSeeds.push_back(CDNSSeedData("testdoge.lionservers.de", "testdoge-seed.lionservers.de"));
+        vSeeds.push_back(CDNSSeedData("lionservers.de", "testdoge-seed-static.lionservers.de"));
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(113);
         base58Prefixes[SCRIPT_ADDRESS] = list_of(196);


### PR DESCRIPTION
testdoge-seed.lionservers.de is running a slightly modified version of https://github.com/langerhans/dogecoin-seeder, testdoge-seed-static.lionservers.de are manually maintained dns records residing on my hoster's nameservers.

With this patch, I immediately get multiple connections to the testnet even when deleting peers.dat and removing any addnode entries from the config file. The static seed should ensure that nodes can join the testnet even if my server is down.
