### PR TITLE
Chain-agnostic coding, part 1 

### DIFF
--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -5,6 +5,7 @@
 
 #include "alert.h"
 
+#include "chainparams.h"
 #include "key.h"
 #include "net.h"
 #include "ui_interface.h"

--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -22,7 +22,7 @@ bool CAuxPow::Check(uint256 hashAuxBlock, int nChainID)
     if (nIndex != 0)
         return error("AuxPow is not a generate");
 
-    if (!TestNet() && parentBlockHeader.GetChainID() == nChainID)
+    if (!Params().AllowSelfAuxParent() && parentBlockHeader.GetChainID() == nChainID)
         return error("Aux POW parent has our chain ID");
 
     if (vChainMerkleBranch.size() > 30)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -8,8 +8,6 @@
 #include "chainparams.h"
 
 #include "assert.h"
-#include "core.h"
-#include "protocol.h"
 #include "util.h"
 
 #include <boost/assign/list_of.hpp>
@@ -102,6 +100,7 @@ unsigned int pnSeed[] =
 class CMainParams : public CChainParams {
 public:
     CMainParams() {
+        networkID = CChainParams::MAIN;
         // The message start string is designed to be unlikely to occur in normal data.
         // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
         // a large 4-byte int at any alignment.
@@ -114,6 +113,10 @@ public:
         nRPCPort = 22555;
         bnProofOfWorkLimit = ~uint256(0) >> 20;
         nSubsidyHalvingInterval = 210000;
+        nEnforceBlockUpgradeMajority = 750;
+        nRejectBlockOutdatedMajority = 950;
+        nToCheckBlockUpgradeMajority = 1000;
+        nMinerThreads = 0;
 
         // Build the genesis block. Note that the output of the genesis coinbase cannot
         // be spent as it did not originally exist in the database.
@@ -177,20 +180,17 @@ public:
             addr.nTime = GetTime() - GetRand(nOneWeek) - nOneWeek;
             vFixedSeeds.push_back(addr);
         }
-    }
 
-    virtual const CBlock& GenesisBlock() const { return genesis; }
-    virtual Network NetworkID() const { return CChainParams::MAIN; }
-
-    virtual const vector<CAddress>& FixedSeeds() const {
-        return vFixedSeeds;
+        fRequireRPCPassword = true;
+        fMiningRequiresPeers = true;
+        fDefaultCheckMemPool = false;
+        fAllowMinDifficultyBlocks = false;
+        fRequireStandard = true;
+        fRPCisTestNet = false;
+        fMineBlocksOnDemand = false;
     }
-protected:
-    CBlock genesis;
-    vector<CAddress> vFixedSeeds;
 };
 static CMainParams mainParams;
-
 
 //
 // Testnet (v3)
@@ -198,6 +198,7 @@ static CMainParams mainParams;
 class CTestNetParams : public CMainParams {
 public:
     CTestNetParams() {
+        networkID = CChainParams::TESTNET;
         // The message start string is designed to be unlikely to occur in normal data.
         // The characters are rarely used upper ASCII, not valid as UTF-8, and produce
         // a large 4-byte int at any alignment.
@@ -208,6 +209,9 @@ public:
         vAlertPubKey = ParseHex("042756726da3c7ef515d89212ee1705023d14be389e25fe15611585661b9a20021908b2b80a3c7200a0139dd2b26946606aab0eef9aa7689a6dc2c7eee237fa834");
         nDefaultPort = 44556;
         nRPCPort = 44555;
+        nEnforceBlockUpgradeMajority = 51;
+        nRejectBlockOutdatedMajority = 75;
+        nToCheckBlockUpgradeMajority = 100;
         strDataDir = "testnet3";
 
         // Modify the testnet genesis block so the timestamp is valid for a later start.
@@ -233,8 +237,15 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = epk;
         std::vector<unsigned char> esk = list_of(0x04)(0x35)(0x75)(0xA4);
         base58Prefixes[EXT_SECRET_KEY] = esk;
+
+        fRequireRPCPassword = true;
+        fMiningRequiresPeers = true;
+        fDefaultCheckMemPool = false;
+        fAllowMinDifficultyBlocks = true;
+        fRequireStandard = false;
+        fRPCisTestNet = true;
+        fMineBlocksOnDemand = false;
     }
-    virtual Network NetworkID() const { return CChainParams::TESTNET; }
 };
 static CTestNetParams testNetParams;
 
