### PR TITLE
build: check for sys/prctl.h in the proper way

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,7 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
-AC_CHECK_HEADERS([endian.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h])
+AC_CHECK_HEADERS([endian.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
 AC_SEARCH_LIBS([getaddrinfo_a], [anl], [AC_DEFINE(HAVE_GETADDRINFO_A, 1, [Define this symbol if you have getaddrinfo_a])])
 AC_SEARCH_LIBS([inet_pton], [nsl resolv], [AC_DEFINE(HAVE_INET_PTON, 1, [Define this symbol if you have inet_pton])])
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,6 +5,10 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
 #include "util.h"
 
 #include "chainparamsbase.h"
@@ -27,7 +31,6 @@
 #endif
 
 #define _POSIX_C_SOURCE 200112L
-#include <sys/prctl.h>
 
 #endif
 
@@ -62,6 +65,10 @@
 
 #include <io.h> /* for _commit */
 #include <shlobj.h>
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
 #endif
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()


### PR DESCRIPTION
Use AC_CHECK_HEADERS to check for the header, and include it only
if detected and the subsequent HAVE_SYS_PRCTL_H is set.