### PR TITLE
Openssl 1.0.1l dependency update

### DIFF
--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1k.tar.gz"
+- "openssl-1.0.1l.tar.gz"
 - "miniupnpc-1.9.20140701.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "protobuf-2.5.0.tar.bz2"
@@ -30,15 +30,15 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
+  echo "b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4  openssl-1.0.1l.tar.gz"  | sha256sum -c
   echo "26f3985bad7768b8483b793448ae49414cdc4451d0ec83e7c1944367e15f9f07  miniupnpc-1.9.20140701.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1k.tar.gz
-  cd openssl-1.0.1k
+  tar xzf openssl-1.0.1l.tar.gz
+  cd openssl-1.0.1l
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o

--- a/contrib/gitian-descriptors/deps-linux.yml
+++ b/contrib/gitian-descriptors/deps-linux.yml
@@ -16,7 +16,7 @@ packages:
 reference_datetime: "2013-06-01 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1j.tar.gz"
+- "openssl-1.0.1k.tar.gz"
 - "miniupnpc-1.9.20140701.tar.gz"
 - "qrencode-3.4.3.tar.bz2"
 - "protobuf-2.5.0.tar.bz2"
@@ -30,15 +30,15 @@ script: |
   export TZ=UTC
   export LIBRARY_PATH="$STAGING/lib"
   # Integrity Check
-  echo "1b60ca8789ba6f03e8ef20da2293b8dc131c39d83814e775069f02d26354edf3  openssl-1.0.1j.tar.gz"  | sha256sum -c
+  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
   echo "26f3985bad7768b8483b793448ae49414cdc4451d0ec83e7c1944367e15f9f07  miniupnpc-1.9.20140701.tar.gz"   | sha256sum -c
   echo "dfd71487513c871bad485806bfd1fdb304dedc84d2b01a8fb8e0940b50597a98  qrencode-3.4.3.tar.bz2" | sha256sum -c
   echo "13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677  protobuf-2.5.0.tar.bz2" | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
 
   #
-  tar xzf openssl-1.0.1j.tar.gz
-  cd openssl-1.0.1j
+  tar xzf openssl-1.0.1k.tar.gz
+  cd openssl-1.0.1k
   #   need -fPIC to avoid relocation error in 64 bit builds
   ./config no-shared no-zlib no-dso no-krb5 --openssldir=$STAGING -fPIC
   #   need to build OpenSSL with faketime because a timestamp is embedded into cversion.o
@@ -95,4 +95,4 @@ script: |
   done
   #
   cd $STAGING
-  find include lib bin host | sort | zip -X@ $OUTDIR/dogecoin-deps-linux${GBUILD_BITS}-gitian-r9.zip
+  find include lib bin host | sort | zip -X@ $OUTDIR/dogecoin-deps-linux${GBUILD_BITS}-gitian-r10.zip

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1j.tar.gz"
+- "openssl-1.0.1k.tar.gz"
 - "db-5.1.29.NC.tar.gz"
 - "miniupnpc-1.9.20140701.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "1b60ca8789ba6f03e8ef20da2293b8dc131c39d83814e775069f02d26354edf3  openssl-1.0.1j.tar.gz"  | sha256sum -c
+  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
   echo "26f3985bad7768b8483b793448ae49414cdc4451d0ec83e7c1944367e15f9f07  miniupnpc-1.9.20140701.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1j.tar.gz
-    cd openssl-1.0.1j
+    tar xzf $INDIR/openssl-1.0.1k.tar.gz
+    cd openssl-1.0.1k
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else
@@ -126,5 +126,5 @@ script: |
     done
     #
     cd $INSTALLPREFIX
-    find include lib | sort | zip -X@ $OUTDIR/dogecoin-deps-win$BITS-gitian-r16.zip
+    find include lib | sort | zip -X@ $OUTDIR/dogecoin-deps-win$BITS-gitian-r17.zip
   done # for BITS in

--- a/contrib/gitian-descriptors/deps-win.yml
+++ b/contrib/gitian-descriptors/deps-win.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1k.tar.gz"
+- "openssl-1.0.1l.tar.gz"
 - "db-5.1.29.NC.tar.gz"
 - "miniupnpc-1.9.20140701.tar.gz"
 - "zlib-1.2.8.tar.gz"