@@ -244,11 +255,16 @@ static CTestNetParams testNetParams;
 class CRegTestParams : public CTestNetParams {
 public:
     CRegTestParams() {
+        networkID = CChainParams::REGTEST;
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
         pchMessageStart[2] = 0xb5;
         pchMessageStart[3] = 0xda;
         nSubsidyHalvingInterval = 150;
+        nEnforceBlockUpgradeMajority = 750;
+        nRejectBlockOutdatedMajority = 950;
+        nToCheckBlockUpgradeMajority = 1000;
+        nMinerThreads = 1;
         bnProofOfWorkLimit = ~uint256(0) >> 1;
         genesis.nTime = 1296688602;
         genesis.nBits = 0x207fffff;
@@ -259,12 +275,17 @@ public:
         assert(hashGenesisBlock == uint256("0x3d2160a3b5dc4a9d62e7e66a295f70313ac808440ef7400d6c0772171ce973a5"));
 
         vSeeds.clear();  // Regtest mode doesn't have any DNS seeds.
-    }
 
-    virtual bool RequireRPCPassword() const { return false; }
-    virtual bool SimplifiedRewards() const { return true; }
-    virtual Network NetworkID() const { return CChainParams::REGTEST; }
+        fRequireRPCPassword = false;
+        fMiningRequiresPeers = false;
+        fDefaultCheckMemPool = true;
+        fAllowMinDifficultyBlocks = true;
+        fRequireStandard = false;
+        fRPCisTestNet = true;
+        fMineBlocksOnDemand = true;
+    }
 };
+
 static CRegTestParams regTestParams;
 
 static CChainParams *pCurrentParams = &mainParams;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -188,6 +188,12 @@ public:
         fRequireStandard = true;
         fRPCisTestNet = false;
         fMineBlocksOnDemand = false;
+
+        // Dogecoin specific properties
+        fSimplifiedRewards = false;
+        nAuxPowStartBlock = 371337;
+        fAllowSelfAuxParent = false;
+        nMinDifficultyAllowedStartBlock = INT_MAX;
     }
 };
 static CMainParams mainParams;
@@ -245,6 +251,12 @@ public:
         fRequireStandard = false;
         fRPCisTestNet = true;
         fMineBlocksOnDemand = false;
+
+        // Dogecoin specific properties
+        fSimplifiedRewards = false;
+        nAuxPowStartBlock = 158100;
+        fAllowSelfAuxParent = true;
+        nMinDifficultyAllowedStartBlock = 157500;
     }
 };
 static CTestNetParams testNetParams;
@@ -283,6 +295,12 @@ public:
         fRequireStandard = false;
         fRPCisTestNet = true;
         fMineBlocksOnDemand = true;
+
+        // Dogecoin specific properties
+        fSimplifiedRewards = true;
+        nAuxPowStartBlock = 5000;
+        fAllowSelfAuxParent = true;
+        nMinDifficultyAllowedStartBlock = 1;
     }
 };
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -87,6 +87,20 @@ public:
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
     const vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
     int RPCPort() const { return nRPCPort; }
+
+    // Dogecoin specific properties
+    bool SimplifiedRewards() const { return fSimplifiedRewards; }
+
+    // AUXPOW
+    /* The block number from where AuxPow starts */
+    int GetAuxPowStartBlock() const { return nAuxPowStartBlock; }
+    /* whether we allow ourself to be the auxpow parent chain */
+    bool AllowSelfAuxParent() const { return fAllowSelfAuxParent; }
+
+    // TESTNET FORK: Allow post-digishield min difficulty at 157500
+    /* The minimum difficulty at which we allow post-DigiShield minimum difficulty blocks */
+    int GetMinDifficultyAllowedStartBlock() const { return nMinDifficultyAllowedStartBlock; }
+
 protected:
     CChainParams() {}
 
@@ -115,6 +129,15 @@ protected:
     bool fRequireStandard;
     bool fRPCisTestNet;
     bool fMineBlocksOnDemand;
+
+    // Dogecoin specific properties
+    bool fSimplifiedRewards;
+
+    int nAuxPowStartBlock;
+    bool fAllowSelfAuxParent;
+
+    int nMinDifficultyAllowedStartBlock;
+
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -6,9 +6,9 @@
 #ifndef BITCOIN_CHAIN_PARAMS_H
 #define BITCOIN_CHAIN_PARAMS_H
 
