### PR TITLE
Fix assertion crash when using SPV clients

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -473,6 +473,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.auxpow         = auxpow;
         return block;
     }
 

--- a/src/main.h
+++ b/src/main.h
@@ -962,6 +962,7 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.nNonce          = nNonce;
+        // AuxPoW is not part of the hash
         return block.GetHash();
     }
 


### PR DESCRIPTION
Patched copying of block headers so that auxpow is also copied. Resolves #595
