### PR TITLE
[minor] fix compiler warning in p2sh script test

### DIFF
--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
 
     // vout[4] is max sigops:
     CScript fifteenSigops; fifteenSigops << OP_1;
-    for (int i = 0; i < MAX_P2SH_SIGOPS; i++)
+    for (unsigned int i = 0; i < MAX_P2SH_SIGOPS; i++)
         fifteenSigops << key[i%3].GetPubKey();
     fifteenSigops << OP_15 << OP_CHECKMULTISIG;
     keystore.AddCScript(fifteenSigops);


### PR DESCRIPTION
Fixes an int->uint comparison compiler warning