-#include "uint256.h"
 #include "core.h"
 #include "protocol.h"
+#include "uint256.h"
 
 #include <vector>
 
@@ -64,7 +64,7 @@ public:
     /* Used if GenerateBitcoins is called with a negative number of threads */
     int DefaultMinerThreads() const { return nMinerThreads; }
 
-    const CBlock& GenesisBlock() const { return genesis; };
+    const CBlock& GenesisBlock() const { return genesis; }
 
     bool RequireRPCPassword() const { return fRequireRPCPassword; }
     /* Make miner wait to have peers to avoid wasting work */

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -7,16 +7,14 @@
 #define BITCOIN_CHAIN_PARAMS_H
 
 #include "uint256.h"
+#include "core.h"
+#include "protocol.h"
 
 #include <vector>
 
 using namespace std;
 
-#define MESSAGE_START_SIZE 4
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
-
-class CAddress;
-class CBlock;
 
 struct CDNSSeedData {
     string name, host;
@@ -57,14 +55,37 @@ public:
     int GetDefaultPort() const { return nDefaultPort; }
     const uint256& ProofOfWorkLimit() const { return bnProofOfWorkLimit; }
     int SubsidyHalvingInterval() const { return nSubsidyHalvingInterval; }
-    virtual const CBlock& GenesisBlock() const = 0;
-    virtual bool RequireRPCPassword() const { return true; }
-    virtual bool SimplifiedRewards() const { return false; }
+
+    /* Used to check majorities for block version upgrade */
+    int EnforceBlockUpgradeMajority() const { return nEnforceBlockUpgradeMajority; }
+    int RejectBlockOutdatedMajority() const { return nRejectBlockOutdatedMajority; }
+    int ToCheckBlockUpgradeMajority() const { return nToCheckBlockUpgradeMajority; }
+
+    /* Used if GenerateBitcoins is called with a negative number of threads */
+    int DefaultMinerThreads() const { return nMinerThreads; }
+
+    const CBlock& GenesisBlock() const { return genesis; };
+
+    bool RequireRPCPassword() const { return fRequireRPCPassword; }
+    /* Make miner wait to have peers to avoid wasting work */
+    bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
+    /* Default value for -checkmempool argument */
+    bool DefaultCheckMemPool() const { return fDefaultCheckMemPool; }
+    /* Allow mining of a min-difficulty block */
+    bool AllowMinDifficultyBlocks() const { return fAllowMinDifficultyBlocks; }
+    /* Make standard checks */
+    bool RequireStandard() const { return fRequireStandard; }
+    /* RPC network identity, to be depreciated */
+    bool RPCisTestNet() const { return fRPCisTestNet; }
+
     const string& DataDir() const { return strDataDir; }
-    virtual Network NetworkID() const = 0;
+    /* Make miner stop after a block is found. In RPC, don't return
+     * until nGenProcLimit blocks are generated */
+    bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
+    Network NetworkID() const { return networkID; }
     const vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
-    const std::vector<unsigned char> &Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
-    virtual const vector<CAddress>& FixedSeeds() const = 0;
+    const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
+    const vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
     int RPCPort() const { return nRPCPort; }
 protected:
     CChainParams() {}
@@ -77,9 +98,23 @@ protected:
     int nRPCPort;
     uint256 bnProofOfWorkLimit;
     int nSubsidyHalvingInterval;
+    int nEnforceBlockUpgradeMajority;
+    int nRejectBlockOutdatedMajority;
+    int nToCheckBlockUpgradeMajority;
     string strDataDir;
+    int nMinerThreads;
     vector<CDNSSeedData> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
+    Network networkID;
+    CBlock genesis;
+    vector<CAddress> vFixedSeeds;
+    bool fRequireRPCPassword;
+    bool fMiningRequiresPeers;
+    bool fDefaultCheckMemPool;
+    bool fAllowMinDifficultyBlocks;
+    bool fRequireStandard;
+    bool fRPCisTestNet;
+    bool fMineBlocksOnDemand;
 };
 
 /**
@@ -96,14 +131,5 @@ void SelectParams(CChainParams::Network network);
  * Returns false if an invalid combination is given.
  */
 bool SelectParamsFromCommandLine();
