### PR TITLE
Remove WriteBestInvalidWork() definition

### DIFF
--- a/src/txdb.h
+++ b/src/txdb.h
@@ -53,7 +53,6 @@ public:
     bool WriteDiskBlockIndex(const CDiskBlockIndex& diskblockindex);
     bool WriteBlockIndex(const CBlockIndex& blockindex);
     bool ReadDiskBlockIndex(const uint256 &blkid, CDiskBlockIndex& diskblockindex);
-    bool WriteBestInvalidWork(const CBigNum& bnBestInvalidWork);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo &fileinfo);
     bool WriteBlockFileInfo(int nFile, const CBlockFileInfo &fileinfo);
     bool ReadLastBlockFile(int &nFile);


### PR DESCRIPTION
Missed from #765 