### PR TITLE
[Auto] Reduce maximum total coinscache size during verification

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3402,7 +3402,7 @@ bool CVerifyDB::VerifyDB(int nCheckLevel, int nCheckDepth)
             }
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
-        if (nCheckLevel >= 3 && pindex == pindexState && (coins.GetCacheSize() + pcoinsTip->GetCacheSize()) <= 2*nCoinCacheSize + 32000) {
+        if (nCheckLevel >= 3 && pindex == pindexState && (coins.GetCacheSize() + pcoinsTip->GetCacheSize()) <= nCoinCacheSize) {
             bool fClean = true;
             if (!DisconnectBlock(block, state, pindex, coins, &fClean))
                 return error("VerifyDB() : *** irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());


### PR DESCRIPTION
Due to growing coinsviewcaches, the memory usage during verification with checklevel=3 (and standard settings for dbcache) could be up to 500MiB on a 64-bit system. This is about twice the peak during reindexing, unnecessarily extending bitcoind's memory envelope.

This commit reduces the maximum total size of the caches used during verification to just nCoinCacheSize, which should be the limit.