-
-inline bool TestNet() {
-    // Note: it's deliberate that this returns "false" for regression test mode.
-    return Params().NetworkID() == CChainParams::TESTNET;
-}
-
-inline bool RegTest() {
-    return Params().NetworkID() == CChainParams::REGTEST;
-}
 
 #endif

--- a/src/core.h
+++ b/src/core.h
@@ -36,8 +36,6 @@ static const int BLOCK_VERSION_CHAIN_END = (1 << 30);
 
 // DogeCoin aux chain ID = 0x0062 (98)
 static const int AUXPOW_CHAIN_ID = 0x0062;
-static const int AUXPOW_START_MAINNET = 371337;
-static const int AUXPOW_START_TESTNET = 158100;
 
 /** No amount larger than this (in satoshi) is valid */
 static const int64_t MAX_MONEY = 10000000000 * COIN; // Dogecoin: maximum of 100B coins (given some randomness), max transaction 10,000,000,000

--- a/src/dogecoin-cli.cpp
+++ b/src/dogecoin-cli.cpp
@@ -33,7 +33,7 @@ static bool AppInitRPC(int argc, char* argv[])
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return false;
     }
-    // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+    // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
     if (!SelectParamsFromCommandLine()) {
         fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
         return false;

--- a/src/dogecoind.cpp
+++ b/src/dogecoind.cpp
@@ -77,7 +77,7 @@ bool AppInit(int argc, char* argv[])
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;
         }
-        // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
+        // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
         if (!SelectParamsFromCommandLine()) {
             fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
             return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -551,7 +551,8 @@ bool AppInit2(boost::thread_group& threadGroup)
         InitWarning(_("Warning: Deprecated argument -debugnet ignored, use -debug=net"));
 
     fBenchmark = GetBoolArg("-benchmark", false);
-    mempool.setSanityCheck(GetBoolArg("-checkmempool", RegTest()));
+    // Checkmempool defaults to true in regtest mode
+    mempool.setSanityCheck(GetBoolArg("-checkmempool", Params().DefaultCheckMemPool()));
     Checkpoints::fEnabled = GetBoolArg("-checkpoints", true);
 
     // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -858,7 +858,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     string reason;
-    if (Params().NetworkID() == CChainParams::MAIN && !IsStandardTx(tx, reason))
+    if (Params().RequireStandard() && !IsStandardTx(tx, reason))
         return state.DoS(0,
                          error("AcceptToMemoryPool : nonstandard transaction: %s", reason),
                          REJECT_NONSTANDARD, reason);
@@ -919,7 +919,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (Params().NetworkID() == CChainParams::MAIN && !AreInputsStandard(tx, view))
+        if (Params().RequireStandard() && !AreInputsStandard(tx, view))
             return error("AcceptToMemoryPool: : nonstandard transaction input");
 
         // Note: if you modify this code to accept non-standard transactions, then
@@ -1290,7 +1290,7 @@ unsigned int ComputeMinWork(unsigned int nBase, int64_t nTime)
     const uint256 &bnLimit = Params().ProofOfWorkLimit();
     // Testnet has min-difficulty blocks
     // after nTargetSpacing*2 time between blocks:
-    if (TestNet() && nTime > nTargetSpacing*2)
+    if (Params().AllowMinDifficultyBlocks() && nTime > nTargetSpacing*2)
         return bnLimit.GetCompact();
 
     uint256 bnResult;
@@ -1344,7 +1344,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     // Only change once per interval
     if ((pindexLast->nHeight+1) % retargetInterval != 0)
     {
-        if (TestNet())
+        if (Params().AllowMinDifficultyBlocks())
         {
             if (pblock->nTime > pindexLast->nTime + nTargetSpacing*2)
             {
@@ -1626,7 +1626,7 @@ void UpdateTime(CBlockHeader& block, const CBlockIndex* pindexPrev)
     block.nTime = max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
 
     // Updating time can change work required on testnet:
-    if (TestNet())
+    if (Params().AllowMinDifficultyBlocks())
         block.nBits = GetNextWorkRequired(pindexPrev, &block);
 }
 
@@ -2700,14 +2700,11 @@ bool AcceptBlockHeader(CBlockHeader& block, CValidationState& state, CBlockIndex
             return state.DoS(100, error("AcceptBlock() : forked chain older than last checkpoint (height %d)", nHeight));
 
         // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
-        if (block.nVersion < 2)
+        if (block.nVersion < 2 && 
+            CBlockIndex::IsSuperMajority(2, pindexPrev, Params().RejectBlockOutdatedMajority()))
         {
-            if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 950, 1000)) ||
-                (TestNet() && CBlockIndex::IsSuperMajority(2, pindexPrev, 75, 100)))
-            {
-                return state.Invalid(error("AcceptBlock() : rejected nVersion=1 block"),
-                                     REJECT_OBSOLETE, "bad-version");
-            }
+            return state.Invalid(error("AcceptBlock() : rejected nVersion=1 block"),
+                                 REJECT_OBSOLETE, "bad-version");
         }
     }
 
