### PR TITLE
Tweak protocol version and minimum protocol

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -27,13 +27,13 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 80000;
+static const int PROTOCOL_VERSION = 70003;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70001;
+static const int MIN_PEER_PROTO_VERSION = 70002;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Changed protocol version number to the less extreme 70003 (from 80000).
Changed minimum protocol version to 70002 to block out pre-1.6 nodes.
