### PR TITLE
Log "version" message IP addresses in client connect summary

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3843,7 +3843,14 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fSuccessfullyConnected = true;
 
-        LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d\n", pfrom->cleanSubVer, pfrom->nVersion, pfrom->nStartingHeight, addrMe.ToString(), pfrom->id);
+        string remoteAddr;
+        if (fLogIPs)
+            remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
+
+        LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n",
+                  pfrom->cleanSubVer, pfrom->nVersion,
+                  pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
+                  remoteAddr);
 
         AddTimeData(pfrom->addr, nTime);
     }


### PR DESCRIPTION
The only other method of logging remote addresses is via

     -logips=1 -debug=net

which increases the logged activity by 100x or more.

Github-Pull: bitcoin/bitcoin#4608
Amended-By: Wladimir J. van der Laan <laanwj@gmail.com>