### PR TITLE
Update openssl.org URL to include https://

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -76,5 +76,5 @@ The Dogecoin repo's [root README](https://github.com/dogecoin/dogecoin/blob/mast
 License
 ---------------------
 Distributed under the [MIT/X11 software license](http://www.opensource.org/licenses/mit-license.php).
-This product includes software developed by the OpenSSL Project for use in the [OpenSSL Toolkit](http://www.openssl.org/). This product includes
+This product includes software developed by the OpenSSL Project for use in the [OpenSSL Toolkit](https://www.openssl.org/). This product includes
 cryptographic software written by Eric Young ([eay@cryptsoft.com](mailto:eay@cryptsoft.com)), and UPnP software written by Thomas Bernard.

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -7,7 +7,7 @@ Dogecoin 1.9
 Distributed under the MIT/X11 software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in
-the OpenSSL Toolkit (http://www.openssl.org/).  This product includes
+the OpenSSL Toolkit (https://www.openssl.org/).  This product includes
 cryptographic software written by Eric Young (eay@cryptsoft.com).
 
 


### PR DESCRIPTION
Suggested by whitj00.  Fixes #4595