### PR TITLE
Add constants for outbound connection limits

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -230,7 +230,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -externalip=<ip>       " + _("Specify your own public address") + "\n";
     strUsage += "  -listen                " + _("Accept connections from outside (default: 1 if no -proxy or -connect)") + "\n";
     strUsage += "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n";
-    strUsage += "  -maxoutconnections=<n> " + _("Maintain at most <n> outbound connections to peers (default: 8)") + "\n";
+    strUsage += "  -maxoutconnections=<n> " + strprintf(_("Maintain at most <n> outbound connections to peers (default: %u)"), DEFAULT_MAX_OUTBOUND_CONNECTIONS) + "\n";
     strUsage += "  -maxreceivebuffer=<n>  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 5000)") + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
     strUsage += "  -onion=<ip:port>       " + _("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)") + "\n";
@@ -536,8 +536,8 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
 
-    nMaxOutboundConnections = GetArg("-maxoutconnections", 8);
-    nMaxOutboundConnections = std::min(std::max(nMaxOutboundConnections, 2), nMaxConnections);
+    nMaxOutboundConnections = GetArg("-maxoutconnections", DEFAULT_MAX_OUTBOUND_CONNECTIONS);
+    nMaxOutboundConnections = std::min(std::max(nMaxOutboundConnections, MIN_OUTBOUND_CONNECTIONS), nMaxConnections);
     // ********************************************************* Step 3: parameter-to-internal-flags
 
     fDebug = !mapMultiArgs["-debug"].empty();

--- a/src/net.h
+++ b/src/net.h
@@ -36,6 +36,11 @@ namespace boost {
     class thread_group;
 }
 
+/** The minimum number of connections to attempt to make out to other peers */
+static const int MIN_OUTBOUND_CONNECTIONS = 2;
+/** The default number of connections to attempt to make out to other peers */
+static const int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 8;
+
 /** The maximum number of entries in an 'inv' protocol message */
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of entries in mapAskFor */


### PR DESCRIPTION
Adds DEFAULT_MAX_OUTBOUND_CONNECTIONS constant to net.h, to replace the previous MAX_OUTBOUND_CONNECTIONS constant.
Adds a new MIN_OUTBOUND_CONNECTIONS constant.