### PR TITLE
[Auto] Break up CAddrMan's IMPLEMENT_SERIALIZE

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -865,6 +865,35 @@ struct ser_streamplaceholder
 
 typedef std::vector<char, zero_after_free_allocator<char> > CSerializeData;
 
+class CSizeComputer
+{
+protected:
+    size_t nSize;
+
+public:
+    int nType;
+    int nVersion;
+
+    CSizeComputer(int nTypeIn, int nVersionIn) : nSize(0), nType(nTypeIn), nVersion(nVersionIn) {}
+
+    CSizeComputer& write(const char *psz, int nSize)
+    {
+        this->nSize += nSize;
+        return *this;
+    }
+
+    template<typename T>
+    CSizeComputer& operator<<(const T& obj)
+    {
+        ::Serialize(*this, obj, nType, nVersion);
+        return (*this);
+    }
+
+    size_t size() const {
+        return nSize;
+    }
+};
+
 /** Double ended buffer combining vector and stream-like interfaces.
  *
  * >> and << read and write unformatted data using the above serialization templates.


### PR DESCRIPTION
clang-format cannot deal with it, and, admittedly, it's way too big anyway.

In order not to duplicate the writing logic for computing the size, introduce a CSizeComputer in serialize.h: a minimal serializer stream implementation that only computes the number of bytes written. Due to inlining, this should be as efficient as the existing GetSerializeSize code.

I'm thinking about getting rid of IMPLEMENT_SERIALIZE entirely, and replace it with one generic method that depending on template instantiation can do either read/write/size.