### PR TITLE
Make configure work on 32-bit i?86

### DIFF
--- a/src/m4/ax_boost_base.m4
+++ b/src/m4/ax_boost_base.m4
@@ -103,6 +103,12 @@ if test "x$want_boost" = "xyes"; then
     AC_REQUIRE([AC_CANONICAL_HOST])
     libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
 
+    case ${host_cpu} in
+      i?86)
+        libsubdirs="lib/i386-${host_os} $libsubdirs"
+        ;;
+    esac
+
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM


### PR DESCRIPTION
These lines were removed relative to bitcoin core, but without them, configure bombs while checking the boost libraries.  So I'm re-adding them.  I've compiled and tested dogecoind and it works fine on 32-bit i686.

My system is Ubuntu 14.04.1 with boost 1.55.
