### PR TITLE
Can't log to debug log before chain params initialized

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -91,3 +91,7 @@ bool SelectBaseParamsFromCommandLine() {
     }
     return true;
 }
+
+bool AreBaseParamsConfigured() {
+    return pCurrentBaseParams != NULL;
+}

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -49,4 +49,10 @@ void SelectBaseParams(CBaseChainParams::Network network);
  */
 bool SelectBaseParamsFromCommandLine();
 
+/**
+ * Return true if SelectBaseParamsFromCommandLine() has been called to select
+ * a network.
+ */
+bool AreBaseParamsConfigured();
+
 #endif

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -34,6 +34,7 @@
 
 #include <boost/filesystem/operations.hpp>
 #include <QApplication>
+#include <QDebug>
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QMessageBox>
@@ -239,7 +240,7 @@ void BitcoinCore::initialize()
 {
     try
     {
-        LogPrintf("Running AppInit2 in thread\n");
+        qDebug() << __func__ << ": Running AppInit2 in thread";
         int rv = AppInit2(threadGroup);
         if(rv)
         {
@@ -260,11 +261,11 @@ void BitcoinCore::shutdown()
 {
     try
     {
-        LogPrintf("Running Shutdown in thread\n");
+        qDebug() << __func__ << ": Running Shutdown in thread";
         threadGroup.interrupt_all();
         threadGroup.join_all();
         Shutdown();
-        LogPrintf("Shutdown finished\n");
+        qDebug() << __func__ << ": Shutdown finished";
         emit shutdownResult(1);
     } catch (std::exception& e) {
         handleRunawayException(&e);
@@ -292,10 +293,10 @@ BitcoinApplication::BitcoinApplication(int &argc, char **argv):
 
 BitcoinApplication::~BitcoinApplication()
 {
-    LogPrintf("Stopping thread\n");
+    qDebug() << __func__ << ": Stopping thread";
     emit stopThread();
     coreThread->wait();
-    LogPrintf("Stopped thread\n");
+    qDebug() << __func__ << ": Stopped thread";
 
     delete window;
     window = 0;
@@ -361,13 +362,13 @@ void BitcoinApplication::startThread()
 
 void BitcoinApplication::requestInitialize()
 {
-    LogPrintf("Requesting initialize\n");
+    qDebug() << __func__ << ": Requesting initialize";
     emit requestedInitialize();
 }
 
 void BitcoinApplication::requestShutdown()
 {
-    LogPrintf("Requesting shutdown\n");
+    qDebug() << __func__ << ": Requesting shutdown";
     window->hide();
     window->setClientModel(0);
     pollShutdownTimer->stop();
@@ -389,7 +390,7 @@ void BitcoinApplication::requestShutdown()
 
 void BitcoinApplication::initializeResult(int retval)
 {
-    LogPrintf("Initialization result: %i\n", retval);
+    qDebug() << __func__ << ": Initialization result: " << retval;
     // Set exit result: 0 if successful, 1 if failure
     returnValue = retval ? 0 : 1;
     if(retval)
@@ -444,7 +445,7 @@ void BitcoinApplication::initializeResult(int retval)
 
 void BitcoinApplication::shutdownResult(int retval)
 {
-    LogPrintf("Shutdown result: %i\n", retval);
+    qDebug() << __func__ << ": Shutdown result: " << retval;
     quit(); // Exit main loop after shutdown finished
 }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -288,15 +288,17 @@ BitcoinApplication::BitcoinApplication(int &argc, char **argv):
     returnValue(0)
 {
     setQuitOnLastWindowClosed(false);
-    startThread();
 }
 
 BitcoinApplication::~BitcoinApplication()
 {
-    qDebug() << __func__ << ": Stopping thread";
-    emit stopThread();
-    coreThread->wait();
-    qDebug() << __func__ << ": Stopped thread";
+    if(coreThread)
+    {
+        qDebug() << __func__ << ": Stopping thread";
+        emit stopThread();
+        coreThread->wait();
+        qDebug() << __func__ << ": Stopped thread";
+    }
 
     delete window;
     window = 0;
@@ -343,6 +345,8 @@ void BitcoinApplication::createSplashScreen(bool isaTestNet)
 
 void BitcoinApplication::startThread()
 {
+    if(coreThread)
+        return;
     coreThread = new QThread(this);
     BitcoinCore *executor = new BitcoinCore();
     executor->moveToThread(coreThread);
@@ -363,12 +367,14 @@ void BitcoinApplication::startThread()
 void BitcoinApplication::requestInitialize()
 {
     qDebug() << __func__ << ": Requesting initialize";
+    startThread();
     emit requestedInitialize();
 }
 
 void BitcoinApplication::requestShutdown()
 {
     qDebug() << __func__ << ": Requesting shutdown";
+    startThread();
     window->hide();
     window->setClientModel(0);
     pollShutdownTimer->stop();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -293,7 +293,7 @@ int LogPrintStr(const std::string &str)
         // print to console
         ret = fwrite(str.data(), 1, str.size(), stdout);
     }
-    else if (fPrintToDebugLog)
+    else if (fPrintToDebugLog && AreBaseParamsConfigured())
     {
         static bool fStartedNewLine = true;
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);


### PR DESCRIPTION
Can't log to debug log before chain params initialized - Add a function `AreBaseParamsConfigured` and use this to check before writing to the debug log.
ui: Replace some LogPrintfs with qDebug() - These are relatively unimportant messages, so don't need to be logged without -debug=ui.
qt: Start core thread only when needed - Start the core thread only when needed for initialization or shutdown.