@@ -2749,19 +2746,15 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         }
 
     // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
-    if (block.nVersion >= 2)
+    // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
+    if (block.nVersion >= 2 && 
+        CBlockIndex::IsSuperMajority(2, pindex->pprev, Params().EnforceBlockUpgradeMajority()))
     {
-        // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-        if ((!TestNet() && CBlockIndex::IsSuperMajority(2, pindex->pprev, 750, 1000)) ||
-            (TestNet() && CBlockIndex::IsSuperMajority(2, pindex->pprev, 51, 100)))
-        {
-            CScript expect = CScript() << nHeight;
-            if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
-                !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
-                pindex->nStatus |= BLOCK_FAILED_VALID;
-                return state.DoS(100, error("AcceptBlock() : block height mismatch in coinbase"),
-                                 REJECT_INVALID, "bad-cb-height");
-            }
+        CScript expect = CScript() << nHeight;
+        if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
+            !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
+            pindex->nStatus |= BLOCK_FAILED_VALID;
+            return state.DoS(100, error("AcceptBlock() : block height mismatch in coinbase"), REJECT_INVALID, "bad-cb-height");
         }
     }
 
@@ -2795,10 +2788,13 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     return true;
 }
 
-bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired, unsigned int nToCheck)
+bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired)
 {
+
     // Dogecoin: temporarily disable v2 block lockin until we are ready for v2 transition
     return false;
+
+    unsigned int nToCheck = Params().ToCheckBlockUpgradeMajority();
 
     unsigned int nFound = 0;
     for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)

--- a/src/main.h
+++ b/src/main.h
@@ -895,10 +895,11 @@ public:
 
     /**
      * Returns true if there are nRequired or more blocks of minVersion or above
-     * in the last nToCheck blocks, starting at pstart and going backwards.
+     * in the last Params().ToCheckBlockUpgradeMajority() blocks, starting at pstart 
+     * and going backwards.
      */
     static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart,
