### PR TITLE
Fix semantic typo in state.CorruptionPossible check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2793,7 +2793,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     int nHeight = pindex->nHeight;
 
     if (!CheckBlock(block, state, nHeight)) {
-        if (state.Invalid() && !state.CorruptionPossible()) {
+        if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
         }
         return false;


### PR DESCRIPTION
state.Invalid() is always false, check should be IsInvalid()

- Dogecoin specific change