### PR TITLE
Make -proxy set all network types, avoiding a connect leak.

### DIFF
--- a/contrib/debian/examples/bitcoin.conf
+++ b/contrib/debian/examples/bitcoin.conf
@@ -6,7 +6,7 @@
 # Run on the test network instead of the real dogecoin network.
 #testnet=1
 
-# Connect via a socks4 proxy
+# Connect via a SOCKS5 proxy
 #proxy=127.0.0.1:9050
 
 # Use as many addnode= settings as you like to connect to specific peers

--- a/contrib/debian/manpages/bitcoin-qt.1
+++ b/contrib/debian/manpages/bitcoin-qt.1
@@ -32,10 +32,7 @@ Set database cache size in megabytes (default: 25)
 Specify connection timeout in milliseconds (default: 5000)
 .TP
 \fB\-proxy=\fR<ip:port>
-Connect through socks proxy
-.TP
-\fB\-socks=\fR<n>
-Select the version of socks proxy to use (4\-5, default: 5)
+Connect through SOCKS5 proxy
 .TP
 \fB\-tor=\fR<ip:port>
 Use proxy to reach tor hidden services (default: same as \fB\-proxy\fR)

--- a/contrib/debian/manpages/bitcoind.1
+++ b/contrib/debian/manpages/bitcoind.1
@@ -28,7 +28,7 @@ Start minimized
 Specify data directory
 .TP
 \fB\-proxy=\fR<ip:port>
-Connect through socks4 proxy
+Connect through SOCKS5 proxy
 .TP
 \fB\-addnode=\fR<ip>
 Add a node to connect to

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -13,11 +13,6 @@ configure Tor.
 The first step is running Dogecoin behind a Tor proxy. This will already make all
 outgoing connections be anonymized, but more is possible.
 
-	-socks=5        SOCKS5 supports connecting-to-hostname, which can be used instead
-	                of doing a (leaking) local DNS lookup. SOCKS5 is the default,
-	                but SOCKS4 does not support this. (SOCKS4a does, but isn't
-	                implemented).
-	
 	-proxy=ip:port  Set the proxy server. If SOCKS5 is selected (default), this proxy
 	                server will be used to try to reach .onion addresses as well.
 	


### PR DESCRIPTION
Previously -proxy was not setting the proxy for IsLimited networks, so
 if you set your configuration to be onlynet=tor you wouldn't get an
 IPv4 proxy set.

The payment protocol gets its proxy configuration from the IPv4 proxy,
 and so it would experience a connection leak.

This addresses issue #5355 and also clears up a cosmetic bug where
 getinfo proxy output shows nothing when onlynet=tor is set.

Conflicts:
	src/init.cpp

Rebased-From: 3c777141349ad82d679a278df0619968af53c23
Github-Issue: #5358