### PR TITLE
[qt] string update (batch 1)

### DIFF
--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -132,7 +132,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 DOGE</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -206,7 +206,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 DOGE</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -286,7 +286,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 DOGE</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -321,7 +321,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 DOGE</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -89,7 +89,7 @@
                  </font>
                 </property>
                 <property name="text">
-                 <string>Watchonly:</string>
+                 <string>Watch-only:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -289,10 +289,10 @@
                  <cursorShape>IBeamCursor</cursorShape>
                 </property>
                 <property name="toolTip">
-                 <string>Your current balance in watchonly addresses</string>
+                 <string>Your current balance in watch-only addresses</string>
                 </property>
                 <property name="text">
-                 <string>0 DOGE</string>
+                 <string notr="true">0 DOGE</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -314,10 +314,10 @@
                  <cursorShape>IBeamCursor</cursorShape>
                 </property>
                 <property name="toolTip">
-                 <string>Unconfirmed transactions to watchonly addresses</string>
+                 <string>Unconfirmed transactions to watch-only addresses</string>
                 </property>
                 <property name="text">
-                 <string>0 BTC</string>
+                 <string notr="true">0 BTC</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -339,10 +339,10 @@
                  <cursorShape>IBeamCursor</cursorShape>
                 </property>
                 <property name="toolTip">
-                 <string>Mined balance in watchonly addresses that has not yet matured</string>
+                 <string>Mined balance in watch-only addresses that has not yet matured</string>
                 </property>
                 <property name="text">
-                 <string>0 BTC</string>
+                 <string notr="true">0 BTC</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -383,10 +383,10 @@
                  <cursorShape>IBeamCursor</cursorShape>
                 </property>
                 <property name="toolTip">
-                 <string>Current total balance in watchonly addresses</string>
+                 <string>Current total balance in watch-only addresses</string>
                 </property>
                 <property name="text">
-                 <string>0 BTC</string>
+                 <string notr="true">0 BTC</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -317,7 +317,7 @@
                  <string>Unconfirmed transactions to watch-only addresses</string>
                 </property>
                 <property name="text">
-                 <string notr="true">0 BTC</string>
+                 <string notr="true">0 DOGE</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -342,7 +342,7 @@
                  <string>Mined balance in watch-only addresses that has not yet matured</string>
                 </property>
                 <property name="text">
-                 <string notr="true">0 BTC</string>
+                 <string notr="true">0 DOGE</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -386,7 +386,7 @@
                  <string>Current total balance in watch-only addresses</string>
                 </property>
                 <property name="text">
-                 <string notr="true">0 BTC</string>
+                 <string notr="true">0 DOGE</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -321,7 +321,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BTC</string>
+                  <string notr="true">0.00 DOGE</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -401,7 +401,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BTC</string>
+                  <string notr="true">0.00 DOGE</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -481,7 +481,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BTC</string>
+                  <string notr="true">0.00 DOGE</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -510,7 +510,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BTC</string>
+                  <string notr="true">0.00 DOGE</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -765,7 +765,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">123.456 BTC</string>
+          <string notr="true">123.456 DOGE</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -182,7 +182,7 @@ void Intro::pickDataDirectory()
                 break;
             } catch(fs::filesystem_error &e) {
                 QMessageBox::critical(0, tr("Dogecoin Core"),
-                    tr("Error: Specified data directory \"%1\" can not be created.").arg(dataDir));
+                    tr("Error: Specified data directory \"%1\" cannot be created.").arg(dataDir));
                 /* fall through, back to choosing screen */
             }
         }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -425,7 +425,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
             }
             else
                 emit message(tr("URI handling"),
-                    tr("URI can not be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters."),
+                    tr("URI cannot be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters."),
                     CClientUIInterface::ICON_WARNING);
 
             return;
@@ -439,7 +439,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
         if (!readPaymentRequest(s, request))
         {
             emit message(tr("Payment request file handling"),
-                tr("Payment request file can not be read! This can be caused by an invalid payment request file."),
+                tr("Payment request file cannot be read! This can be caused by an invalid payment request file."),
                 CClientUIInterface::ICON_WARNING);
         }
         else if (processPaymentRequest(request, recipient))
@@ -664,7 +664,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
         {
             qWarning() << "PaymentServer::netRequestFinished : Error parsing payment request";
             emit message(tr("Payment request error"),
-                tr("Payment request can not be parsed!"),
+                tr("Payment request cannot be parsed!"),
                 CClientUIInterface::MSG_ERROR);
         }
         else if (processPaymentRequest(request, recipient))


### PR DESCRIPTION
- *cannot* is more common, thus preferred to *can not*
- Use *Watch-only* instead of *Watchonly* as one word
- Remove '0 BTC' placeholder from translation
- Translate BTC to DOGE in the form sources now that those will not use locale
