### PR TITLE
qt/splashscreen: #include version.h

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -4,6 +4,7 @@
 
 #include "splashscreen.h"
 
+#include "version.h"
 #include "clientversion.h"
 #include "init.h"
 #include "ui_interface.h"


### PR DESCRIPTION
Needed to build breakage reported by Arnavion on IRC:
qt/splashscreen.cpp: In constructor 'SplashScreen::SplashScreen(const QPixmap&, Qt::WindowFlags, bool)':
qt/splashscreen.cpp:33:98: error: 'FormatFullVersion' was not declared in this scope