### PR TITLE
Remove fixed change address option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -591,19 +591,6 @@ bool AppInit2(boost::thread_group& threadGroup)
             InitWarning(_("Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction."));
     }
     
-    if (mapArgs.count("-change"))
-    {
-        BOOST_FOREACH(std::string strChange, mapMultiArgs["-change"]) {
-            CBitcoinAddress address(strChange);
-            CKeyID keyID;
-            
-            if (!address.GetKeyID(keyID)) {
-                return InitError(strprintf(_("Bad -change address: '%s'"), strChange));
-            }
-            AddFixedChangeAddress(keyID);
-        }
-    }
-    
     bSpendZeroConfChange = GetArg("-spendzeroconfchange", true);
 
     strWalletFile = GetArg("-wallet", "wallet.dat");

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -19,7 +19,6 @@ using namespace std;
 // Settings
 int64_t nTransactionFee = DEFAULT_TRANSACTION_FEE;
 bool bSpendZeroConfChange = true;
-static std::vector<CKeyID> vChangeAddresses;
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -1411,13 +1410,6 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                     // coin control: send change to custom address
                     if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
                         scriptChange.SetDestination(coinControl->destChange);
-                        
-                    // send change to one of the specified change addresses, if specified at init
-                    else if (vChangeAddresses.size())
-                    {
-                        CKeyID keyID = vChangeAddresses[GetRandInt(vChangeAddresses.size())];
-                        scriptChange.SetDestination(keyID);
-                    }
 
                     // send change to newly generated address
                     else
@@ -2205,12 +2197,4 @@ bool CWallet::GetDestData(const CTxDestination &dest, const std::string &key, st
         }
     }
     return false;
-}
-
-// Add an address to the list of fixed change addresses to use. Fixed
-// addresses can be used to reduce the pace at which wallets expand
-// due to number of change addresses
-void AddFixedChangeAddress(const CKeyID &changeAddress)
-{
-    vChangeAddresses.push_back(changeAddress);
 }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -59,9 +59,6 @@ static void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
     mapValue["n"] = i64tostr(nOrderPos);
 }
 
-// Add an address to the list of fixed change addresses to use.
-void AddFixedChangeAddress(const CKeyID &changeAddress);
-
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {


### PR DESCRIPTION
Removed old fixed change address option as it compromises the anonymisation process, and exists purely for legacy reasons.
