### PR TITLE
Fix DoS tests to take into account DigiShield.

### DIFF
--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(DoS_checknbits)
     // First checkpoint difficulty at or a while after the last checkpoint time should fail when
     // compared to last checkpoint
     BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*10, lastcheck.second, lastcheck.first));
-    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*60*24*4, lastcheck.second, lastcheck.first));
+    BOOST_CHECK(!CheckNBits(firstcheck.second, lastcheck.first+60*60*24*3, lastcheck.second, lastcheck.first));
 
     // ... but OK if enough time passed for difficulty to adjust downward:
     BOOST_CHECK(CheckNBits(firstcheck.second, lastcheck.first+60*60*24*365*4, lastcheck.second, lastcheck.first));


### PR DESCRIPTION
Changed the time period covered for DoS tests from 4 days to 3, to take into account massively reduced retarget time from DigiShield.
