### PR TITLE
Fix addnode "onetry": Connect with OpenNetworkConnection

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -39,9 +39,6 @@
 using namespace std;
 using namespace boost;
 
-bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
-
-
 //
 // Global state variables
 //

--- a/src/net.h
+++ b/src/net.h
@@ -51,6 +51,7 @@ void AddressCurrentlyConnected(const CService& addr);
 CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CService& ip);
 CNode* ConnectNode(CAddress addrConnect, const char *strDest = NULL);
+bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError=REF(std::string()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -167,7 +167,7 @@ Value addnode(const Array& params, bool fHelp)
     if (strCommand == "onetry")
     {
         CAddress addr;
-        ConnectNode(addr, strNode.c_str());
+        OpenNetworkConnection(addr, NULL, strNode.c_str());
         return Value::null;
     }
 


### PR DESCRIPTION
Corrects addnode RPC command's "onetry" option to use OpenNetworkConnection() rather than attempting to directly connect to a node.
 
Conflicts:
	src/net.cpp