### PR TITLE
change step value for amount input fields to 1 DOGE

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -59,7 +59,7 @@ BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     amount(0),
     currentUnit(-1)
 {
-    nSingleStep = 100000; // satoshis
+    nSingleStep = 100000000; // satoshis
 
     amount = new AmountSpinBox(this);
     amount->installEventFilter(this);


### PR DESCRIPTION
This influences the arrows of the amount spinboxes. Previously they changed the amount in steps of 0.001 DOGE.
