### PR TITLE
[minor] fix syntax in gitian-downloader yml files

### DIFF
--- a/contrib/gitian-downloader/linux-download-config
+++ b/contrib/gitian-downloader/linux-download-config
@@ -15,7 +15,7 @@ signers:
     weight: 40
     name: langerhans
     key: langerhans
-  86601A39AEE177B1D1F0F7971AEF9F73ECA11726
+  86601A39AEE177B1D1F0F7971AEF9F73ECA11726:
     weight: 40
     name: leofidus-ger
     key: leofidus-key

--- a/contrib/gitian-downloader/win32-download-config
+++ b/contrib/gitian-downloader/win32-download-config
@@ -15,7 +15,7 @@ signers:
     weight: 40
     name: langerhans
     key: langerhans
-  86601A39AEE177B1D1F0F7971AEF9F73ECA11726
+  86601A39AEE177B1D1F0F7971AEF9F73ECA11726:
     weight: 40
     name: leofidus-ger
     key: leofidus-key


### PR DESCRIPTION
while i was editing the gitian-downloader yml files, I found missing colons. added them.
