### PR TITLE
Update build-osx.md

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -76,20 +76,6 @@ Instructions: Homebrew
 
         brew install autoconf automake berkeley-db5 boost miniupnpc openssl pkg-config protobuf qt
 
-Note: After you have installed the dependencies, you should check that the Homebrew installed version of OpenSSL is the one available for compilation. You can check this by typing
-
-        openssl version
-
-into Terminal. You should see OpenSSL 1.0.1f 6 Jan 2014.
-
-If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
-
-        brew link openssl --force
-
-Rerunning "openssl version" should now return the correct version. If it
-doesn't, make sure `/usr/local/bin` comes before `/usr/bin` in your
-PATH. 
-
 ### Building `dogecoind`
 
 1. Clone the github tree to get the source code and go into the directory.


### PR DESCRIPTION
Don't recommend people force OpenSSL into their Homebrew prefix. It creates _so so_ many build problems for other software, and can cause serious issues for OS X as a whole. This change was accepted by Bitcoin [here](https://github.com/bitcoin/bitcoin/pull/4753). Dogecoin's configure process should already make this line about forcing OpenSSL redundant as well, and does seem to.
