### PR TITLE
Disable payment protocol pending further assessment and potential rework

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -430,14 +430,14 @@ void BitcoinApplication::initializeResult(int retval)
         // Now that initialization/startup is done, process any command-line
         // dogecoin: URIs or payment requests:
         /*
-	connect(paymentServer, SIGNAL(receivedPaymentRequest(SendCoinsRecipient)),
+        connect(paymentServer, SIGNAL(receivedPaymentRequest(SendCoinsRecipient)),
                          window, SLOT(handlePaymentRequest(SendCoinsRecipient)));
         connect(window, SIGNAL(receivedURI(QString)),
                          paymentServer, SLOT(handleURIOrFile(QString)));
         connect(paymentServer, SIGNAL(message(QString,QString,unsigned int)),
                          window, SLOT(message(QString,QString,unsigned int)));
-	QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
-	*/
+        QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
+        */
 #endif
     } else {
         quit(); // Exit main loop


### PR DESCRIPTION
This is a very quick job to cut out the hooks to the payment server, so trying to load payment protocol requests will simply do nothing.

To come back to when we've had a better chance to evaluate and potentially rework the protocol.
