### PR TITLE
Increment minimum protocol version

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -33,7 +33,7 @@ static const int PROTOCOL_VERSION = 70003;
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70002;
+static const int MIN_PEER_PROTO_VERSION = 70003;
 
 // nTime field added to CAddress, starting with this version;
 // if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Set minimum protocol version to 70003 so connections to pre-1.8 clients are rejected.
