### PR TITLE
[Qt] move SubstituteFonts() above ToolTipToRichTextFilter

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -385,12 +385,6 @@ void openDebugLogfile()
         QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
 }
 
-ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :
-    QObject(parent), size_threshold(size_threshold)
-{
-
-}
-
 void SubstituteFonts()
 {
 #if defined(Q_OS_MAC)
@@ -409,6 +403,13 @@ void SubstituteFonts()
         QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
 #endif
 #endif
+}
+
+ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :
+    QObject(parent),
+    size_threshold(size_threshold)
+{
+
 }
 
 bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -102,14 +102,13 @@ namespace GUIUtil
     // Open debug.log
     void openDebugLogfile();
 
+    // Replace invalid default fonts with known good ones
+    void SubstituteFonts();
+
     /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.
      */
-
-    // Replace invalid default fonts with known good ones
-    void SubstituteFonts();
-
     class ToolTipToRichTextFilter : public QObject
     {
         Q_OBJECT


### PR DESCRIPTION
- doesn't belong to the ToolTipToRichTextFilter class so move it up