### PR TITLE
transaction tests: fix dust test.

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -271,10 +271,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     string reason;
     BOOST_CHECK(IsStandardTx(t, reason));
 
-    t.vout[0].nValue = 501; // dust
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    // disabled, as there is no dust
+    // t.vout[0].nValue = 501; // dust
+    // BOOST_CHECK(!IsStandardTx(t, reason));
 
-    t.vout[0].nValue = 601; // not dust
+    // 1 should pass as not dust
+    t.vout[0].nValue = 1; // not dust
     BOOST_CHECK(IsStandardTx(t, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;


### PR DESCRIPTION
DOGE does not have a DUST limit, so the only valid test for us is that a value of 1 should not be marked as dust
