### PR TITLE
Set -discover=0 in regtest framework

### DIFF
--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -85,7 +85,7 @@ def initialize_chain(test_dir):
         # Create cache directories, run dogecoinds:
         for i in range(4):
             datadir=initialize_datadir("cache", i)
-            args = [ "dogecoind", "-keypool=1", "-datadir="+datadir ]
+            args = [ "dogecoind", "-keypool=1", "-datadir="+datadir, "-discover=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             dogecoind_processes.append(subprocess.Popen(args))
@@ -147,7 +147,7 @@ def start_node(i, dir, extra_args=None, rpchost=None):
     Start a dogecoind and return RPC connection to it
     """
     datadir = os.path.join(dir, "node"+str(i))
-    args = [ "dogecoind", "-datadir="+datadir, "-keypool=1" ]
+    args = [ "dogecoind", "-datadir="+datadir, "-keypool=1","-discover=0" ]
     if extra_args is not None: args.extend(extra_args)
     dogecoind_processes.append(subprocess.Popen(args))
     devnull = open("/dev/null", "w+")


### PR DESCRIPTION
The regtest framework is local, so often there is no need to
discover our external IP.  Setting -discover=0 in util.py works
around shutdown hang caused by GetExternalIP waiting in recv().