### PR TITLE
Remove std namespace imports from header file

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/assign/list_of.hpp>
 
+using namespace std;
 using namespace boost::assign;
 
 //

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -12,13 +12,11 @@
 
 #include <vector>
 
-using namespace std;
-
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
 struct CDNSSeedData {
-    string name, host;
-    CDNSSeedData(const string &strName, const string &strHost) : name(strName), host(strHost) {}
+    std::string name, host;
+    CDNSSeedData(const std::string &strName, const std::string &strHost) : name(strName), host(strHost) {}
 };
 
 /**
@@ -51,7 +49,7 @@ public:
 
     const uint256& HashGenesisBlock() const { return hashGenesisBlock; }
     const MessageStartChars& MessageStart() const { return pchMessageStart; }
-    const vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
+    const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
     const uint256& ProofOfWorkLimit() const { return bnProofOfWorkLimit; }
     int SubsidyHalvingInterval() const { return nSubsidyHalvingInterval; }
@@ -78,14 +76,17 @@ public:
     /* RPC network identity, to be depreciated */
     bool RPCisTestNet() const { return fRPCisTestNet; }
 
-    const string& DataDir() const { return strDataDir; }
+    const std::string& DataDir() const { return strDataDir; }
     /* Make miner stop after a block is found. In RPC, don't return
      * until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
+
     Network NetworkID() const { return networkID; }
-    const vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
+
+    const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
+
     const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
-    const vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
+    const std::vector<CAddress>& FixedSeeds() const { return vFixedSeeds; }
     int RPCPort() const { return nRPCPort; }
 
     // Dogecoin specific properties
@@ -107,7 +108,7 @@ protected:
     uint256 hashGenesisBlock;
     MessageStartChars pchMessageStart;
     // Raw pub key bytes for the broadcast alert signing key.
-    vector<unsigned char> vAlertPubKey;
+    std::vector<unsigned char> vAlertPubKey;
     int nDefaultPort;
     int nRPCPort;
     uint256 bnProofOfWorkLimit;
@@ -115,13 +116,13 @@ protected:
     int nEnforceBlockUpgradeMajority;
     int nRejectBlockOutdatedMajority;
     int nToCheckBlockUpgradeMajority;
-    string strDataDir;
+    std::string strDataDir;
     int nMinerThreads;
-    vector<CDNSSeedData> vSeeds;
+    std::vector<CDNSSeedData> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     Network networkID;
     CBlock genesis;
-    vector<CAddress> vFixedSeeds;
+    std::vector<CAddress> vFixedSeeds;
     bool fRequireRPCPassword;
     bool fMiningRequiresPeers;
     bool fDefaultCheckMemPool;

--- a/src/dogecoin-cli.cpp
+++ b/src/dogecoin-cli.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/filesystem/operations.hpp>
 
+using namespace std;
 using namespace boost;
 using namespace boost::asio;
 using namespace json_spirit;

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -17,6 +17,7 @@
 #include <QDebug>
 #include <QSslCertificate>
 
+using namespace std;
 
 class SSLVerifyError : public std::runtime_error
 {

--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -24,7 +24,7 @@ public:
     PaymentRequestPlus() { }
 
     bool parse(const QByteArray& data);
-    bool SerializeToString(string* output) const;
+    bool SerializeToString(std::string* output) const;
 
     bool IsInitialized() const;
     QString getPKIType() const;

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -44,6 +44,7 @@
 #include <QUrlQuery>
 #endif
 
+using namespace std;
 using namespace boost;
 
 const int BITCOIN_IPC_CONNECT_TIMEOUT = 1000; // milliseconds

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -18,6 +18,8 @@
 #include <stdint.h>
 #include <string>
 
+using namespace std;
+
 QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
 {
     AssertLockHeld(cs_main);

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -49,6 +49,7 @@
 #include <QPainter>
 #include "walletmodel.h"
 
+using namespace std;
 
 /** "Help message" or "About" dialog box */
 HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -24,6 +24,8 @@
 #include <QSet>
 #include <QTimer>
 
+using namespace std;
+
 WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *parent) :
     QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
     transactionTableModel(0),

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -8,6 +8,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+using namespace std;
+
 BOOST_AUTO_TEST_SUITE(main_tests)
 
 /**


### PR DESCRIPTION
Hopefully to be followed up with some cleanup of .cpp files where we now import std namespace but it's not really needed :)