### PR TITLE
Update protocol version

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -27,7 +27,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70002;
+static const int PROTOCOL_VERSION = 80000;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Change protocol version so post-AuxPoW clients can refuse to deal with pre-AuxPoW clients.
This mitigates excessive bandwidth usage by pre-AuxPoW clients repeatedly requesting blocks
they don't know how to use.
