### PR TITLE
Update linearize.py

### DIFF
--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -26,6 +26,7 @@ output.
 
 Optional config file setting for linearize-data:
 * "netmagic": network magic number
+* "genesis_hash": Genesis hash of the used chain. Used for sanity check. (default mainnet genesis hash)
 * "max_out_sz": maximum output file size (default 1000*1000*1000)
 * "split_year": Split files when a new year is first seen, in addition to
 reaching a maximum file size.

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,16 +1,17 @@
 
-# bitcoind RPC settings (linearize-hashes)
+# dogecoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
 host=127.0.0.1
-port=8332
+port=22555
 
 # bootstrap.dat hashlist settings (linearize-hashes)
-max_height=313000
+max_height=650000
 
 # bootstrap.dat input/output settings (linearize-data)
-netmagic=f9beb4d9
-input=/home/example/.bitcoin/blocks
+netmagic=c0c0c0c0
+genesis_hash=1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691
+input=/home/example/.dogecoin/blocks
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
 split_year=1

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -179,7 +179,9 @@ if __name__ == '__main__':
 	f.close()
 
 	if 'netmagic' not in settings:
-		settings['netmagic'] = 'f9beb4d9'
+		settings['netmagic'] = 'c0c0c0c0'
+	if 'genesis_hash' not in settings:
+		settings['genesis_hash'] = '1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691'
 	if 'input' not in settings:
 		settings['input'] = 'input'
 	if 'hashlist' not in settings:
@@ -200,7 +202,7 @@ if __name__ == '__main__':
 	blkindex = get_block_hashes(settings)
 	blkset = mkblockset(blkindex)
 
-	if not "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f" in blkset:
+	if not settings['genesis_hash'] in blkset:
 		print("not found")
 	else:
 		copydata(settings, blkindex, blkset)

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -89,11 +89,11 @@ if __name__ == '__main__':
 	if 'host' not in settings:
 		settings['host'] = '127.0.0.1'
 	if 'port' not in settings:
-		settings['port'] = 8332
+		settings['port'] = 22555
 	if 'min_height' not in settings:
 		settings['min_height'] = 0
 	if 'max_height' not in settings:
-		settings['max_height'] = 313000
+		settings['max_height'] = 650000
 	if 'rpcuser' not in settings or 'rpcpassword' not in settings:
 		print "Missing username and/or password in cfg file"
 		sys.exit(1)


### PR DESCRIPTION
Successfully created a testnet bootstrap and synced from it. The error at the end of linearize-data.py is expected (see bitcoin/bitcoin#4893).  

It also pulls out the hardcoded genesis hash and makes it configurable.

Fixes #1014 

Config I used for testnet
```
# dogecoind RPC settings (linearize-hashes)
rpcuser=dogecoinrpc
rpcpassword=pass
host=127.0.0.1
port=44555

# bootstrap.dat input/output settings (linearize-data)
netmagic=fcc1b7dc
genesis_hash=bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e
input=/home/max/.dogecoin/testnet3/blocks
output_file=/home/max/Downloads/testnet_bootstrap.dat
hashlist=hashlist.txt
```