### PR TITLE
Fix right alignment of amount in receive tab

### DIFF
--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -83,6 +83,11 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
                 return BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), rec->recipient.amount);
         }
     }
+    else if (role == Qt::TextAlignmentRole)
+    {
+        if (index.column() == Amount)
+            return (int)(Qt::AlignRight|Qt::AlignVCenter);
+    }
     return QVariant();
 }
 


### PR DESCRIPTION
This pulls in the only part of https://github.com/bitcoin/bitcoin/pull/4563 that we actually "need". Since we never pulled the thin space separator thing.