### PR TITLE
Close cursor in case of error reading blocks

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -119,7 +119,7 @@ bool CBlockTreeDB::ReadLastBlockFile(int &nFile) {
 }
 
 bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
-    leveldb::Iterator *pcursor = db.NewIterator();
+    boost::scoped_ptr<leveldb::Iterator> pcursor(db.NewIterator());
     pcursor->SeekToFirst();
 
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
@@ -162,7 +162,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
             return error("%s : Deserialize or I/O error - %s", __func__, e.what());
         }
     }
-    delete pcursor;
+    
     stats.nHeight = mapBlockIndex.find(GetBestBlock())->second->nHeight;
     stats.hashSerialized = ss.GetHash();
     stats.nTotalAmount = nTotalAmount;


### PR DESCRIPTION
Added missing step of deleting cursor in case of an error reading blocks from disk. This fixes the assertion crash when loading a 1.7 block index in 1.8, and ensures the re-index can happen instead.
