### PR TITLE
Fix a reference to scrypt.h in the Makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -97,7 +97,6 @@ BITCOIN_CORE_H = \
   rpcprotocol.h \
   rpcserver.h \
   script.h \
-  scrypt.h \
   serialize.h \
   sync.h \
   threadsafety.h \
@@ -111,7 +110,8 @@ BITCOIN_CORE_H = \
   version.h \
   walletdb.h \
   wallet.h \
-  compat/sanity.h
+  compat/sanity.h \
+  crypto/scrypt.h
 
 JSON_H = \
   json/json_spirit.h \


### PR DESCRIPTION
Fixes the (Windows?) build in Gitian. Makefiles are still weird...