-                                unsigned int nRequired, unsigned int nToCheck);
+                                unsigned int nRequired);
 
     std::string ToString() const; //moved code to main.cpp because new method required access to auxpow
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -500,7 +500,7 @@ void static DogecoinMiner(CWallet *pwallet)
     unsigned int nExtraNonce = 0;
 
     try { while (true) {
-        if (Params().NetworkID() != CChainParams::REGTEST) {
+        if (Params().MiningRequiresPeers()) {
             // Busy-wait for the network to come online so we don't waste time mining
             // on an obsolete chain. In regtest mode we expect to fly solo.
             while (vNodes.empty())
@@ -558,10 +558,9 @@ void static DogecoinMiner(CWallet *pwallet)
                     SetThreadPriority(THREAD_PRIORITY_NORMAL);
                     CheckWork(pblock, *pwallet, reservekey);
                     SetThreadPriority(THREAD_PRIORITY_LOWEST);
-                    
-                    // In regression test mode, stop mining after a block is found. This
-                    // allows developers to controllably generate a block on demand.
-                    if (Params().NetworkID() == CChainParams::REGTEST)
+
+                    // In regression test mode, stop mining after a block is found.
+                    if (Params().MineBlocksOnDemand())
                         throw boost::thread_interrupted();
                     
                     break;
@@ -603,7 +602,8 @@ void static DogecoinMiner(CWallet *pwallet)
 
             // Check for stop or if block needs to be rebuilt
             boost::this_thread::interruption_point();
-            if (vNodes.empty() && Params().NetworkID() != CChainParams::REGTEST)
+            // Regtest mode doesn't require peers
+            if (vNodes.empty() && Params().MiningRequiresPeers())
                 break;
             if (pblock->nNonce >= 0xffff0000)
                 break;
@@ -615,7 +615,7 @@ void static DogecoinMiner(CWallet *pwallet)
             // Update nTime every few seconds
             UpdateTime(*pblock, pindexPrev);
             nBlockTime = ByteReverse(pblock->nTime);
-            if (TestNet())
+            if (Params().AllowMinDifficultyBlocks())
             {
                 // Changing pblock->nTime can change work required on testnet:
                 nBlockBits = ByteReverse(pblock->nBits);
@@ -635,8 +635,9 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
     static boost::thread_group* minerThreads = NULL;
 
     if (nThreads < 0) {
-        if (Params().NetworkID() == CChainParams::REGTEST)
-            nThreads = 1;
+        // In regtest threads defaults to 1
+        if (Params().DefaultMinerThreads())
+            nThreads = Params().DefaultMinerThreads();
         else
             nThreads = boost::thread::hardware_concurrency();
     }

--- a/src/net.h
+++ b/src/net.h
@@ -141,7 +141,7 @@ struct LocalServiceInfo {
 };
 
 extern CCriticalSection cs_mapLocalHost;
-extern map<CNetAddr, LocalServiceInfo> mapLocalHost;
+extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 
 class CNodeStats
 {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -5,6 +5,7 @@
 
 #include "protocol.h"
 
+#include "chainparams.h"
 #include "util.h"
 
 #ifndef WIN32

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -13,7 +13,6 @@
 #ifndef __INCLUDED_PROTOCOL_H__
 #define __INCLUDED_PROTOCOL_H__
 
-#include "chainparams.h"
 #include "netbase.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -21,6 +20,8 @@
 
 #include <stdint.h>
 #include <string>
+
+#define MESSAGE_START_SIZE 4
 
 /** Message header.
  * (4) message start.

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -495,6 +495,17 @@ bool PaymentServer::readPaymentRequest(const QString& filename, PaymentRequestPl
     return request.parse(data);
 }
 
+std::string PaymentServer::mapNetworkIdToName(CChainParams::Network networkId)
+{
+    if (networkId == CChainParams::MAIN)
+        return "main";
+    if (networkId == CChainParams::TESTNET)
+        return "test";
+    if (networkId == CChainParams::REGTEST)
+        return "regtest";
+    return "";
+}
+
 bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient)
 {
     if (!optionsModel)
@@ -504,8 +515,11 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
         const payments::PaymentDetails& details = request.getDetails();
         
         // Payment request network matches client network?
-        if ((details.genesis() == "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691" && TestNet()) ||
-            (details.genesis() == "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e" && !TestNet()))
+
+        //if ((details.genesis() == "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691" && TestNet()) ||
+        //    (details.genesis() == "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e" && !TestNet()))
+
+        if (details.network() != mapNetworkIdToName(Params().NetworkID()))
         {
             emit message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
                 CClientUIInterface::MSG_ERROR);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -495,17 +495,6 @@ bool PaymentServer::readPaymentRequest(const QString& filename, PaymentRequestPl
     return request.parse(data);
 }
 
-std::string PaymentServer::mapNetworkIdToName(CChainParams::Network networkId)
-{
-    if (networkId == CChainParams::MAIN)
-        return "main";
-    if (networkId == CChainParams::TESTNET)
-        return "test";
-    if (networkId == CChainParams::REGTEST)
-        return "regtest";
-    return "";
-}
-
 bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient)
 {
     if (!optionsModel)
@@ -515,11 +504,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
         const payments::PaymentDetails& details = request.getDetails();
         
         // Payment request network matches client network?
-
-        //if ((details.genesis() == "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691" && TestNet()) ||
-        //    (details.genesis() == "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e" && !TestNet()))
-
-        if (details.network() != mapNetworkIdToName(Params().NetworkID()))
+        if (details.genesis() != Params().HashGenesisBlock().GetHex())
         {
             emit message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
                 CClientUIInterface::MSG_ERROR);

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -118,6 +118,7 @@ protected:
 
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);
+    std::string mapNetworkIdToName(CChainParams::Network networkId);
     bool processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
 

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -118,7 +118,6 @@ protected:
 
 private:
     static bool readPaymentRequest(const QString& filename, PaymentRequestPlus& request);
-    std::string mapNetworkIdToName(CChainParams::Network networkId);
     bool processPaymentRequest(PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -663,7 +663,7 @@ Value getworkaux(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Dogecoin is downloading blocks...");
     
     // We use height plus one because we're testing the next block
-    if ((chainActive.Tip()->nHeight+1) < GetAuxPowStartBlock()) {
+    if ((chainActive.Tip()->nHeight+1) < Params().GetAuxPowStartBlock()) {
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "getworkaux method is not available until switch-over block.");
     }
 
@@ -829,7 +829,7 @@ Value getauxblock(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Dogecoin is downloading blocks...");
     
     // We use height plus one because we're testing the next block
-    if ((chainActive.Tip()->nHeight+1) < GetAuxPowStartBlock()) {
+    if ((chainActive.Tip()->nHeight+1) < Params().GetAuxPowStartBlock()) {
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "getauxblock method is not available until switch-over block.");
     }
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -178,7 +178,7 @@ Value setgenerate(const Array& params, bool fHelp)
     }
 
     // -regtest mode: don't return until nGenProcLimit blocks are generated
-    if (fGenerate && Params().NetworkID() == CChainParams::REGTEST)
+    if (fGenerate && Params().MineBlocksOnDemand())
     {
         int nHeightStart = 0;
         int nHeightEnd = 0;
@@ -269,7 +269,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("genproclimit",     (int)GetArg("-genproclimit", -1)));
     obj.push_back(Pair("networkhashps",    getnetworkhashps(params, false)));
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
-    obj.push_back(Pair("testnet",          TestNet()));
+    obj.push_back(Pair("testnet",          Params().RPCisTestNet()));
 #ifdef ENABLE_WALLET
     obj.push_back(Pair("generate",         getgenerate(params, false)));
     obj.push_back(Pair("hashespersec",     gethashespersec(params, false)));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -73,7 +73,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (proxy.first.IsValid() ? proxy.first.ToStringIPPort() : string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("testnet",       TestNet()));
+    obj.push_back(Pair("testnet",       Params().RPCisTestNet()));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));


### PR DESCRIPTION
By removing the TestNet() and RegTest() functions, this change attempts to enforce chain-agnostic coding throughout the source. This helps making the code easier to understand, because we will now code against properties of the active chain, instead of implicitly against the identity of the chain. 

The ultimate benefit, since this makes chain conditions throughout the code explicit, is that we don't have to spend time wondering: 
> why was this ```if (!TestNet())``` condition here again?

This PR is part 1 of a series of Pull Requests on this subject and is fully functional. There are still a lot of chain identity conditions inside the code, but to retain optimal compliance with bitcoin/bitcoin, other changes will have to be pulled in between this part and others. Subsequent PRs in this series will implement this principle further throughout the code, including PoW parameterization, qt client styling and get.*info rpc replies.

##### Changes pulled in from bitcoin/bitcoin
- Get rid of TestNet()
- Get rid of RegTest()
- Replace virtual methods with static attributes in chainparams.h
- Move majority constants to chainparams
- Add RPCisTestNet chain parameter (for compatibility, to be depreciated)
- Add RequireStandard chain parameter
- Add AllowMinDifficultyBlocks chain parameter
- Add DefaultCheckMemPool chain parameter
- Add DefaultMinerThreads chain parameter
- Add MineBlocksOnDemand chain parameter
- Add MiningRequiresPeers chain parameter

##### Dogecoin-specific changes
- Recreated Params().SimplifiedRewards(), without overrides.
- Moved GetAuxPowStartBlock() from main.cpp to a Params() member and remove the constants AUXPOW_START_MAINNET and AUXPOW_START_TESTNET from core.h as they are now unused.
- Created Params().AllowSelfAuxParent() to indicate whether a chain allows blocks to be formed with our own chain as parent (currently testnets allow this, mainnet does not.)
- Created Params().GetMinDifficultyAllowedStartBlock() which indicates from which block post-DigiShield min difficulty blocks are allowed, formerly signified by nTestnetResetTargetFix in main.cpp.
- Created a helper function AllowMinDifficultyForBlock() in main.cpp to clean up GetNextWorkRequired().
- Got rid of all TestNet() calls and replaced them by any of the above CChainParams based functions, as TestNet() doesn't exist anymore.
- Check network match against PaymentDetails.genesis()
- remove PaymentServer::mapNetworkIdToName() because we don't use network names in payment requests. (this is removed in bitcoin/bitcoin 0.10 in a subsequent PR too)

