### PR TITLE
bitcoin-cli, rpcclient: prefer EXIT_FAILURE cstdlib constant

### DIFF
--- a/src/dogecoin-cli.cpp
+++ b/src/dogecoin-cli.cpp
@@ -63,17 +63,17 @@ int main(int argc, char* argv[])
     try
     {
         if(!AppInitRPC(argc, argv))
-            return abs(RPC_MISC_ERROR);
+            return EXIT_FAILURE;
     }
     catch (std::exception& e) {
         PrintExceptionContinue(&e, "AppInitRPC()");
-        return abs(RPC_MISC_ERROR);
+        return EXIT_FAILURE;
     } catch (...) {
         PrintExceptionContinue(NULL, "AppInitRPC()");
-        return abs(RPC_MISC_ERROR);
+        return EXIT_FAILURE;
     }
 
-    int ret = abs(RPC_MISC_ERROR);
+    int ret = EXIT_FAILURE;
     try
     {
         ret = CommandLineRPC(argc, argv);

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -233,7 +233,7 @@ int CommandLineRPC(int argc, char *argv[])
     }
     catch (std::exception& e) {
         strPrint = string("error: ") + e.what();
-        nRet = abs(RPC_MISC_ERROR);
+        nRet = EXIT_FAILURE;
     }
     catch (...) {
         PrintExceptionContinue(NULL, "CommandLineRPC()");


### PR DESCRIPTION
A more complex construction via abs() yields the same end result.

Rebased-From: 34ff109
Rebased-By: Wladimir J. van der Laan <laanwj@gmail.com>