### PR TITLE
add OpenSSL RAND_cleanup() on OpenSSL shutdown

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -125,15 +125,17 @@ public:
         CRYPTO_set_locking_callback(locking_callback);
 
 #ifdef WIN32
-        // Seed random number generator with screen scrape and other hardware sources
+        // Seed OpenSSL PRNG with current contents of the screen
         RAND_screen();
 #endif
 
-        // Seed random number generator with performance counter
+        // Seed OpenSSL PRNG with performance counter
         RandAddSeed();
     }
     ~CInit()
     {
+        // Securely erase the memory used by the PRNG
+        RAND_cleanup();
         // Shutdown OpenSSL library multithreading support
         CRYPTO_set_locking_callback(NULL);
         for (int i = 0; i < CRYPTO_num_locks(); i++)


### PR DESCRIPTION
- to securely erase the memory used by the PNRG
- also rework 2 comments in OpenSSL init