### PR TITLE
Revert unneeded changes introduced as a side-effect AuxPoW.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -953,7 +953,7 @@ public:
         ReadWriteAuxPow(s, auxpow, nType, this->nVersion, ser_action);
     )
 
-    uint256 CalcBlockHash() const
+    uint256 GetBlockHash() const
     {
         CBlockHeader block;
         block.nVersion        = nVersion;


### PR DESCRIPTION
Revert unneeded changes introduced as a side-effect AuxPoW; most of these simply re-order code or change variable names, although a number of data items were not being loaded from disk post-change as well.