@@ -28,7 +28,7 @@ script: |
   INDIR=$HOME/build
   TEMPDIR=$HOME/tmp
   # Input Integrity Check
-  echo "8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c  openssl-1.0.1k.tar.gz"  | sha256sum -c
+  echo "b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4  openssl-1.0.1l.tar.gz"  | sha256sum -c
   echo "08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c  db-5.1.29.NC.tar.gz"    | sha256sum -c
   echo "26f3985bad7768b8483b793448ae49414cdc4451d0ec83e7c1944367e15f9f07  miniupnpc-1.9.20140701.tar.gz"   | sha256sum -c
   echo "36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d  zlib-1.2.8.tar.gz"      | sha256sum -c
@@ -48,8 +48,8 @@ script: |
     mkdir -p $INSTALLPREFIX $BUILDDIR
     cd $BUILDDIR
     #
-    tar xzf $INDIR/openssl-1.0.1k.tar.gz
-    cd openssl-1.0.1k
+    tar xzf $INDIR/openssl-1.0.1l.tar.gz
+    cd openssl-1.0.1l
     if [ "$BITS" == "32" ]; then
       OPENSSL_TGT=mingw
     else

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -25,8 +25,8 @@ remotes:
 - "url": "https://github.com/dogecoin/dogecoin.git"
   "dir": "dogecoin"
 files:
-- "dogecoin-deps-linux32-gitian-r9.zip"
-- "dogecoin-deps-linux64-gitian-r9.zip"
+- "dogecoin-deps-linux32-gitian-r10.zip"
+- "dogecoin-deps-linux64-gitian-r10.zip"
 - "boost-linux32-1.55.0-gitian-r1.zip"
 - "boost-linux64-1.55.0-gitian-r1.zip"
 - "qt-linux32-4.6.4-gitian-r1.tar.gz"
@@ -43,7 +43,7 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/dogecoin-deps-linux${GBUILD_BITS}-gitian-r9.zip
+  unzip ../build/dogecoin-deps-linux${GBUILD_BITS}-gitian-r10.zip
   unzip ../build/boost-linux${GBUILD_BITS}-1.55.0-gitian-r1.zip
   tar -zxf ../build/qt-linux${GBUILD_BITS}-4.6.4-gitian-r1.tar.gz
   cd ../build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -26,8 +26,8 @@ files:
 - "qt-win64-5.2.0-gitian-r3.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
 - "boost-win64-1.55.0-gitian-r6.zip"
-- "dogecoin-deps-win32-gitian-r16.zip"
-- "dogecoin-deps-win64-gitian-r16.zip"
+- "dogecoin-deps-win32-gitian-r17.zip"
+- "dogecoin-deps-win64-gitian-r17.zip"
 - "protobuf-win32-2.5.0-gitian-r4.zip"
 - "protobuf-win64-2.5.0-gitian-r4.zip"
 script: |
@@ -61,7 +61,7 @@ script: |
     cd $STAGING
     unzip $INDIR/qt-win${BITS}-5.2.0-gitian-r3.zip
     unzip $INDIR/boost-win${BITS}-1.55.0-gitian-r6.zip
-    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r16.zip
+    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r17.zip
     unzip $INDIR/protobuf-win${BITS}-2.5.0-gitian-r4.zip
     if [ "$NEEDDIST" == "1" ]; then
       # Make source code archive which is architecture independent so it only needs to be done once

--- a/contrib/gitian-descriptors/qt-win.yml
+++ b/contrib/gitian-descriptors/qt-win.yml
@@ -15,8 +15,8 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-5.2.0.tar.gz"
-- "dogecoin-deps-win32-gitian-r16.zip"
-- "dogecoin-deps-win64-gitian-r16.zip"
+- "dogecoin-deps-win32-gitian-r17.zip"
+- "dogecoin-deps-win64-gitian-r17.zip"
 script: |
   # Defines
   export TZ=UTC
@@ -48,7 +48,7 @@ script: |
     #
     # Need mingw-compiled openssl from dogecoin-deps:
     cd $DEPSDIR
