### PR TITLE
Fixing typos in Unix build notes

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -156,7 +156,7 @@ Optional:
 
 Security
 --------
-To help make your bitcoin installation more secure by making certain attacks impossible to
+To help make your Dogecoin installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, binaries are hardened by default.
 This can be disabled with:
 
@@ -188,7 +188,7 @@ Hardening enables the following features:
 
 * Non-executable Stack
     If the stack is executable then trivial stack based buffer overflow exploits are possible if
-    vulnerable buffers are found. By default, bitcoin should be built with a non-executable stack
+    vulnerable buffers are found. By default, Dogecoin should be built with a non-executable stack
     but if one of the libraries it uses asks for an executable stack or someone makes a mistake
     and uses a compiler extension which requires an executable stack, it will silently build an
     executable without the non-executable stack protection.
@@ -204,7 +204,7 @@ Hardening enables the following features:
 
 Disable-wallet mode
 --------------------
-When the intention is to run only a P2P node without a wallet, bitcoin may be compiled in
+When the intention is to run only a P2P node without a wallet, Dogecoin may be compiled in
 disable-wallet mode with:
 
     ./configure --disable-wallet


### PR DESCRIPTION
It appears you guys skimmed the build notes and missed a couple of Bitcoins. I fixed it for you.
