### PR TITLE
Remove useless MilliSleep() from network code

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1037,8 +1037,6 @@ void ThreadSocketHandler()
             BOOST_FOREACH(CNode* pnode, vNodesCopy)
                 pnode->Release();
         }
-
-        MilliSleep(10);
     }
 }
 


### PR DESCRIPTION
While normally I'd be nervous of changing timings, this appears to stem from the original Satoshi code according to discussions at https://github.com/bitcoin/bitcoin/pull/4833 , and has no obvious rationale for existing.
