### PR TITLE
[Auto] Do not flush the cache after every block outside of IBD

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -107,7 +107,12 @@ bool CCoinsViewCache::SetCoins(const uint256 &txid, const CCoins &coins) {
 }
 
 bool CCoinsViewCache::HaveCoins(const uint256 &txid) {
-    return FetchCoins(txid) != cacheCoins.end();
+    CCoinsMap::iterator it = FetchCoins(txid);
+    // We're using vtx.empty() instead of IsPruned here for performance reasons,
+    // as we only care about the case where an transaction was replaced entirely
+    // in a reorganization (which wipes vout entirely, as opposed to spending
+    // which just cleans individual outputs).
+    return (it != cacheCoins.end() && !it->second.vout.empty());
 }
 
 uint256 CCoinsViewCache::GetBestBlock() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2152,7 +2152,7 @@ bool ConnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, C
 // Update the on-disk chain state.
 bool static WriteChainState(CValidationState &state) {
     static int64_t nLastWrite = 0;
-    if (!IsInitialBlockDownload() || pcoinsTip->GetCacheSize() > nCoinCacheSize || GetTimeMicros() > nLastWrite + 600*1000000) {
+    if (pcoinsTip->GetCacheSize() > nCoinCacheSize || (!IsInitialBlockDownload() && GetTimeMicros() > nLastWrite + 600*1000000)) {
         // Typical CCoins structures on disk are around 100 bytes in size.
         // Pushing a new one to the database can cause it to be written
         // twice (once in the log, and once in the tables). This is already


### PR DESCRIPTION
It seems the reason why jenkins has been failing for several months is that a 200-pathological-block reorg takes over 20 minutes, at which time a timeout occurs.

The reason is that since a refactor, we're now doing reorganizations in steps (and since more recently, even releasing cs_main in between if possible), which means that outside of IBD, we're dumping the entire coins database (over a million txids in the large-reorg test!) to disk, and removing it from memory after every block.

This change, in combination with a sufficiently large -dbcache may be enough to bring that time down.