### PR TITLE
Add unit tests for calculating next difficulty

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ BITCOIN_TESTS =\
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
+  test/pow_tests.cpp \
   test/rpc_tests.cpp \
   test/script_P2SH_tests.cpp \
   test/script_tests.cpp \

--- a/src/pow.h
+++ b/src/pow.h
@@ -14,6 +14,7 @@ class CBlockHeader;
 class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nLastRetargetTime);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2015 The Dogecoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+#include "pow.h"
+#include "util.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(pow_tests)
+
+BOOST_AUTO_TEST_CASE(get_next_work_difficulty_limit)
+{
+    SelectParams(CChainParams::MAIN);
+
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1386474927; // Block # 1
+    
+    pindexLast.nHeight = 239;
+    pindexLast.nTime = 1386475638; // Block #239
+    pindexLast.nBits = 0x1e0ffff0;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1e00ffff);
+}
+
+BOOST_AUTO_TEST_CASE(get_next_work_pre_digishield)
+{
+    SelectParams(CChainParams::MAIN);
+    
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1386942008; // Block 9359
+
+    pindexLast.nHeight = 9599;
+    pindexLast.nTime = 1386954113;
+    pindexLast.nBits = 0x1c1a1206;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1c15ea59);
+}
+
+BOOST_AUTO_TEST_CASE(get_next_work_digishield)
+{
+    SelectParams(CChainParams::MAIN);
+    
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1395094427;
+
+    // First hard-fork at 145,000, which applies to block 145,001 onwards
+    pindexLast.nHeight = 145000;
+    pindexLast.nTime = 1395094679;
+    pindexLast.nBits = 0x1b499dfd;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1b671062);
+}
+
+BOOST_AUTO_TEST_CASE(get_next_work_digishield_modulated_upper)
+{
+    SelectParams(CChainParams::MAIN);
+    
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1395100835;
+
+    // Test the upper bound on modulated time using mainnet block #145,107
+    pindexLast.nHeight = 145107;
+    pindexLast.nTime = 1395101360;
+    pindexLast.nBits = 0x1b3439cd;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1b4e56b3);
+}
+
+BOOST_AUTO_TEST_CASE(get_next_work_digishield_modulated_lower)
+{
+    SelectParams(CChainParams::MAIN);
+    
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1395380517;
+
+    // Test the lower bound on modulated time using mainnet block #149,423
+    pindexLast.nHeight = 149423;
+    pindexLast.nTime = 1395380447;
+    pindexLast.nBits = 0x1b446f21;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1b335358);
+}
+
+BOOST_AUTO_TEST_CASE(get_next_work_digishield_rounding)
+{
+    SelectParams(CChainParams::MAIN);
+    
+    CBlockIndex pindexLast;
+    int64_t nLastRetargetTime = 1395094679;
+
+    // Test case for correct rounding of modulated time - this depends on
+    // handling of integer division, and is not obvious from the code
+    pindexLast.nHeight = 145001;
+    pindexLast.nTime = 1395094727;
+    pindexLast.nBits = 0x1b671062;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime), 0x1b6558a4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add new unit tests which test difficulty calculation pre and post Digishield works as expected. Requires
some refactoring to isolate the maths from the originating data.