### PR TITLE
CoinControl red label at 5kb instead of 1kb

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -597,7 +597,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     l8->setStyleSheet((nChange > 0 && nChange < COIN) ? "color:red;" : "");             // Change < 0.01DOGE
 
     // tool tips
-    QString toolTip1 = tr("This label turns red, if the transaction size is greater than 1000 bytes.") + "<br /><br />";
+    QString toolTip1 = tr("This label turns red, if the transaction size is greater than 5000 bytes.") + "<br /><br />";
     toolTip1 += tr("This means a fee of at least %1 per kB is required.").arg(BitcoinUnits::formatWithUnit(nDisplayUnit, CTransaction::nMinTxFee)) + "<br /><br />";
     toolTip1 += tr("Can vary +/- 1 byte per input.");
 

--- a/src/qt/locale/bitcoin_ach.ts
+++ b/src/qt/locale/bitcoin_ach.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_af_ZA.ts
+++ b/src/qt/locale/bitcoin_af_ZA.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -932,7 +932,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -928,7 +928,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -929,7 +929,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_bs.ts
+++ b/src/qt/locale/bitcoin_bs.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ca@valencia.ts
+++ b/src/qt/locale/bitcoin_ca@valencia.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -924,8 +924,8 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Aquesta etiqueta es posa de color vermell si la mida de la transacció és més gran de 1000 bytes.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Aquesta etiqueta es posa de color vermell si la mida de la transacció és més gran de 5000 bytes.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_cmn.ts
+++ b/src/qt/locale/bitcoin_cmn.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -933,7 +933,7 @@ Adresa: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -933,7 +933,7 @@ Adresse: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -932,8 +932,8 @@ Adresse: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Diese Bezeichnung wird rot, wenn die Transaktion größer als 1000 Byte ist.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Diese Bezeichnung wird rot, wenn die Transaktion größer als 5000 Byte ist.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_de_AT.ts
+++ b/src/qt/locale/bitcoin_de_AT.ts
@@ -928,7 +928,7 @@ Wohin: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -934,7 +934,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -953,7 +953,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -933,8 +933,8 @@ Adreso: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Tiu ĉi etikedo ruĝiĝas se la grando de la transakcio estas pli ol 1000 bajtoj.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Tiu ĉi etikedo ruĝiĝas se la grando de la transakcio estas pli ol 5000 bajtoj.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -942,8 +942,8 @@ Dirección: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 1000 bytes.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 5000 bytes.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -935,7 +935,7 @@ Dirección: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -936,8 +936,8 @@ Dirección: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 1000 bytes.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 5000 bytes.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_UY.ts
+++ b/src/qt/locale/bitcoin_es_UY.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -932,7 +932,7 @@ Aadress: %4⏎</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_eu_ES.ts
+++ b/src/qt/locale/bitcoin_eu_ES.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -928,7 +928,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fa_IR.ts
+++ b/src/qt/locale/bitcoin_fa_IR.ts
@@ -926,7 +926,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -933,7 +933,7 @@ Osoite: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -933,8 +933,8 @@ Adresse : %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Cette étiquette devient rouge si la taille de la transaction est plus grande que 1 000 octets.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Cette étiquette devient rouge si la taille de la transaction est plus grande que 5000 octets.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -929,7 +929,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -933,7 +933,7 @@ Dirección: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_gu_IN.ts
+++ b/src/qt/locale/bitcoin_gu_IN.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -932,8 +932,8 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>תווית זו מאדימה במידה וגודל הפעולה עולה על 1000 בייט</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>תווית זו מאדימה במידה וגודל הפעולה עולה על 5000 בייט</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_hi_IN.ts
+++ b/src/qt/locale/bitcoin_hi_IN.ts
@@ -928,7 +928,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -928,7 +928,7 @@ Adresa:%4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -932,7 +932,7 @@ Cím: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -928,7 +928,7 @@ Alamat: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -934,8 +934,8 @@ Indirizzo: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Questa etichetta diventa rossa, se la dimensione della transazione supera i 1000 bytes</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Questa etichetta diventa rossa, se la dimensione della transazione supera i 5000 bytes</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -933,7 +933,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -933,8 +933,8 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>ნიშნული წითლდება, როცა ტრანსაქციის ზომა 1000 ბაიტზე მეტია.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>ნიშნული წითლდება, როცა ტრანსაქციის ზომა 5000 ბაიტზე მეტია.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_kk_KZ.ts
+++ b/src/qt/locale/bitcoin_kk_KZ.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -939,7 +939,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -932,7 +932,7 @@ Inscriptio: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -931,7 +931,7 @@ Adresas: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -928,7 +928,7 @@ Adrese: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ms_MY.ts
+++ b/src/qt/locale/bitcoin_ms_MY.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -933,8 +933,8 @@ Adresse: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Denne merkelappen blir rød, hvis transaksjonsstørrelsen er større enn 1000 bytes.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Denne merkelappen blir rød, hvis transaksjonsstørrelsen er større enn 5000 bytes.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -933,8 +933,8 @@ Adres: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Dit label wordt rood als de transactie grootte meer dan 1000 bytes is.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Dit label wordt rood als de transactie grootte meer dan 5000 bytes is.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -931,7 +931,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -939,7 +939,7 @@ Adres: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -932,7 +932,7 @@ Endereço: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -933,8 +933,8 @@ Endereço: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Esta legenda fica vermelha se o tamanho de transacção exceder os 1000 bytes.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Esta legenda fica vermelha se o tamanho de transacção exceder os 5000 bytes.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -939,8 +939,8 @@ Adresa: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Această etichetă devine roşie, în cazul în care dimensiunea tranzacţiei este mai mare de 1000 de octeţi. </translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Această etichetă devine roşie, în cazul în care dimensiunea tranzacţiei este mai mare de 5000 de octeţi. </translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -933,8 +933,8 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Эта пометка становится красной, если размер транзакции больше 1000 байт.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Эта пометка становится красной, если размер транзакции больше 5000 байт.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_sah.ts
+++ b/src/qt/locale/bitcoin_sah.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -927,7 +927,7 @@ Adresa: %4</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -928,7 +928,7 @@ Naslov: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sq.ts
+++ b/src/qt/locale/bitcoin_sq.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -934,7 +934,7 @@ Adress: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_th_TH.ts
+++ b/src/qt/locale/bitcoin_th_TH.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -933,8 +933,8 @@ Adres: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Eğer muamele boyutu 1000 bayttan büyükse bu etkiket kırmızı olur.</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>Eğer muamele boyutu 5000 bayttan büyükse bu etkiket kırmızı olur.</translation>
     </message>
     <message>
         <location line="+1"/>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -933,7 +933,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ur_PK.ts
+++ b/src/qt/locale/bitcoin_ur_PK.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -933,7 +933,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -924,7 +924,7 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -933,8 +933,8 @@ Address: %4
     </message>
     <message>
         <location line="+10"/>
-        <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>當交易大小大於 1000 位元組時，文字會變紅色。</translation>
+        <source>This label turns red, if the transaction size is greater than 5000 bytes.</source>
+        <translation>當交易大小大於 5000 位元組時，文字會變紅色。</translation>
     </message>
     <message>
         <location line="+1"/>


### PR DESCRIPTION
As it was before in 1.6
