### PR TITLE
Bugfix: strerror_r can return an error, and if it does, POSIX does not s...

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -1261,7 +1261,8 @@ std::string NetworkErrorString(int err)
 #ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
     s = strerror_r(err, buf, sizeof(buf));
 #else /* POSIX variant always returns message in buffer */
-    (void) strerror_r(err, buf, sizeof(buf));
+    if (strerror_r(err, buf, sizeof(buf)))
+        buf[0] = 0;
 #endif
     return strprintf("%s (%d)", s, err);
 }


### PR DESCRIPTION
...pecify the content of the buffer