### PR TITLE
build: fix release name strings for gitian builds

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -16,7 +16,7 @@ fi
 DESC=""
 SUFFIX=""
 LAST_COMMIT_DATE=""
-if [ -e "$(which git 2>/dev/null)" -a -d ".git" ]; then
+if [ -e "$(which git 2>/dev/null)" -a $(git rev-parse --is-inside-work-tree 2>/dev/null) = "true" ]; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null 
 


### PR DESCRIPTION
When building from a distdir as gitian does, checking for the .git dir
is not reliable. Instead, ask git if we're in a repo.