### PR TITLE
Fix thread name setting

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -20,7 +20,7 @@
 
 #ifndef WIN32
 // for posix_fallocate
-#ifdef __linux_
+#ifdef __linux__
 
 #ifdef _POSIX_C_SOURCE
 #undef _POSIX_C_SOURCE
@@ -29,7 +29,7 @@
 #define _POSIX_C_SOURCE 200112L
 #include <sys/prctl.h>
 
-#endif
+#endif // __linux__
 
 #include <algorithm>
 #include <fcntl.h>


### PR DESCRIPTION
Because of a typo, thread names no longer appeared in the overview.

This was broken in bitcoin/bitcoin#2767