### PR TITLE
Fix values used in fee calculation unit tests

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -109,26 +109,26 @@ BOOST_AUTO_TEST_CASE(GetMinFee_test)
     CTxOut txout1(value, (CScript)vector<unsigned char>(24, 0));
     tx.vout.push_back(txout1);
     
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
+    int64_t nMinTxFee = COIN;
+    int64_t nMinRelayTxFee = COIN;
     
-    BOOST_CHECK(GetMinFee(tx, 100, false, GMF_RELAY) == CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 100, false, GMF_SEND) == CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 100, false, GMF_RELAY) == nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 100, false, GMF_SEND) == nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 2 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 2 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 2 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 2 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 3 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 3 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 3 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 3 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (1+(MAX_STANDARD_TX_SIZE/1000))*nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*nMinTxFee);
 }
 
 BOOST_AUTO_TEST_CASE(GetMinFee_dust_test)
@@ -139,23 +139,23 @@ BOOST_AUTO_TEST_CASE(GetMinFee_dust_test)
     CTxOut txout1(value, (CScript)vector<unsigned char>(24, 0));
     tx.vout.push_back(txout1);
     
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
+    int64_t nMinTxFee = COIN;
+    int64_t nMinRelayTxFee = COIN;
     
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == 2 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == 2 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == 2 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == 2 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == 2 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == 2 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == 2 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == 2 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 3 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 3 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 3 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 3 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 4 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 4 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 4 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 4 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (2+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (2+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (2+(MAX_STANDARD_TX_SIZE/1000))*nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (2+(MAX_STANDARD_TX_SIZE/1000))*nMinTxFee);
 }
 
 BOOST_AUTO_TEST_CASE(GetMinFee_manydust_test)
@@ -174,23 +174,23 @@ BOOST_AUTO_TEST_CASE(GetMinFee_manydust_test)
     CTxOut txout101(1000 * COIN, (CScript)vector<unsigned char>(24, 0));
     tx.vout.push_back(txout101);
     
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
+    int64_t nMinTxFee = COIN;
+    int64_t nMinRelayTxFee = COIN;
     
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == 101 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == 101 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_RELAY) == 101 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1, false, GMF_SEND) == 101 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == 101 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == 101 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_RELAY) == 101 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 999, false, GMF_SEND) == 101 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 102 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 102 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_RELAY) == 102 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 1000, false, GMF_SEND) == 102 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 103 * CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 103 * CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_RELAY) == 103 * nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, 2000, false, GMF_SEND) == 103 * nMinTxFee);
     
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (101+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinRelayTxFee);
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (101+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_RELAY) == (101+(MAX_STANDARD_TX_SIZE/1000))*nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, false, GMF_SEND) == (101+(MAX_STANDARD_TX_SIZE/1000))*nMinTxFee);
 }
 
 BOOST_AUTO_TEST_CASE(GetMinFee_relayfree_test)
@@ -201,8 +201,7 @@ BOOST_AUTO_TEST_CASE(GetMinFee_relayfree_test)
     CTxOut txout1(value, (CScript)vector<unsigned char>(24, 0));
     tx.vout.push_back(txout1);
     
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
+    int64_t nMinRelayTxFee = COIN;
     
     BOOST_CHECK(GetMinFee(tx, 100, true, GMF_RELAY) == 0);
     BOOST_CHECK(GetMinFee(tx, 1000, true, GMF_RELAY) == 0);
@@ -211,7 +210,7 @@ BOOST_AUTO_TEST_CASE(GetMinFee_relayfree_test)
     BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_RELAY) > 0);
     BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_RELAY) == GetMinFee(tx, 26000, false, GMF_RELAY));
     
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_RELAY) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinRelayTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_RELAY) == (1+(MAX_STANDARD_TX_SIZE/1000))*nMinRelayTxFee);
 }
 
 BOOST_AUTO_TEST_CASE(GetMinFee_createNoFree_test)
@@ -222,8 +221,7 @@ BOOST_AUTO_TEST_CASE(GetMinFee_createNoFree_test)
     CTxOut txout1(value, (CScript)vector<unsigned char>(24, 0));
     tx.vout.push_back(txout1);
     
-    if(CTransaction::nMinTxFee == CTransaction::nMinRelayTxFee)
-        CTransaction::nMinTxFee++;
+    int64_t nMinTxFee = COIN;
     
     BOOST_CHECK(GetMinFee(tx, 100, true, GMF_SEND) > 0);
     BOOST_CHECK(GetMinFee(tx, 100, true, GMF_SEND) == GetMinFee(tx, 100, false, GMF_SEND));
@@ -235,7 +233,7 @@ BOOST_AUTO_TEST_CASE(GetMinFee_createNoFree_test)
     BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_SEND) > 0);
     BOOST_CHECK(GetMinFee(tx, 26000, true, GMF_SEND) == GetMinFee(tx, 26000, false, GMF_SEND));
     
-    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*CTransaction::nMinTxFee);
+    BOOST_CHECK(GetMinFee(tx, MAX_STANDARD_TX_SIZE, true, GMF_SEND) == (1+(MAX_STANDARD_TX_SIZE/1000))*nMinTxFee);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This modifies the fee calculation unit tests to use the current fee values, rather than those written in the code, for the tests. This means that if someone changes the min fee/min relay fee values in the code without updating the tests, they will fail. This is desirable as any change to this should be test-driven (i.e. tests should updated so they fail with the current code, and the code then updated to match).

Should be merged before #833, which depends on these tests.
