### PR TITLE
[Auto] Perform CVerifyDB on pcoinsdbview instead of pcoinsTip

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -950,7 +950,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 }
 
                 uiInterface.InitMessage(_("Verifying blocks..."));
-                if (!CVerifyDB().VerifyDB(GetArg("-checklevel", 3),
+                if (!CVerifyDB().VerifyDB(pcoinsdbview, GetArg("-checklevel", 3),
                               GetArg("-checkblocks", 288))) {
                     strLoadError = _("Corrupted block database detected");
                     break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3361,7 +3361,7 @@ CVerifyDB::~CVerifyDB()
     uiInterface.ShowProgress("", 100);
 }
 
-bool CVerifyDB::VerifyDB(int nCheckLevel, int nCheckDepth)
+bool CVerifyDB::VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth)
 {
     LOCK(cs_main);
     if (chainActive.Tip() == NULL || chainActive.Tip()->pprev == NULL)
@@ -3374,7 +3374,7 @@ bool CVerifyDB::VerifyDB(int nCheckLevel, int nCheckDepth)
         nCheckDepth = chainActive.Height();
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
     LogPrintf("Verifying last %i blocks at level %i\n", nCheckDepth, nCheckLevel);
-    CCoinsViewCache coins(*pcoinsTip, true);
+    CCoinsViewCache coins(*coinsview, true);
     CBlockIndex* pindexState = chainActive.Tip();
     CBlockIndex* pindexFailure = NULL;
     int nGoodTransactions = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -1060,7 +1060,7 @@ class CVerifyDB {
 public:
     CVerifyDB();
     ~CVerifyDB();
-    bool VerifyDB(int nCheckLevel, int nCheckDepth);
+    bool VerifyDB(CCoinsView *coinsview, int nCheckLevel, int nCheckDepth);
 };
 
 /** An in-memory indexed chain of blocks. */

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -465,7 +465,7 @@ Value verifychain(const Array& params, bool fHelp)
     if (params.size() > 1)
         nCheckDepth = params[1].get_int();
 
-    return CVerifyDB().VerifyDB(nCheckLevel, nCheckDepth);
+    return CVerifyDB().VerifyDB(pcoinsTip, nCheckLevel, nCheckDepth);
 }
 
 Value getblockchaininfo(const Array& params, bool fHelp)


### PR DESCRIPTION
Perform CVerifyDB on pcoinsdbview instead of pcoinsTip. Bypassing the main coins cache allows more thorough checking with the same memory budget.

This has no effect on performance because everything ends up in the child cache created by VerifyDB itself.

It has bugged me ever since #4675, which effectively reduced the number of checked blocks to reduce peak memory usage.

- Pass the coinsview to use as argument to VerifyDB

- This also avoids that the first `pcoinsTip->Flush()` after VerifyDB  writes a large slew of unchanged coin records (only read by the child cache) back to the database.

For comparison:
```
Without:
2014-08-27 07:18:09 No coin database inconsistencies in last 148 blocks (61620 transactions)

With:
2014-08-27 07:12:28 No coin database inconsistencies in last 262 blocks (101764 transactions)
```
(both started with default arguments to check 282 blocks, this log message reports the actual number of blocks checked at level 3)