### PR TITLE
[minor] Condense retarget debug output even more.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1389,12 +1389,13 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (bnNew > Params().ProofOfWorkLimit())
         bnNew = Params().ProofOfWorkLimit();
 
-    /// debug print
-    LogPrintf("RETARGET: target: %d, actual: %d, modulated: %d\n", retargetTimespan, nActualTimespan, nModulatedTimespan);
-    LogPrintf("Before: %08x  %s\n", pindexLast->nBits, CBigNum().SetCompact(pindexLast->nBits).getuint256().ToString());
-    LogPrintf("After:  %08x  %s\n", bnNew.GetCompact(), bnNew.getuint256().ToString());
+    unsigned int nNewBits = bnNew.GetCompact();
 
-    return bnNew.GetCompact();
+    /// debug print
+    LogPrintf("GetNextWorkRequired() : RETARGET; target: %d, actual: %d, modulated: %d, before: %08x, after: %08x\n",
+        retargetTimespan, nActualTimespan, nModulatedTimespan, pindexLast->nBits, nNewBits);
+
+    return nNewBits;
 }
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits)


### PR DESCRIPTION
This takes 147 chars out of debug.log for every block, plus every time a new block is generated for aux purposes, by removing the hash target full uint256 hex notation and just using the CBigNum compact hex notation. Condensed everything to one line, as that saves date/time chars, and has the additional benefit that all information is available from a single `grep RETARGET debug.log`

results:
- all nodes: ~26% reduction in debug output per block
- mining/pool nodes: additional ~35% reduction in debug output for every getauxblock/work cache refresh (refresh currently happens at a new block or every 60 seconds if new transactions exist, whichever comes first)
