### PR TITLE
[Auto] Check pindexBestForkBase for null

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1567,7 +1567,7 @@ void CheckForkWarningConditions()
 
     if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (chainActive.Tip()->GetBlockWork() * 30)))
     {
-        if (!fLargeWorkForkFound)
+        if (!fLargeWorkForkFound && pindexBestForkBase)
         {
             std::string strCmd = GetArg("-alertnotify", "");
             if (!strCmd.empty())
@@ -1578,7 +1578,7 @@ void CheckForkWarningConditions()
                 boost::thread t(runCommand, strCmd); // thread runs free
             }
         }
-        if (pindexBestForkTip)
+        if (pindexBestForkTip && pindexBestForkBase)
         {
             LogPrintf("CheckForkWarningConditions: Warning: Large valid fork found\n  forking the chain at height %d (%s)\n  lasting to height %d (%s).\nChain state database corruption likely.\n",
                    pindexBestForkBase->nHeight, pindexBestForkBase->phashBlock->ToString(),


### PR DESCRIPTION
This addresses an edge case where pindexBestForkBase is not previously set. Longer term, the logic further upstream in ActivateBestChainStep needs to be reworked.