### PR TITLE
Adjust trigger conditions for safe mode to suit Dogecoin block time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1436,12 +1436,12 @@ void CheckForkWarningConditions()
     if (IsInitialBlockDownload())
         return;
 
-    // If our best fork is no longer within 72 blocks (+/- 12 hours if no one mines it)
+    // If our best fork is no longer within 360 blocks (+/- 6 hours if no one mines it)
     // of our head, drop it
-    if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
+    if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 360)
         pindexBestForkTip = NULL;
 
-    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (chainActive.Tip()->GetBlockWork() * 6).getuint256()))
+    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (chainActive.Tip()->GetBlockWork() * 30).getuint256()))
     {
         if (!fLargeWorkForkFound)
         {


### PR DESCRIPTION
Values for triggering safe mode are time sensitive, and have not been
modified to take into account the differing block times between Bitcoin and
Dogecoin. This patch changes the interval across which a fork must exist to
override any other fork to 6 hours, and increases the number of blocks an
invalid fork must have before it trips safe mode.

This should help mitigate disruption in the 1.7/1.8 hard fork, but miners will
still need to run with -disablesafemode for the preceeding and following 2-3
days to be sure.
