### PR TITLE
Add copyright notices to README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,6 +2,8 @@ Dogecoin 0.9.0rc1 BETA
 =====================
 
 Copyright (c) 2009-2014 Bitcoin Developers
+Copyright (c) 2011-2013 Litecoin Developers
+Copyright (c) 2013-2014 Dogecoin Developers
 
 
 Setup


### PR DESCRIPTION
Added Litecoin copyright notice to README.md, for Scrypt elements.
Added Dogecoin copyright notice to README.md.

This effectively replaces https://github.com/dogecoin/dogecoin/pull/184/files
