### PR TITLE
Fix assertion error loading 1.7 blocks in 1.8 client

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -198,7 +198,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 
     CDataStream ssKeySet(SER_DISK, CLIENT_VERSION);
     uint256 hash;
-    ssKeySet << boost::tuples::make_tuple('b', uint256(0), 'a'); // 'b' is the prefix for BlockIndex, 'a' sigifies the first part
+    ssKeySet << boost::tuples::make_tuple('b', uint256(0), 'a'); // 'b' is the prefix for BlockIndex, 'a' signifies the first part
     pcursor->Seek(ssKeySet.str());
 
     // Load mapBlockIndex
@@ -210,6 +210,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
             char chType;
             ssKey >> chType;
             if (chType == 'b') {
+                // Detect pre-1.8 keys in the database and abort if found
+                if (slKey.size() < ssKeySet.size()) {
+                    return error("Database key size is %d expected %d, require reindex to upgrade.", slKey.size(), ssKeySet.size());
+                }
+
                 ssKey >> hash;
                 
                 leveldb::Slice slValue = pcursor->value();


### PR DESCRIPTION
Added explicit check for key length when loading blocks from disk, to catch 1.7/1.8 change. This avoids the problem where mis-loaded blocks later cause an assertion error.

Also fixes typo in comment on line 201.
