### PR TITLE
Point to location of BDB 4.8 in /doc/build-unix.md

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -98,12 +98,12 @@ Berkeley DB
 -----------
 You need Berkeley DB 4.8.  If you have to build it yourself:
 	
-	wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
- 	echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256sum -c
- 	# -> db-4.8.30.NC.tar.gz: OK
- 	tar -xzvf db-4.8.30.NC.tar.gz
-	../dist/configure --enable-cxx
-	make
+    wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+    echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256sum -c
+    # -> db-4.8.30.NC.tar.gz: OK
+    tar -xzvf db-4.8.30.NC.tar.gz
+    ../dist/configure --enable-cxx
+    make
 
 
 Boost


### PR DESCRIPTION
This downloads the correct BDB library and checksums to ensure purity.

Identical to a committ to the bitcoin source tree a few weeks ago 

https://github.com/bitcoin/bitcoin/commit/61d388d98ddd6d3fd521b6afbbb06209a6a50598
