### PR TITLE
[Auto] docs: ThreadGetMyExternalIP has been removed

### DIFF
--- a/doc/coding.md
+++ b/doc/coding.md
@@ -129,8 +129,6 @@ Threads
 
 - StartNode : Starts other threads.
 
-- ThreadGetMyExternalIP : Determines outside-the-firewall IP address, sends addr message to connected peers when it determines it.
-
 - ThreadDNSAddressSeed : Loads addresses of peers from the DNS.
 
 - ThreadMapPort : Universal plug-and-play startup/shutdown


### PR DESCRIPTION
It was removed in https://github.com/bitcoin/bitcoin/pull/5161