### PR TITLE
Fix for OpenSSL 1.0.1k+

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -227,10 +227,20 @@ public:
     }
 
     bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
-        // -1 = error, 0 = bad sig, 1 = good
-        if (ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), &vchSig[0], vchSig.size(), pkey) != 1)
+        // New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
+        unsigned char *norm_der = NULL;
+        ECDSA_SIG *norm_sig = ECDSA_SIG_new();
+        const unsigned char* sigptr = &vchSig[0];
+        d2i_ECDSA_SIG(&norm_sig, &sigptr, vchSig.size());
+        int derlen = i2d_ECDSA_SIG(norm_sig, &norm_der);
+        ECDSA_SIG_free(norm_sig);
+        if (derlen <= 0)
             return false;
-        return true;
+
+        // -1 = error, 0 = bad sig, 1 = good
+        bool ret = ECDSA_verify(0, (unsigned char*)&hash, sizeof(hash), norm_der, derlen, pkey) == 1;
+        OPENSSL_free(norm_der);
+        return ret;
     }
 
     bool SignCompact(const uint256 &hash, unsigned char *p64, int &rec) {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -227,6 +227,9 @@ public:
     }
 
     bool Verify(const uint256 &hash, const std::vector<unsigned char>& vchSig) {
+        if (vchSig.empty())
+            return false;
+
         // New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
         unsigned char *norm_der = NULL;
         ECDSA_SIG *norm_sig = ECDSA_SIG_new();


### PR DESCRIPTION
This is pulled from bitcoin/bitcoin#5634 . 

Fixes a problem when linking against the newest OpenSSL which can cause a fork. Note that this is only relevant for people compiling their own wallet.s Buildss on dogecoin.com are unaffected. So IMHO we don't need to push a full release for this. Just merge this into master and tag it. Objections?  

Thanks to @mxtm for the hint :)