### PR TITLE
Remove unused Print/PrintHex functions

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -838,10 +838,6 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     valtype& vchSig    = stacktop(-2);
                     valtype& vchPubKey = stacktop(-1);
 
-                    ////// debug print
-                    //PrintHex(vchSig.begin(), vchSig.end(), "sig: %s\n");
-                    //PrintHex(vchPubKey.begin(), vchPubKey.end(), "pubkey: %s\n");
-
                     // Subset of script starting at the most recent codeseparator
                     CScript scriptCode(pbegincodehash, pend);
 

--- a/src/script.h
+++ b/src/script.h
@@ -691,12 +691,6 @@ public:
     void SetDestination(const CTxDestination& address);
     void SetMultisig(int nRequired, const std::vector<CPubKey>& keys);
 
-
-    void PrintHex() const
-    {
-        LogPrintf("CScript(%s)\n", HexStr(begin(), end(), true).c_str());
-    }
-
     std::string ToString() const
     {
         std::string str;
@@ -718,11 +712,6 @@ public:
                 str += GetOpName(opcode);
         }
         return str;
-    }
-
-    void print() const
-    {
-        LogPrintf("%s\n", ToString());
     }
 
     CScriptID GetID() const

--- a/src/util.h
+++ b/src/util.h
@@ -290,17 +290,6 @@ inline std::string HexStr(const T& vch, bool fSpaces=false)
     return HexStr(vch.begin(), vch.end(), fSpaces);
 }
 
-template<typename T>
-void PrintHex(const T pbegin, const T pend, const char* pszFormat="%s", bool fSpaces=true)
-{
-    LogPrintf(pszFormat, HexStr(pbegin, pend, fSpaces).c_str());
-}
-
-inline void PrintHex(const std::vector<unsigned char>& vch, const char* pszFormat="%s", bool fSpaces=true)
-{
-    LogPrintf(pszFormat, HexStr(vch, fSpaces).c_str());
-}
-
 inline int64_t GetPerformanceCounter()
 {
     int64_t nCounter = 0;


### PR DESCRIPTION
You can just use HexStr(script) or script.ToString() for debugging, no
need for these extra functions.