### PR TITLE
[minor] Fix expected SHA256 hashes for dogecoin-deps-*

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -67,16 +67,16 @@ Release Process
 
  The expected SHA256 hashes of the intermediate inputs are:
 
-    46710f673467e367738d8806e45b4cb5931aaeea61f4b6b55a68eea56d5006c5  dogecoin-deps-linux32-gitian-r6.zip
-    f03be39fb26670243d3a659e64d18e19d03dec5c11e9912011107768390b5268  dogecoin-deps-linux64-gitian-r6.zip
+    d517e84a79fdcdebfdb3405aa91fb2e53bce9fb760d34b9dda611db8813ae7a3  dogecoin-deps-linux32-gitian-r6.zip
+    2c275eecbe11b4b29620fac523ccc30c35c45dbac096ed7d0a117467c95b1b13  dogecoin-deps-linux64-gitian-r6.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
     57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
-    70de248cd0dd7e7476194129e818402e974ca9c5751cbf591644dc9f332d3b59  dogecoin-deps-win32-gitian-r13.zip
-    9eace4c76f639f4f3580a478eee4f50246e1bbb5ccdcf37a158261a5a3fa3e65  dogecoin-deps-win64-gitian-r13.zip
+    2d9d16006c61a23ecb82e3d440599aa324d2b48ada58a2c017b5ca0d74a1bab3  dogecoin-deps-win32-gitian-r13.zip
+    0fea0b372c2586713d3c277e4a36d1ca518591f59097a1f23ed095124505b71b  dogecoin-deps-win64-gitian-r13.zip
     963e3e5e85879010a91143c90a711a5d1d5aba992e38672cdf7b54e42c56b2f1  qt-win32-5.2.0-gitian-r3.zip
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip


### PR DESCRIPTION
Because we use a different bdb version than Bitcoin, SHA256 of dogecoin-deps-\* gitian built files are different from the bitcoin equivalents. New hashes match both langerhans' 1.7.2-Beta-1 committed sigs at https://github.com/dogecoin/gitian.sigs and my own.
