### PR TITLE
fee changes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -704,7 +704,7 @@ int64_t GetMinFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree, 
 
     int64_t nMinFee = (1 + (int64_t)nBytes / 1000) * nBaseFee;
 
-    if (fAllowFree)
+    if (fAllowFree && mode != GMF_SEND)
     {
             // Free transaction area
             if (nBytes < 26000)


### PR DESCRIPTION
The changed function GetMinFee is used both for choosing the fee when sending a transaction and for relaying/mining transactions.

The first commit refactors the function by removing all dead code and inlining the confusingly named nNewBlockSize. Careful review advised.

The second commit may be more controversial: with that commit, transactions sent by the client always include a fee, even if they contain enough priority inputs (high value, high coin-age) to be free. I think that rule for fee-less transactions is more confusing than useful, but I may be wrong and am willing to remove that commit after some discussion. The idea is to stop using the rule and then remove it in a future version when no/few clients use the old rule for sending transactions.
