### PR TITLE
don't request blocks from clients without Digishield

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -40,7 +40,7 @@ static const int CADDR_TIME_VERSION = 31402;
 
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 60000;
-static const int NOBLKS_VERSION_END = 60002;
+static const int NOBLKS_VERSION_END = 70001;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;


### PR DESCRIPTION
If we release 1.6.1 (see #431), this might be worth considering. Now that 1.6 is widely used, we can stop accepting blocks from clients stuck on the 3rd fork, without completely stopping to talk with them.

I'm not sure about all implications, but this seems like a good choice. Alternatively, we could bump the minimum protocol version.
