### PR TITLE
adapt base58 testdata

### DIFF
--- a/src/test/data/base58_keys_valid.json
+++ b/src/test/data/base58_keys_valid.json
@@ -1,7 +1,7 @@
 [
     [
-        "1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i", 
-        "65a16059864a2fdbc7c99a4723a8395bc6f188eb", 
+        "DD4KSSuBJqcjuTcvUg1CgUKeurPUFeEZkE", 
+        "56d9b1d684d5abef32134ebc6883d75d3a53e9be", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -9,8 +9,8 @@
         }
     ], 
     [
-        "3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou", 
-        "74f209f6ea907e2ea48f74fae05782ae8a665257", 
+        "A7HRQk3GFCW2QasvdZxXuYj8kkQK5QrYLs", 
+        "a2dd71f34fe73314d6e37c44035513f203aa400b", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -18,8 +18,8 @@
         }
     ], 
     [
-        "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 
-        "53c0307d6851aa0ce7825ba883c6bd9ad242b486", 
+        "nhRsrUaxZou6sewjqaS37cJrMRJRgwVXdk", 
+        "9131c29384f000c0d651660eefaf1717c8ca1855", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -27,8 +27,8 @@
         }
     ], 
     [
-        "2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 
-        "6349a418fc4578d10a372b54b45c280cc8c4382f", 
+        "2MsvyG12kxxipe276Au4zKqvd2xdrBuHWb3", 
+        "078457e357c6c4d8736515d14482089dd2a1f9f8", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -36,8 +36,8 @@
         }
     ], 
     [
-        "5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr", 
-        "eddbdc1168f1daeadbd3e44c1e3f8f5a284c2029f78ad26af98583a499de5b19", 
+        "6K7a8wZW8A1oZxNd7wZz8PhgAAaDxybkzNpD1sGVvmSaBmc3Hg2", 
+        "81517fd848ebfeda7e2c684e7a3f5ebbb28b15d52d33d8a201d8873a0cdaf761", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -45,8 +45,8 @@
         }
     ], 
     [
-        "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD", 
-        "55c9bccb9ed68446d1b75273bbce89d7fe013a8acd1625514420fb2aca1a21c4", 
+        "QP5rQxpaP8HHPEdCEqxTjiHGWRvsyPvzZJeJ9BCxpfT13FN9VesQ", 
+        "0e017cc6ad98c6646a1139114e8dcd9bf2537f3e0306a2f43dea03f91fea370a0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -54,8 +54,8 @@
         }
     ], 
     [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko", 
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2", 
+        "96MAePnF8ppQm8165ABvzSEShnNy3vgxjmMhcqEkQVZ9FtPV2XL", 
+        "73423bf1fa6526ee571f3b4b4ad19799c81d40ce5c18a37d87dc38b55746627d", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -63,8 +63,8 @@
         }
     ], 
     [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH", 
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3", 
+        "ckaDjxhDsVyZTHLUF7uoojCXVYcciUGeEk53VFzKUJsKUKhnbUnZ", 
+        "ae03398655b29f80badf1e6909e75ccf9bcdb6062e8886d0aca4b3d46a82aa830", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -72,8 +72,8 @@
         }
     ], 
     [
-        "1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ", 
-        "6d23156cbbdcc82a5a47eee4c2c7c583c18b6bf4", 
+        "DBjW6kna7rUPE4Mj9j4B3oK3xVA1SDHrdt", 
+        "485290865b407657e0aedbdbb4aa6618310af50d", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -81,8 +81,8 @@
         }
     ], 
     [
-        "3QjYXhTkvuj8qPaXHTTWb5wjXhdsLAAWVy", 
-        "fcc5460dd6e2487c7d75b1963625da0e8f4c5975", 
+        "A3RHoAQLPDSuBewbuvt5NMqEKasqs9ty3C", 
+        "7879ea0f1053bcbd4c60c88f922f76d27e622e1e", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -90,8 +90,8 @@
         }
     ], 
     [
-        "n3ZddxzLvAY9o7184TB4c6FJasAybsw4HZ", 
-        "f1d470f9b02370fdec2e6b708b08ac431bf7a5f7", 
+        "ngbSgr1dhCqsLg6Z5tpsaCspwrH72x2Zk3", 
+        "8808c94daaa2e4f53102703b2c3de534d670e87e", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -99,8 +99,8 @@
         }
     ], 
     [
-        "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n", 
-        "c579342c2c4c9220205e2cdc285617040c924a0a", 
+        "2MvY1BBau2C6jRC1hNX5LmviLrpvVG386TM", 
+        "2414c0f3862d25178830fb1ae01d982b8385eea4", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -108,8 +108,8 @@
         }
     ], 
     [
-        "5K494XZwps2bGyeL71pWid4noiSNA2cfCibrvRWqcHSptoFn7rc", 
-        "a326b95ebae30164217d7a7f57d72ab2b54e3be64928a19da0210b9568d4015e", 
+        "6KVnGBP927t1rfowDpRcqYyE7WUX9w814iCNyYwtQEqKxEq8kBa", 
+        "b3bf28e85693936da055bc47e846657173e08ad30e143aaf2825ebacac325d6a", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -117,8 +117,8 @@
         }
     ], 
     [
-        "L1RrrnXkcKut5DEMwtDthjwRcTTwED36thyL1DebVrKuwvohjMNi", 
-        "7d998b45c219a1e38e99e7cbd312ef67f77a455a9b50c730c27f02c6f730dfb4", 
+        "QVi86rdL3APa6TXXwPdRnKfqVfzGv6a993E5LeiHXaGGjE7cpah1", 
+        "d3b068bb594f19c1c70931d8aa19ab774147f946021737c988cafb51980f53fa0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -126,8 +126,8 @@
         }
     ], 
     [
-        "93DVKyFYwSN6wEo3E2fCrFPUp17FtrtNi2Lf7n4G3garFb16CRj", 
-        "d6bca256b5abc5602ec2e1c121a08b0da2556587430bcf7e1898af2224885203", 
+        "95zguKdTJ9FznRvT4oUuBdqUxfrXe6qZby53E1GKsc1y5K713pe", 
+        "44c29c1910335047e44cf55d71d6a98b9935014016820532f067b6546b619cbf", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -135,8 +135,8 @@
         }
     ], 
     [
-        "cTDVKtMGVYWTHCb1AFjmVbEbWjvKpKqKgMaR3QJxToMSQAhmCeTN", 
-        "a81ca4e8f90181ec4b61b6a7eb998af17b2cb04de8a03b504b9e34c4c61db7d9", 
+        "cmcFP2C5YMhPQpxv3X2i6byHxt21VYyuju7kCiVmUXqihMPshNKe", 
+        "cce4b63fa376a9d9d1828919d8df8435bdda853193b7fc8eff997a1144bf8d6e0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -144,8 +144,8 @@
         }
     ], 
     [
-        "1C5bSj1iEGUgSTbziymG7Cn18ENQuT36vv", 
-        "7987ccaa53d02c8873487ef919677cd3db7a6912", 
+        "D77Z1nmgSZxJTmtN65n2MVF9yvLSB4MpiC", 
+        "15a585042e96300b5ad4f9d7c7c6cba2d56a0989", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -153,8 +153,8 @@
         }
     ], 
     [
-        "3AnNxabYGoTxYiTEZwFEnerUoeFXK2Zoks", 
-        "63bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb", 
+        "9zYnVRaekPtdKBYuPw5QiBtv3NNrzD2LLW", 
+        "58fc66bf64b3c8d8accd80110bb6df6c13735937", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -162,8 +162,8 @@
         }
     ], 
     [
-        "n3LnJXCqbPjghuVs8ph9CYsAe4Sh4j97wk", 
-        "ef66444b5b17f14e8fae6e7e19b045a78c54fd79", 
+        "ngao4q8auS6YuDKYPkzjt7zKYYT8LzkGZS", 
+        "87e961c7a75c7048de3758ad6723d5e047a0a66d", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -171,8 +171,8 @@
         }
     ], 
     [
-        "2NB72XtkjpnATMggui83aEtPawyyKvnbX2o", 
-        "c3e55fceceaa4391ed2a9677f4a4d34eacd021a0", 
+        "2N22vuiMGhfqD77vPqsXPiALBfn6oUTtFtH", 
+        "6065e2440e0b5dcb108e4eb019777e1a8377cd22", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -180,8 +180,8 @@
         }
     ], 
     [
-        "5KaBW9vNtWNhc3ZEDyNCiXLPdVPHCikRxSBWwV9NrpLLa4LsXi9", 
-        "e75d936d56377f432f404aabb406601f892fd49da90eb6ac558a733c93b47252", 
+        "6Jz9frVjB2g4F7tALvkt6yytWo5vQbLeGdvHPP3TRtZ8NDz7ayS", 
+        "70775592babf3ce95769229e6735a4b57e0c6b78f2c2dc7fb67b59e85ea7bd03", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -189,8 +189,8 @@
         }
     ], 
     [
-        "L1axzbSyynNYA8mCAhzxkipKkfHtAXYF4YQnhSKcLV8YXA874fgT", 
-        "8248bd0375f2f75d7e274ae544fb920f51784480866b102384190b1addfbaa5c", 
+        "QPyvGzBensKS63stwvzsxrqQafwdFtYYqqmDhuxySpY1jkEKZ6kr", 
+        "28ca745f92b0b9b2ca2b4ebe566b665b3fca522855482c840f457b2a6cef55350", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -198,8 +198,8 @@
         }
     ], 
     [
-        "927CnUkUbasYtDwYwVn2j8GdTuACNnKkjZ1rpZd2yBB1CLcnXpo", 
-        "44c4f6a096eac5238291a94cc24c01e3b19b8d8cef72874a079e00a242237a52", 
+        "96SJY1FrWHRvDuWtAMCbfZPqUkA6JxQpqjihjpbwrqFYcmLBuMW", 
+        "7eebb40de099f1feef864f880835b5d8614ad5cf3fd1e8a113b920ce6876496d", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -207,8 +207,8 @@
         }
     ], 
     [
-        "cUcfCMRjiQf85YMzzQEk9d1s5A4K7xL5SmBCLrezqXFuTVefyhY7", 
-        "d1de707020a9059d6d3abaf85e17967c6555151143db13dbb06db78df0f15c69", 
+        "cjN4SQ4pHBLNnsyDPwjTPRTtoPN4YZoSthpAs2ysuF8kLnUYc12C", 
+        "89eb5ff85053c07eb1feefea07ea106564e0229e3b2c99d88f2f89c884dd7a390", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -216,8 +216,8 @@
         }
     ], 
     [
-        "1Gqk4Tv79P91Cc1STQtU3s1W6277M2CVWu", 
-        "adc1cc2081a27206fae25792f28bbc55b831549d", 
+        "DGYdw7jC17b9SappjsrAsaghhDTS8sV5Mx", 
+        "7d1d283ff32f3a425ea22d21032e1bca7d14efaa", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -225,8 +225,8 @@
         }
     ], 
     [
-        "33vt8ViH5jsr115AGkW6cEmEz9MpvJSwDk", 
-        "188f91a931947eddd7432d6e614387e32b244709", 
+        "A3YUuiZjn3FzW2i6KqFVgHaN5r5fjvwEJ1", 
+        "79d61a4a63956139414b4e0698588cfb2c3466bf", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -234,8 +234,8 @@
         }
     ], 
     [
-        "mhaMcBxNh5cqXm4aTQ6EcVbKtfL6LGyK2H", 
-        "1694f5bc1a7295b600f40018a618a6ea48eeb498", 
+        "nbo7vyCuiMxiYW4thwwuaTHQdCoqinmzJz", 
+        "53657de94e3b0ecf22a3188e1bc220b7ba0bbff9", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -243,8 +243,8 @@
         }
     ], 
     [
-        "2MxgPqX1iThW3oZVk9KoFcE5M4JpiETssVN", 
-        "3b9b3fd7a50d4f08d1a5b0f62f644fa7115ae2f3", 
+        "2N1Gz97rN7P6VCj9xf64wWFqQZgpUng1mM3", 
+        "5816475b6d3419099db394dfd9b81200d6618b9c", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -252,8 +252,8 @@
         }
     ], 
     [
-        "5HtH6GdcwCJA4ggWEL1B3jzBBUB8HPiBi9SBc5h9i4Wk4PSeApR", 
-        "091035445ef105fa1bb125eccfb1882f3fe69592265956ade751fd095033d8d0", 
+        "6Kr2pQ4e9nGGZH8zYZMGWbeM4bft4L8efsg4jhN3rhMCJfB2Pkx", 
+        "e1ba9f4402a578bcb09701757b49ce37017510d2cc304db3027bb9bcc932fdff", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -261,8 +261,8 @@
         }
     ], 
     [
-        "L2xSYmMeVo3Zek3ZTsv9xUrXVAmrWxJ8Ua4cw8pkfbQhcEFhkXT8", 
-        "ab2b4bcdfc91d34dee0ae2a8c6b6668dadaeb3a88b9859743156f462325187af", 
+        "QUsNNw934sS8DjjTNKAkpZbN2RUFW1YaNz6PHYgkFMaj8uWhCuLc", 
+        "ba9bb7f48969e94301025313c298916b2913fb7eecefe98b9128ef4d87e40ea40", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -270,8 +270,8 @@
         }
     ], 
     [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq", 
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856", 
+        "979GQk1egwDTfCWnzeyNVxEiqfoKBudz1FRVooEzcTCb8JA9dau", 
+        "dbeedb336fb0f76b3de009d248fcf55d2a0a73ccf75096aa997248915fc03371", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -279,8 +279,8 @@
         }
     ], 
     [
-        "cVM65tdYu1YK37tNoAyGoJTR13VBYFva1vg9FLuPAsJijGvG6NEA", 
-        "e7b230133f1b5489843260236b06edca25f66adb1be455fbd38d4010d48faeef", 
+        "cf2NrvygA68y6ZCAkW2ueCuQ1B8qzyWpjGY38qhjvQgZAFLhRWGB", 
+        "0871ca5e089defd44b5076eecb20dcccaa9c97ad53253595d8957239c11410fb0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -288,8 +288,8 @@
         }
     ], 
     [
-        "1JwMWBVLtiqtscbaRHai4pqHokhFCbtoB4", 
-        "c4c1b72491ede1eedaca00618407ee0b772cad0d", 
+        "DExWunrSkF2P9NAzW4JpEeC38uC3z36cCk", 
+        "6bb106bf7cc3f80e5cfeb3eacdd8f7dd9201fa09", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -297,8 +297,8 @@
         }
     ], 
     [
-        "3QCzvfL4ZRvmJFiWWBVwxfdaNBT8EtxB5y", 
-        "f6fe69bcb548a829cce4c57bf6fff8af3a5981f9", 
+        "AFVkW8WgPP2rsTdAeyogFK9k8gXJ1LZwrb", 
+        "fcf36180b62ef220a182b1b246571bb2fce30ec8", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -306,8 +306,8 @@
         }
     ], 
     [
-        "mizXiucXRCsEriQCHUkCqef9ph9qtPbZZ6", 
-        "261f83568a098a8638844bd7aeca039d5f2352c0", 
+        "nagGnGDKWYpvnphf9rgo3xtQhAxiEM1QGD", 
+        "4721d78285d03bbb968537f80426b5af244e1c31", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -315,8 +315,8 @@
         }
     ], 
     [
-        "2NEWDzHWwY5ZZp8CQWbB7ouNMLqCia6YRda", 
-        "e930e1834a4d234702773951d627cce82fbb5d2e", 
+        "2N2f7vA5j92GCGuNt868zihqDBexEdDmJ8V", 
+        "673e0c152e1677a9a8fd55df78bb1eab3db3c53c", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -324,8 +324,8 @@
         }
     ], 
     [
-        "5KQmDryMNDcisTzRp3zEq9e4awRmJrEVU1j5vFRTKpRNYPqYrMg", 
-        "d1fab7ab7385ad26872237f1eb9789aa25cc986bacc695e07ac571d6cdac8bc0", 
+        "6KaPu5s64YkVCz5n4oc5FEFVL6qVCh9a8Sdd6BYoE1SN2awEgb5", 
+        "be396d0ed750dc736ef1cabd65e813b3bf7417d21159919f49dd7cd2fa6b467e", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -333,8 +333,8 @@
         }
     ], 
     [
-        "L39Fy7AC2Hhj95gh3Yb2AU5YHh1mQSAHgpNixvm27poizcJyLtUi", 
-        "b0bbede33ef254e8376aceb1510253fc3550efd0fcf84dcd0c9998b288f166b3", 
+        "QRy3VpfeQ9hynFuZe7wJ7aPUNTtFmLrXoWQDtUY7fkoFQsNDLiTu", 
+        "6403e70451390134f2bddbe5ecb33c5b264af292fcbf2cdd97deaac7e1e8f7ba0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -342,8 +342,8 @@
         }
     ], 
     [
-        "91cTVUcgydqyZLgaANpf1fvL55FH53QMm4BsnCADVNYuWuqdVys", 
-        "037f4192c630f399d9271e26c575269b1d15be553ea1a7217f0cb8513cef41cb", 
+        "96fTvLn3vYVp3ztgSEJdH4LfUNUvNdGav8SGD1hzpuupXVQuEWm", 
+        "9cce64818e4d50f761d1fcb230e9b8a0f20fc09c00c87e6a704cbfc5dd063489", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -351,8 +351,8 @@
         }
     ], 
     [
-        "cQspfSzsgLeiJGB2u8vrAiWpCU4MxUT6JseWo2SjXy4Qbzn2fwDw", 
-        "6251e205e8ad508bab5596bee086ef16cd4b239e0cc0c5d7c4e6035441e7d5de", 
+        "ckoubjh1yr1Hyg8NPtGwDz4tx91b6qztxrJZgTtdR4Ed9CqAV5cn", 
+        "b50dc6e116f4f4ae8b05fa6cb197cdfd27bd0c61e1c53c1ca83fcb9b56d59a830", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -360,8 +360,8 @@
         }
     ], 
     [
-        "19dcawoKcZdQz365WpXWMhX6QCUpR9SY4r", 
-        "5eadaf9bb7121f0f192561a5a62f5e5f54210292", 
+        "DMYFDsuFamS4kogsiqxQRXK9diCfmJzNLh", 
+        "b3e2d3f49932081bd0a9936d0cc239aafed51a64", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -369,8 +369,8 @@
         }
     ], 
     [
-        "37Sp6Rv3y4kVd1nQ1JV5pfqXccHNyZm1x3", 
-        "3f210e7277c899c3a155cc1c90f4106cbddeec6e", 
+        "A2CUbyEtqGUjngAjxpGmM5Nwhrz72gh23v", 
+        "6b1566fa4c70a69df12bacc138efffd9b9cb0e72", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -378,8 +378,8 @@
         }
     ], 
     [
-        "myoqcgYiehufrsnnkqdqbp69dddVDMopJu", 
-        "c8a3c2a09a298592c3e180f02487cd91ba3400b5", 
+        "nics7FiGssSKTuDrfNbHXa913W4LrLLK2w", 
+        "9e3dd6e04d1a35b84740e9a1b71c2809f7c578d4", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -387,8 +387,8 @@
         }
     ], 
     [
-        "2N7FuwuUuoTBrDFdrAZ9KxBmtqMLxce9i1C", 
-        "99b31df7c9068d1481b596578ddbb4d3bd90baeb", 
+        "2MtHzsXQHKJCW6s6MikTVM14kk8aqF3WmZv", 
+        "0b7e6cae84a027bdb60c9d6760c329b98ce87d45", 
         {
             "addrType": "script", 
             "isPrivkey": false, 
@@ -396,8 +396,8 @@
         }
     ], 
     [
-        "5KL6zEaMtPRXZKo1bbMq7JDjjo1bJuQcsgL33je3oY8uSJCR5b4", 
-        "c7666842503db6dc6ea061f092cfb9c388448629a6fe868d068c42a488b478ae", 
+        "6KWRvmWB1YXTp54zTKBPS4QUHbag7aP2CKkJ5eN7YqFcfFRjFaM", 
+        "b538a4cc390ca5c29bf2cb06d5b851418aa2eef0e175e0b655dadcfd6b9f0284", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -405,8 +405,8 @@
         }
     ], 
     [
-        "KwV9KAfwbwt51veZWNscRTeZs9CKpojyu1MsPnaKTF5kz69H1UN2", 
-        "07f0803fc5399e773555ab1e8939907e9badacc17ca129e67a2f5f2ff84351dd", 
+        "QVDwi7RFwB1hL2upnnEBn1HjaTexNWSYtkYpdE1VhcY3n7faQ32D", 
+        "c531526045e4585f3893dfa6e6e6b71af4fa517ba280039b35667b60a95de9e20", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -414,8 +414,8 @@
         }
     ], 
     [
-        "93N87D6uxSBzwXvpokpzg8FFmfQPmvX4xHoWQe3pLdYpbiwT5YV", 
-        "ea577acfb5d1d14d3b7b195c321566f12f87d2b77ea3a53f68df7ebf8604a801", 
+        "95cdHztwpWKgA4dgw8chw9hjR4yjxNFZrPr9otqgPL5mH9PGesJ", 
+        "12aa4b855eedc7026fb706ec1598023d04e95256c7beebd6556fbe9493be4d61", 
         {
             "isCompressed": false, 
             "isPrivkey": true, 
@@ -423,8 +423,8 @@
         }
     ], 
     [
-        "cMxXusSihaX58wpJ3tNuuUcZEQGt6DKJ1wEpxys88FFaQCYjku9h", 
-        "0b3b34f0958d8a268193a9814da92c3e8b58b4a4378a542863e34ac289cd830c", 
+        "ckrhHfB5k7NzVEqEsksYGvh2xSjZiT71oVGGSysP97bGMCkm3EgK", 
+        "b67ce8f38601e2f35bcca9b9cc9ac7f5ed7bfad783cf8ecdb21a1f912086cf4d0", 
         {
             "isCompressed": true, 
             "isPrivkey": true, 
@@ -432,8 +432,8 @@
         }
     ], 
     [
-        "13p1ijLwsnrcuyqcTvJXkq2ASdXqcnEBLE", 
-        "1ed467017f043e91ed4c44b4e8dd674db211c4e6", 
+        "DQJXChtyuN3aiU3W6pG4mgnykisHH5hqst", 
+        "d232b89955f8f77e27eea5b818c459aa8f8d364d", 
         {
             "addrType": "pubkey", 
             "isPrivkey": false, 
@@ -441,8 +441,8 @@
         }
     ], 
     [
-        "3ALJH9Y951VCGcVZYAdpA3KchoP9McEj1G", 
-        "5ece0cadddc415b1980f001785947120acdb36fc", 
+        "AD21pKoCWcrqrUW4oRv5xUaGwCfXhiyx6y", 
+        "e1c443feb1eede60962dc808899086f8dc589336", 
         {
             "addrType": "script", 
             "isPrivkey": false, 


### PR DESCRIPTION
This replaces all Bitcoin keys used for base58 unit test with Dogecoin keys.

Keys generated with bitcoinjs (outside of this codebase, to be independent)
