### PR TITLE
Qt: Move to a monospace font for addresses

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -76,8 +76,12 @@ QString dateTimeStr(qint64 nTime)
 
 QFont bitcoinAddressFont()
 {
-    QFont font("Cursive");
-    font.setFamily("Comic Sans MS");
+    QFont font("Monospace");
+#if QT_VERSION >= 0x040800
+    font.setStyleHint(QFont::Monospace);
+#else
+    font.setStyleHint(QFont::TypeWriter);
+#endif
     return font;
 }
 


### PR DESCRIPTION
This was a fix done in upstream where they always used monospace there. I personally agree with having a monospace font on sensitive data like the addresses as they are more readable when you try copying them by hand. Therefore doing this move here.  
ACK/NACK?