### PR TITLE
fix maturity depth in CMerkleTx::GetBlocksToMaturity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -941,11 +941,12 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!IsCoinBase())
         return 0;
-        
-    if(GetHeightInMainChain() >= COINBASE_MATURITY_SWITCH)
-        return max(0, (COINBASE_MATURITY_NEW+20) - GetDepthInMainChain());
-    else
-        return max(0, (COINBASE_MATURITY+20) - GetDepthInMainChain());
+
+    int nHeight = GetHeightInMainChain();
+    int nMaturity = GetRequiredMaturityDepth(nHeight);
+
+    return max(0, (nMaturity+20) - GetDepthInMainChain());
+
 }
 
 
@@ -1539,6 +1540,19 @@ bool VerifySignature(const CCoins& txFrom, const CTransaction& txTo, unsigned in
     return CScriptCheck(txFrom, txTo, nIn, flags, nHashType)();
 }
 
+int GetRequiredMaturityDepth(int nHeight)
+{
+
+    if (nHeight >= COINBASE_MATURITY_SWITCH)
+    {
+        return COINBASE_MATURITY_NEW;
+    }
+    else
+    {
+        return COINBASE_MATURITY;
+    }
+}
+
 bool CheckInputs(const CTransaction& tx, CValidationState &state, CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, std::vector<CScriptCheck> *pvChecks)
 {
     if (!tx.IsCoinBase())
@@ -1564,9 +1578,9 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, CCoinsViewCach
 
             // If prev is coinbase, check that it's matured
             if (coins.IsCoinBase()) {
-                int minDepth = COINBASE_MATURITY;
-                if(coins.nHeight >= COINBASE_MATURITY_SWITCH)
-                    minDepth = COINBASE_MATURITY_NEW;
+
+                int minDepth = GetRequiredMaturityDepth(coins.nHeight);
+
                 if (nSpendHeight - coins.nHeight < minDepth)
                     return state.Invalid(
                         error("CheckInputs() : tried to spend coinbase at depth %d", nSpendHeight - coins.nHeight),

--- a/src/main.h
+++ b/src/main.h
@@ -307,6 +307,13 @@ inline bool AllowFree(double dPriority)
         return dPriority > 100 * COIN * 1440 / 250; // Dogecoin: 1440 blocks found a day. Priority cutoff is 100 dogecoin day / 250 bytes.
     }
 
+/** Get the maturity depth for coinbase transactions at a given height.
+    @param[in] nHeight  The height at which to check maturity for
+    @return the depth at which the coinbase transaction matures
+ */
+// Dogecoin specific implementation, standardizes checks for the hard maturity change at block 145k
+int GetRequiredMaturityDepth(int nHeight);
+
 // Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
 // This does not modify the UTXO set. If pvChecks is not NULL, script checks are pushed onto it
 // instead of being performed inline.


### PR DESCRIPTION
#479 reported that mined funds could not be transferred, this is most likely being caused by `CMerkleTx::GetBlocksToMaturity` not being patched properly. This PR fixes that, and centralizes the calculation of which maturity requirement to use by implementing `GetRequiredMaturityDepth(int nHeight)`
