### PR TITLE
Remove any / from the end of a URI

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -108,7 +108,10 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
         return false;
 
     SendCoinsRecipient rv;
-    rv.address = uri.path();
+    QStringList addressParts = uri.path().split("/", QString::SkipEmptyParts, Qt::CaseSensitive);
+    rv.address = addressParts.isEmpty()
+      ? ""
+      : addressParts.first();
     rv.amount = 0;
 
 #if QT_VERSION < 0x050000
@@ -171,6 +174,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     {
         uri.replace(0, 11, "dogecoin:");
     }
+    
     QUrl uriInstance(uri);
     return parseBitcoinURI(uriInstance, out);
 }


### PR DESCRIPTION
This resolves the issue under Windows of addresses in dogecoin: URIs being mangled.
