### PR TITLE
fix compilation error in core_io.h

### DIFF
--- a/src/core_io.h
+++ b/src/core_io.h
@@ -2,6 +2,7 @@
 #define __BITCOIN_CORE_IO_H__
 
 #include <string>
+#include <vector>
 
 class uint256;
 class CScript;

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -1,5 +1,4 @@
 
-#include <vector>
 #include "core_io.h"
 #include "core.h"
 #include "serialize.h"

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -1,5 +1,4 @@
 
-#include <vector>
 #include "core_io.h"
 #include "univalue/univalue.h"
 #include "script.h"


### PR DESCRIPTION
- error: 'vector' in namespace 'std' does not name a type
- add <vector> include in core_io.h
- remove <vector> includes from core_read.cpp and core_write.cpp