### PR TITLE
move GetPoWHash to CBlockHeader class

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -383,6 +383,13 @@ public:
     }
 
     uint256 GetHash() const;
+    
+    uint256 GetPoWHash() const
+    {
+        uint256 thash;
+        scrypt_1024_1_1_256(BEGIN(nVersion), BEGIN(thash));
+        return thash;
+    }
 
     int64_t GetBlockTime() const
     {
@@ -422,13 +429,6 @@ public:
         CBlockHeader::SetNull();
         vtx.clear();
         vMerkleTree.clear();
-    }
-    
-    uint256 GetPoWHash() const
-    {
-        uint256 thash;
-        scrypt_1024_1_1_256(BEGIN(nVersion), BEGIN(thash));
-        return thash;
     }
 
     CBlockHeader GetBlockHeader() const


### PR DESCRIPTION
It is semantically similar to GetHash and operates on block headers, so it belongs here. This makes merging Bitcoin PRs easier and makes the code more sane.
