### PR TITLE
Fail with a friendlier message on missing OpenSSL EC support

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -392,6 +392,23 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     }
 }
 
+/** Sanity checks
+ *  Ensure that Dogecoin is running in a usable environment with all
+ *  necessary library support.
+ */
+bool InitSanityCheck(void)
+{
+    if(!ECC_InitSanityCheck()) {
+        InitError("OpenSSL appears to lack support for elliptic curve cryptography. For more "
+                  "information, visit https://en.bitcoin.it/wiki/OpenSSL_and_EC_Libraries");
+        return false;
+    }
+
+    // TODO: remaining sanity checks, see BitCoin issue #4081
+
+    return true;
+}
+
 /** Initialize dogecoin.
  *  @pre Parameters should be parsed and config file should be read.
  */
@@ -612,6 +629,9 @@ bool AppInit2(boost::thread_group& threadGroup)
     strWalletFile = GetArg("-wallet", "wallet.dat");
 #endif
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
+    // Sanity check
+    if (!InitSanityCheck())
+        return InitError(_("Initialization sanity check failed. Dogecoin Core is shutting down."));
 
     std::string strDataDir = GetDataDir().string();
 #ifdef ENABLE_WALLET

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -656,3 +656,15 @@ bool CExtPubKey::Derive(CExtPubKey &out, unsigned int nChild) const {
     out.nChild = nChild;
     return pubkey.Derive(out.pubkey, out.vchChainCode, nChild, vchChainCode);
 }
+
+bool ECC_InitSanityCheck() {
+    EC_KEY *pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
+    if(pkey == NULL)
+        return false;
+    EC_KEY_free(pkey);
+
+    // TODO Is there more EC functionality that could be missing?
+    return true;
+}
+
+

--- a/src/key.h
+++ b/src/key.h
@@ -313,4 +313,7 @@ struct CExtKey {
     void SetMaster(const unsigned char *seed, unsigned int nSeedLen);
 };
 
+/** Check that required EC support is available at runtime */
+bool ECC_InitSanityCheck(void);
+
 #endif


### PR DESCRIPTION
Previously if bitcoind is linked with an OpenSSL which is compiled
without EC support, this is seen as an assertion failure "pKey !=
NULL" at key.cpp:134, which occurs after several seconds. It is an
esoteric piece of knowledge to interpret this as "oops, I linked
with the wrong OpenSSL", and because of the delay it may not even
be noticed.

The new output is

: OpenSSL appears to lack support for elliptic curve cryptography. For
more information, visit
https://en.bitcoin.it/wiki/OpenSSL_and_EC_Libraries
: Initialization sanity check failed. Bitcoin Core is shutting down.

which occurs immediately after attempted startup.

This also blocks in an InitSanityCheck() function which currently only
checks for EC support but should eventually do more. See #4081.

Rebased-From: 4a09e1d

Conflicts:
    src/init.cpp