-    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r16.zip
+    unzip $INDIR/dogecoin-deps-win${BITS}-gitian-r17.zip
     #
     cd $BUILDDIR
     #

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -22,7 +22,7 @@ for the build process to succeed.
 
 	name            default path               download
 	--------------------------------------------------------------------------------------------------------------------
-	OpenSSL         \openssl-1.0.1j-mgw        http://www.openssl.org/source/
+	OpenSSL         \openssl-1.0.1k-mgw        http://www.openssl.org/source/
 	Berkeley DB     \db-5.1.29.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 	Boost           \boost-1.55.0-mgw          http://www.boost.org/users/download/
 	miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -44,7 +44,7 @@ Their licenses:
 
 Versions used in this release:
 
-	OpenSSL      1.0.1j
+	OpenSSL      1.0.1k
 	Berkeley DB  5.1.29.NC
 	Boost        1.55.0
 	miniupnpc    1.6
@@ -61,7 +61,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-	cd /c/openssl-1.0.1j-mgw
+	cd /c/openssl-1.0.1k-mgw
 	./config
 	make
 

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -22,7 +22,7 @@ for the build process to succeed.
 
 	name            default path               download
 	--------------------------------------------------------------------------------------------------------------------
-	OpenSSL         \openssl-1.0.1k-mgw        http://www.openssl.org/source/
+	OpenSSL         \openssl-1.0.1l-mgw        http://www.openssl.org/source/
 	Berkeley DB     \db-5.1.29.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
 	Boost           \boost-1.55.0-mgw          http://www.boost.org/users/download/
 	miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
@@ -44,7 +44,7 @@ Their licenses:
 
 Versions used in this release:
 
-	OpenSSL      1.0.1k
+	OpenSSL      1.0.1l
 	Berkeley DB  5.1.29.NC
 	Boost        1.55.0
 	miniupnpc    1.6
@@ -61,7 +61,7 @@ MSYS shell:
 un-tar sources with MSYS 'tar xfz' to avoid issue with symlinks (OpenSSL ticket 2377)
 change 'MAKE' env. variable from 'C:\MinGW32\bin\mingw32-make.exe' to '/c/MinGW32/bin/mingw32-make.exe'
 
-	cd /c/openssl-1.0.1k-mgw
+	cd /c/openssl-1.0.1l-mgw
 	./config
 	make
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -25,7 +25,7 @@ Dependencies
  libqrencode | QR codes in GUI  | Optional for generating QR codes
  
  Suggested versions of these libraries are as follows:
-      openssl-1.0.1k
+      openssl-1.0.1l
       db-5.1.29
       boost 1.55
       miniupnpc-1.9.20140701

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -25,7 +25,7 @@ Dependencies
  libqrencode | QR codes in GUI  | Optional for generating QR codes
  
  Suggested versions of these libraries are as follows:
-      openssl-1.0.1j
+      openssl-1.0.1k
       db-5.1.29
       boost 1.55
       miniupnpc-1.9.20140701

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -38,7 +38,7 @@ Release Process
 
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.20140701.tar.gz' -O miniupnpc-1.9.20140701.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1k.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1l.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.8/libpng-1.6.8.tar.gz'
@@ -67,16 +67,16 @@ Release Process
 
  The expected SHA256 hashes of the intermediate inputs are:
 
-    d7036b520d6682bf9023965d876347e0250e67cae86771117c1e9ce77ebbbdad  dogecoin-deps-linux32-gitian-r10.zip
-    d2cdd0610bc6ccb04140494f00274a9bf14d19951b80e0902edcb5bd2970eafa  dogecoin-deps-linux64-gitian-r10.zip
+    0331de2b05c275986545e8d2d6a4becf625e5935034803dc508c9d641e70c7cb  dogecoin-deps-linux32-gitian-r10.zip
+    d99caabf13011494dd147b4ffad1626480889f5080270a1a04e1a7adc543cc4f  dogecoin-deps-linux64-gitian-r10.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
     57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
