### PR TITLE
AvailableCoins() now acquires cs_main lock

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1124,7 +1124,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
     vCoins.clear();
 
     {
-        LOCK(cs_wallet);
+        LOCK2(cs_main, cs_wallet);
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const uint256& wtxid = it->first;


### PR DESCRIPTION
It's required when called from listunspent() which doesn't acquire locks (unlike via SelectCoins() which does).

Rebased-From: ea3acaf
