### PR TITLE
[Auto] LLu is standard, but not portable. use ULL

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -259,7 +259,7 @@ uint64_t ReadCompactSize(Stream& is)
         uint64_t xSize;
         READDATA(is, xSize);
         nSizeRet = xSize;
-        if (nSizeRet < 0x100000000LLu)
+        if (nSizeRet < 0x100000000ULL)
             throw std::ios_base::failure("non-canonical ReadCompactSize()");
     }
     if (nSizeRet > (uint64_t)MAX_SIZE)


### PR DESCRIPTION
LLu is standard, but not portable with msvc. use ULL.