-    e2f12eb4963ee2e1df154b11628298341d89a5c260facfd4fab07c90b0820fec  dogecoin-deps-win32-gitian-r17.zip
-    cd2f29030ec5b0a5ea313e3bff9641e730573c19a7b9dcc8b4abccc13fb41944  dogecoin-deps-win64-gitian-r17.zip
+    3783d98ac49256f11381d4eadffed5b51c1779afedca43ffef6cf8998d1db9c5  dogecoin-deps-win32-gitian-r17.zip
+    b579a9af8a8b77d542738cf93e5a12bfb0957dade0281bebd96a1619fc587855  dogecoin-deps-win64-gitian-r17.zip
     963e3e5e85879010a91143c90a711a5d1d5aba992e38672cdf7b54e42c56b2f1  qt-win32-5.2.0-gitian-r3.zip
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -38,7 +38,7 @@ Release Process
 
 	mkdir -p inputs; cd inputs/
 	wget 'http://miniupnp.free.fr/files/download.php?file=miniupnpc-1.9.20140701.tar.gz' -O miniupnpc-1.9.20140701.tar.gz
-	wget 'https://www.openssl.org/source/openssl-1.0.1j.tar.gz'
+	wget 'https://www.openssl.org/source/openssl-1.0.1k.tar.gz'
 	wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
 	wget 'http://zlib.net/zlib-1.2.8.tar.gz'
 	wget 'https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/1.6.8/libpng-1.6.8.tar.gz'
@@ -67,16 +67,16 @@ Release Process
 
  The expected SHA256 hashes of the intermediate inputs are:
 
-    19afcc075d52b7853dd0b0b7d54ad2bf71e2746625677e24a1f9f63474674577  dogecoin-deps-linux32-gitian-r9.zip
-    e6d34fe758bf965b759421c7049a7b5aac9d53356caff6f53c95d01cbc49bd85  dogecoin-deps-linux64-gitian-r9.zip
+    d7036b520d6682bf9023965d876347e0250e67cae86771117c1e9ce77ebbbdad  dogecoin-deps-linux32-gitian-r10.zip
+    d2cdd0610bc6ccb04140494f00274a9bf14d19951b80e0902edcb5bd2970eafa  dogecoin-deps-linux64-gitian-r10.zip
     f29b7d9577417333fb56e023c2977f5726a7c297f320b175a4108cf7cd4c2d29  boost-linux32-1.55.0-gitian-r1.zip
     88232451c4104f7eb16e469ac6474fd1231bd485687253f7b2bdf46c0781d535  boost-linux64-1.55.0-gitian-r1.zip
     57e57dbdadc818cd270e7e00500a5e1085b3bcbdef69a885f0fb7573a8d987e1  qt-linux32-4.6.4-gitian-r1.tar.gz
     60eb4b9c5779580b7d66529efa5b2836ba1a70edde2a0f3f696d647906a826be  qt-linux64-4.6.4-gitian-r1.tar.gz
     60dc2d3b61e9c7d5dbe2f90d5955772ad748a47918ff2d8b74e8db9b1b91c909  boost-win32-1.55.0-gitian-r6.zip
     f65fcaf346bc7b73bc8db3a8614f4f6bee2f61fcbe495e9881133a7c2612a167  boost-win64-1.55.0-gitian-r6.zip
-    d46a21cad396fcb7bed0d5f430a37b76117fe06b3349c7a4784f11b35bd00989  dogecoin-deps-win32-gitian-r16.zip
-    ab93f7c623904f1f70638119a239ec2b41bc0c6295dad9f81fcd0bc9aa2f83d8  dogecoin-deps-win64-gitian-r16.zip
+    e2f12eb4963ee2e1df154b11628298341d89a5c260facfd4fab07c90b0820fec  dogecoin-deps-win32-gitian-r17.zip
+    cd2f29030ec5b0a5ea313e3bff9641e730573c19a7b9dcc8b4abccc13fb41944  dogecoin-deps-win64-gitian-r17.zip
     963e3e5e85879010a91143c90a711a5d1d5aba992e38672cdf7b54e42c56b2f1  qt-win32-5.2.0-gitian-r3.zip
     751c579830d173ef3e6f194e83d18b92ebef6df03289db13ab77a52b6bc86ef0  qt-win64-5.2.0-gitian-r3.zip
     e2e403e1a08869c7eed4d4293bce13d51ec6a63592918b90ae215a0eceb44cb4  protobuf-win32-2.5.0-gitian-r4.zip


### PR DESCRIPTION
Replaces #785 with OpenSSL 1.0.1l version.
