### PR TITLE
build: work around ccache/autotools warning-spamming bug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -588,6 +588,9 @@ if test "x$use_ccache" != "xno"; then
   fi
   AC_MSG_RESULT($use_ccache)
 fi
+if test "x$use_ccache" = "xyes"; then
+    AX_CHECK_PREPROC_FLAG([-Qunused-arguments],[CPPFLAGS="-Qunused-arguments $CPPFLAGS"])
+fi
 
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])


### PR DESCRIPTION
When using clang and ccache, builds spew lots of:
Clang: warning: argument unused during compilation

Upstream bug: https://bugzilla.samba.org/show_bug.cgi?id=8118

This is harmless, bug annoying. If ccache is being used and the
-Qunused-arguments flag is supported (clang), use it.