### PR TITLE
Make max_outbound_connections configurable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -230,6 +230,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -externalip=<ip>       " + _("Specify your own public address") + "\n";
     strUsage += "  -listen                " + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n";
     strUsage += "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n";
+    strUsage += "  -maxoutconnections=<n> " + _("Maintain at most <n> outbound connections to peers (default: 8)") + "\n";
     strUsage += "  -maxreceivebuffer=<n>  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 5000)") + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
     strUsage += "  -onion=<ip:port>       " + _("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)") + "\n";
@@ -535,6 +536,8 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
 
+    nMaxOutboundConnections = GetArg("-maxoutconnections", 8);
+    nMaxOutboundConnections = std::min(std::max(nMaxOutboundConnections, 2), nMaxConnections);
     // ********************************************************* Step 3: parameter-to-internal-flags
 
     fDebug = !mapMultiArgs["-debug"].empty();

--- a/src/net.h
+++ b/src/net.h
@@ -104,6 +104,7 @@ extern uint64_t nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 extern int nMaxConnections;
+extern int nMaxOutboundConnections;
 
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;


### PR DESCRIPTION
Using at least 2 connections, and not more than -maxconnections=<n> connections (which defaults to 128). Default is kept at the current 8, so no changes for the normal user.
