### PR TITLE
Add 100k-200k checkpoints

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -53,7 +53,7 @@ namespace Checkpoints
         ;
     static const CCheckpointData data = {
         &mapCheckpoints,
-        1398691148, // * UNIX timestamp of last checkpoint block
+        1398694748, // * UNIX timestamp of last checkpoint block
         9493347,    // * total number of transactions between genesis and last checkpoint
                     //   (the tx=... number in the SetBestChain debug.log lines)
         8000.0      // * estimated number of transactions per day after checkpoint


### PR DESCRIPTION
Inserted checkpoints through the 100k-200k block range, with emphasis on the 145k (hard fork) and 200k (second reward halving) blocks.
