### PR TITLE
add unit tests for GetMinFee

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -231,28 +231,4 @@ BOOST_AUTO_TEST_CASE(GetMinFee_createFree_test)
     BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
 }
 
-BOOST_AUTO_TEST_CASE(GetMinFee_createNoFree_test)
-{
-    uint64_t value = 1000 * COIN;
-
-    CTransaction tx;
-    CTxOut txout1(value, (CScript)vector<unsigned char>(24, 0));
-    tx.vout.push_back(txout1);
-    
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
-    
-    BOOST_CHECK(GetMinFee(tx, 100, true, GMF_SEND) > 0);
-    BOOST_CHECK(GetMinFee(tx, 100, true, GMF_SEND) == GetMinFee(tx, 100, false, GMF_SEND));
-    BOOST_CHECK(GetMinFee(tx, 1000, true, GMF_SEND) > 0);
-    BOOST_CHECK(GetMinFee(tx, 1000, true, GMF_SEND) == GetMinFee(tx, 1000, false, GMF_SEND));
-    BOOST_CHECK(GetMinFee(tx, 25999, true, GMF_SEND) > 0);
-    BOOST_CHECK(GetMinFee(tx, 25999, true, GMF_SEND) == GetMinFee(tx, 25999, false, GMF_SEND));
-    
-    BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_SEND) > 0);
-    BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_SEND) == GetMinFee(tx, 26000, false, GMF_SEND));
-    
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
-}
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a bunch of unit tests for the fee calculation. For initial testing, I added a tests which fail with either the new or the old fee rules: GetMinFee_createFree_test passes only with the new rules while GetMinFee_createNoFree_test passes only with the old rules. Before merging, I'll remove on of these tests, but I though it's good to include both. All other tests pass with both the old rules and the new rules.
