### PR TITLE
Update gitian descriptors and docs for openssl 1.0.1i

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1h.tar.gz"
+- "openssl-1.0.1i.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "protobuf-2.5.0.tar.bz2"
@@ -30,15 +30,15 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
+  echo "3c179f46ca77069a6a0bac70212a9b3b838b2f66129cb52d568837fc79d8fcc7  openssl-1.0.1i.tar.gz"  | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1h.tar.gz
-  cd openssl-1.0.1h
+  tar xzf openssl-1.0.1i.tar.gz
+  cd openssl-1.0.1i
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
@@ -95,4 +95,4 @@ script: |
   done
   #
   cd $STAGING
-  find include lib bin host | sort | zip -X@ $OUTDIR/dogecoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/dogecoin-deps-linux${GBUILD_BITS}-gitian-r7.zip

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1h.tar.gz"
+- "openssl-1.0.1i.tar.gz"
 - "db-5.1.29.NC.tar.gz"
 - "miniupnpc-1.9.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093  openssl-1.0.1h.tar.gz"  | sha256sum -c
+  echo "3c179f46ca77069a6a0bac70212a9b3b838b2f66129cb52d568837fc79d8fcc7  openssl-1.0.1i.tar.gz"  | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
   echo "2923e453e880bb949e3d4da9f83dd3cb6f08946d35de0b864d0339cf70934464  miniupnpc-1.9.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1h.tar.gz
-    cd openssl-1.0.1h
+    tar xzf $INDIR/openssl-1.0.1i.tar.gz
+    cd openssl-1.0.1i
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else
@@ -126,5 +126,5 @@ script: |
     done
     #
     cd $INSTALLPREFIX
-    find include lib | sort | zip -X@ $OUTDIR/dogecoin-deps-win$BITS-gitian-r13.zip
+    find include lib | sort | zip -X@ $OUTDIR/dogecoin-deps-win$BITS-gitian-r14.zip
   done # for BITS in

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -25,8 +25,8 @@ remotes:
 - "url": "https://github.com/dogecoin/dogecoin.git"
   "dir": "dogecoin"
 files:
-- "dogecoin-deps-linux32-gitian-r6.zip"
-- "dogecoin-deps-linux64-gitian-r6.zip"
+- "dogecoin-deps-linux32-gitian-r7.zip"
+- "dogecoin-deps-linux64-gitian-r7.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 - "qt-linux32-4.6.4-gitian-r1.tar.gz"
@@ -43,7 +43,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/dogecoin-deps-linux${GBUILD_BITS}-gitian-r6.zip
+  unzip ../build/dogecoin-deps-linux${GBUILD_BITS}-gitian-r7.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
   cd ../build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -26,8 +26,8 @@ files:
 - "qt-win64-5.2.0-gitian-r3.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
-- "dogecoin-deps-win32-gitian-r13.zip"
-- "dogecoin-deps-win64-gitian-r13.zip"
+- "dogecoin-deps-win32-gitian-r14.zip"
+- "dogecoin-deps-win64-gitian-r14.zip"
 - "protobuf-win32-2.5.0-gitian-r4.zip"
 - "protobuf-win64-2.5.0-gitian-r4.zip"
 script: |
@@ -61,7 +61,7 @@ script: |
     cd $STAGING
     unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r3.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
-    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r13.zip
+    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r14.zip
     unzip $INDIR/protobuf-win${BITS}-2.5.0-gitian-r4.zip
     if [ "$NEEDDIST" == "1" ]; then
       # Make source code archive which is architecture independent so it only needs to be done once

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -15,8 +15,8 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.0.tar.gz"
-- "dogecoin-deps-win32-gitian-r13.zip"
-- "dogecoin-deps-win64-gitian-r13.zip"
+- "dogecoin-deps-win32-gitian-r14.zip"
+- "dogecoin-deps-win64-gitian-r14.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -48,7 +48,7 @@ script: |
     #
     # Need mingw-compiled openssl from dogecoin-deps:
     cd $DEPSDIR
-    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r13.zip
+    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r14.zip
     #
     cd $BUILDDIR
     #

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -22,7 +22,7 @@ for the build process to succeed.
 
 	name            default path               download
 	--------------------------------------------------------------------------------------------------------------------
-	OpenSSL         \openssl-1.0.1c-mgw        http://www.openssl.org/source/
+	OpenSSL         \openssl-1.0.1i-mgw        http://www.openssl.org/source/
 	Berkeley DB     \db-5.1.29.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 	Boost           \boost-1.55.0-mgw          http://www.boost.org/users/download/
 	miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -44,7 +44,7 @@ Their licenses:
 
 Versions used in this release:
 
-	OpenSSL      1.0.1c
+	OpenSSL      1.0.1i
 	Berkeley DB  5.1.29.NC
 	Boost        1.55.0
 	miniupnpc    1.6
@@ -61,7 +61,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-	cd /c/openssl-1.0.1c-mgw
+	cd /c/openssl-1.0.1i-mgw
 	./config
 	make
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -38,7 +38,7 @@ Release Process
 
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.tar.gz' -O miniupnpc-1.9.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1h.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1i.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.8/libpng-1.6.8.tar.gz'


### PR DESCRIPTION
Use OpenSSL 1.0.1i for gitian builds (and build docs) Solves openssl part of issue #655, boost PR coming soon.
