### PR TITLE
Cleaning up bitcoin from the UI

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -67,7 +67,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent) :
     header = tr("Dogecoin Core") + " " + tr("version") + " " +
         QString::fromStdString(FormatFullVersion()) + "\n\n" +
         tr("Usage:") + "\n" +
-        "  bitcoin-qt [" + tr("command-line options") + "]                     " + "\n";
+        "  dogecoin-qt [" + tr("command-line options") + "]                     " + "\n";
 
     coreOptions = QString::fromStdString(HelpMessage(HMM_BITCOIN_QT));
 


### PR DESCRIPTION
I checked if bitcoin was mentioned anywhere in the UI, and was left out by mistake. 
This is the only instance I could find.

![dogecoin-qt](https://cloud.githubusercontent.com/assets/374361/2688090/aeef5628-c281-11e3-945b-ee0bdcaf9117.jpeg)

Sending a pull request for the cleanup.
