### PR TITLE
Build-osx: Force Fix.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -74,21 +74,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db5 boost miniupnpc openssl pkg-config protobuf qt
-
-Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
-
-        openssl version
-
-into Terminal. You should see OpenSSL 1.0.1f 6 Jan 2014.
-
-If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
-
-        brew link openssl --force
-
-Rerunning "openssl version" should now return the correct version. If it
-doesn't, make sure `/usr/local/bin` comes before `/usr/bin` in your
-PATH. 
+        brew install autoconf automake berkeley-db boost miniupnpc openssl pkg-config protobuf qt
 
 ### Building `dogecoind`
 


### PR DESCRIPTION
The dependencies were out of date. Homebrew doesn't have a formula called berkeley-db5, berkeley-db _is_ version 5.3.28.

I've also stripped out the language about forcing OpenSSL to link, because with the build process it shouldn't even be necessary, and it's an incredibly incredibly bad idea to force OpenSSL into `/usr/local`. Even if we did need it in the path, which we shouldn't because pkg-config should find the Homebrew OpenSSL build path automatically, we could temporarily add the Homebrew OpenSSL to the $PATH with an export command rather than forcing a permanent link.

This change was adopted by Bitcoin a few days back.
