### PR TITLE
ensure clean and consistent "namespace" usage

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -186,6 +186,7 @@ int CBase58Data::CompareTo(const CBase58Data& b58) const {
 }
 
 namespace {
+
     class CBitcoinAddressVisitor : public boost::static_visitor<bool> {
     private:
         CBitcoinAddress *addr;
@@ -196,7 +197,8 @@ namespace {
         bool operator()(const CScriptID &id) const { return addr->Set(id); }
         bool operator()(const CNoDestination &no) const { return false; }
     };
-};
+
+} // anon namespace
 
 bool CBitcoinAddress::Set(const CKeyID &id) {
     SetData(Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS), &id, 20);

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -14,8 +14,8 @@
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/foreach.hpp>
 
-namespace Checkpoints
-{
+namespace Checkpoints {
+
     typedef std::map<int, uint256> MapCheckpoints;
 
     // How many times we expect transactions after the last checkpoint to
@@ -170,4 +170,5 @@ namespace Checkpoints
         }
         return NULL;
     }
-}
+
+} // namespace Checkpoints

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -13,8 +13,8 @@ class uint256;
 /** Block-chain checkpoints are compiled-in sanity checks.
  * They are updated every release or three.
  */
-namespace Checkpoints
-{
+namespace Checkpoints {
+
     // Returns true if block passes checkpoint checks
     bool CheckBlock(int nHeight, const uint256& hash);
 
@@ -27,6 +27,7 @@ namespace Checkpoints
     double GuessVerificationProgress(CBlockIndex *pindex, bool fSigchecks = true);
 
     extern bool fEnabled;
-}
+
+} //namespace Checkpoints
 
 #endif

--- a/src/init.h
+++ b/src/init.h
@@ -12,7 +12,7 @@ class CWallet;
 
 namespace boost {
     class thread_group;
-};
+} // namespace boost
 
 extern CWallet* pwalletMain;
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -401,8 +401,7 @@ const unsigned char vchMaxModHalfOrder[32] = {
 
 const unsigned char vchZero[0] = {};
 
-
-}; // end of anonymous namespace
+} // anon namespace
 
 bool CKey::Check(const unsigned char *vch) {
     return CompareBigEndian(vch, 32, vchZero, 0) > 0 &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ const string strMessageMagic = "Dogecoin Signed Message:\n";
 
 // Internal stuff
 namespace {
+
     struct CBlockIndexWorkComparator
     {
         bool operator()(CBlockIndex *pa, CBlockIndex *pb) {
@@ -131,7 +132,8 @@ namespace {
     };
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> > mapBlocksInFlight;
     map<uint256, pair<NodeId, list<uint256>::iterator> > mapBlocksToDownload;
-}
+
+} // anon namespace
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -141,6 +143,7 @@ namespace {
 // These functions dispatch to one or all registered wallets
 
 namespace {
+
 struct CMainSignals {
     // Notifies listeners of updated transaction data (transaction, and optionally the block it is found in.
     boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
@@ -155,7 +158,8 @@ struct CMainSignals {
     // Tells listeners to broadcast their data.
     boost::signals2::signal<void ()> Broadcast;
 } g_signals;
-}
+
+} // anon namespace
 
 void RegisterWallet(CWalletInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CWalletInterface::SyncTransaction, pwalletIn, _1, _2));
@@ -292,7 +296,6 @@ void MarkBlockAsReceived(const uint256 &hash, NodeId nodeFrom = -1) {
             state->nLastBlockReceive = GetTimeMicros();
         mapBlocksInFlight.erase(itInFlight);
     }
-
 }
 
 // Requires cs_main.

--- a/src/net.h
+++ b/src/net.h
@@ -34,7 +34,7 @@ class CNode;
 
 namespace boost {
     class thread_group;
-}
+} // namespace boost
 
 /** The minimum number of connections to attempt to make out to other peers */
 static const int MIN_OUTBOUND_CONNECTIONS = 2;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -974,6 +974,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
 
 
 namespace {
+
 /** Wrapper that serializes like CTransaction, but with the modifications
  *  required for the signature hash done in-place
  */
@@ -1066,7 +1067,8 @@ public:
         ::Serialize(s, txTo.nLockTime, nType, nVersion);
     }
 };
-}
+
+} // anon namespace
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
@@ -1091,7 +1093,6 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
     ss << txTmp << nHashType;
     return ss.GetHash();
 }
-
 
 // Valid signature cache, to avoid doing expensive ECDSA signature checking
 // twice for every transaction (once when accepted into memory pool, and

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -80,11 +80,12 @@
 // See also: http://stackoverflow.com/questions/10020179/compilation-fail-in-boost-librairies-program-options
 //           http://clang.debian.net/status.php?version=3.0&key=CANNOT_FIND_FUNCTION
 namespace boost {
+
     namespace program_options {
         std::string to_internal(const std::string&);
     }
-}
 
+} // namespace boost
 
 using namespace std;
 


### PR DESCRIPTION
- remove some missplaced ;
- ensure end of a namespace is clearly visible
- use same formatting when using namespace