### PR TITLE
[Auto] [Qt] remove ProxySocksVersion from OptionID

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -32,7 +32,6 @@ public:
         ProxyUse,               // bool
         ProxyIP,                // QString
         ProxyPort,              // int
-        ProxySocksVersion,      // int
         Fee,                    // qint64
         DisplayUnit,            // BitcoinUnits::Unit
         DisplayAddresses,       // bool


### PR DESCRIPTION
- we only support SOCKS5, so remove it