### PR TITLE
berkeley-db5 -> berkeley-db

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -74,7 +74,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db5 boost miniupnpc openssl pkg-config protobuf qt
+        brew install autoconf automake berkeley-db boost miniupnpc openssl pkg-config protobuf qt
 
 Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
 


### PR DESCRIPTION
Currently berkeley-db on homebrew is at version 5. brew install berkeley-db5 will result in "Error: No available formula for berkeley-db5"
