### PR TITLE
Break testnet difficulty reset out of never matching condition.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1300,24 +1300,24 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
+    if (TestNet() && pblock->nTime > pindexLast->nTime + nTargetSpacing*2)
+    {
+        // Special difficulty rule for testnet:
+        // If the new block's timestamp is more than 2* nTargetSpacing minutes
+        // then allow mining of a min-difficulty block.
+        return nProofOfWorkLimit;
+    }
+
     // Only change once per interval
     if ((pindexLast->nHeight+1) % retargetInterval != 0)
     {
         if (TestNet())
         {
-            // Special difficulty rule for testnet:
-            // If the new block's timestamp is more than 2* nTargetSpacing minutes
-            // then allow mining of a min-difficulty block.
-            if (pblock->nTime > pindexLast->nTime + nTargetSpacing*2)
-                return nProofOfWorkLimit;
-            else
-            {
-                // Return the last non-special-min-difficulty-rules-block
-                const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % retargetInterval != 0 && pindex->nBits == nProofOfWorkLimit)
-                    pindex = pindex->pprev;
-                return pindex->nBits;
-            }
+            // Return the last non-special-min-difficulty-rules-block
+            const CBlockIndex* pindex = pindexLast;
+            while (pindex->pprev && pindex->nHeight % retargetInterval != 0 && pindex->nBits == nProofOfWorkLimit)
+                pindex = pindex->pprev;
+            return pindex->nBits;
         }
         return pindexLast->nBits;
     }


### PR DESCRIPTION
Testnet resets difficulty if after 2 minutes no block has been found. However, this feature was implemented with the condition to only trigger on blocks where no retargeting is done. Since the introduction of DigiShield, we retarget at every block, making this condition never to be matched. This commit removes that condition.

**_WARNING: THIS COMMIT HARDFORKS THE DOGECOIN TESTNET!**_

The main network is not affected by this change.
