### PR TITLE
[Qt] Fix amount spinbox

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -149,6 +149,7 @@ BITCOIN_MM = \
 
 QT_MOC = \
   qt/bitcoin.moc \
+  qt/bitcoinamountfield.moc \
   qt/intro.moc \
   qt/overviewpage.moc \
   qt/rpcconsole.moc

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -24,7 +24,7 @@ public:
     explicit AmountSpinBox(QWidget *parent):
         QAbstractSpinBox(parent),
         currentUnit(BitcoinUnits::DOGE),
-        singleStep(100000) // satoshis
+        singleStep(100000000) // satoshis
     {
         setAlignment(Qt::AlignRight);
 

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -9,58 +9,185 @@
 #include "qvaluecombobox.h"
 
 #include <QApplication>
-#include <QDoubleSpinBox>
+#include <QAbstractSpinBox>
 #include <QHBoxLayout>
 #include <QKeyEvent>
-#include <qmath.h> // for qPow()
+#include <QLineEdit>
 
-/** QDoubleSpinBox that shows number group seperators.
- * In Qt 5.3+ this could be replaced with QAbstractSpinBox::setGroupSeparatorShown(true)
- * See https://bugreports.qt-project.org/browse/QTBUG-5142
- *
- * TODO: We should not use a QDoubleSpinBox at all but implement our own
- * spinbox for fixed-point numbers.
+/** QSpinBox that uses fixed-point numbers internally and uses our own
+ * formatting/parsing functions.
  */
-class AmountSpinBox: public QDoubleSpinBox
+class AmountSpinBox: public QAbstractSpinBox
 {
+    Q_OBJECT
 public:
     explicit AmountSpinBox(QWidget *parent):
-        QDoubleSpinBox(parent)
+        QAbstractSpinBox(parent),
+        currentUnit(BitcoinUnits::DOGE),
+        singleStep(100000) // satoshis
     {
+        setAlignment(Qt::AlignRight);
+
+        connect(lineEdit(), SIGNAL(textEdited(QString)), this, SIGNAL(valueChanged()));
     }
-    QString textFromValue(double value) const
+
+    QValidator::State validate(QString &text, int &pos) const
     {
-        return QLocale().toString(value, 'f', decimals());
+        if(text.isEmpty())
+            return QValidator::Intermediate;
+        bool valid = false;
+        parse(text, &valid);
+        /* Make sure we return Intermediate so that fixup() is called on defocus */
+        return valid ? QValidator::Intermediate : QValidator::Invalid;
     }
-    QValidator::State validate (QString &text, int &pos) const
+
+    void fixup(QString &input) const
     {
-        bool ok = false;
-        QValidator::State rv = QDoubleSpinBox::validate(text, pos);
-        if (rv == QValidator::Acceptable)
+        bool valid = false;
+        qint64 val = parse(input, &valid);
+        if(valid)
         {
-            // Make sure that we only return acceptable if group seperators
-            // are in the right place. If not, a fixup step is needed first so
-            // return Intermediate.
-            QLocale().toDouble(text, &ok);
-            if (!ok)
-                return QValidator::Intermediate;
+            input = BitcoinUnits::format(currentUnit, val, false, true);
+            lineEdit()->setText(input);
+        }
+    }
+
+    qint64 value(bool *valid_out=0) const
+    {
+        return parse(text(), valid_out);
+    }
+
+    void setValue(qint64 value)
+    {
+        lineEdit()->setText(BitcoinUnits::format(currentUnit, value, false, true));
+        emit valueChanged();
+    }
+
+    void stepBy(int steps)
+    {
+        bool valid = false;
+        qint64 val = value(&valid);
+        val = val + steps * singleStep;
+        val = qMin(qMax(val, Q_INT64_C(0)), BitcoinUnits::maxMoney());
+        setValue(val);
+    }
+
+    StepEnabled stepEnabled() const
+    {
+        StepEnabled rv = 0;
+        if(text().isEmpty()) // Allow step-up with empty field
+            return StepUpEnabled;
+        bool valid = false;
+        qint64 val = value(&valid);
+        if(valid)
+        {
+            if(val > 0)
+                rv |= StepDownEnabled;
+            if(val < BitcoinUnits::maxMoney())
+                rv |= StepUpEnabled;
         }
         return rv;
     }
 
-    double valueFromText(const QString& text) const
+    void setDisplayUnit(int unit)
     {
-        return QLocale().toDouble(text);
+        bool valid = false;
+        qint64 val = value(&valid);
+
+        currentUnit = unit;
+
+        if(valid)
+            setValue(val);
+        else
+            clear();
     }
+
+    void setSingleStep(qint64 step)
+    {
+        singleStep = step;
+    }
+
+    QSize minimumSizeHint() const
+    {
+        if(cachedMinimumSizeHint.isEmpty())
+        {
+            ensurePolished();
+
+            const QFontMetrics fm(fontMetrics());
+            int h = lineEdit()->minimumSizeHint().height();
+            int w = fm.width(BitcoinUnits::format(BitcoinUnits::DOGE, BitcoinUnits::maxMoney(), false, true));
+            w += 2; // cursor blinking space
+
+            QStyleOptionSpinBox opt;
+            initStyleOption(&opt);
+            QSize hint(w, h);
+            QSize extra(35, 6);
+            opt.rect.setSize(hint + extra);
+            extra += hint - style()->subControlRect(QStyle::CC_SpinBox, &opt,
+                                                    QStyle::SC_SpinBoxEditField, this).size();
+            // get closer to final result by repeating the calculation
+            opt.rect.setSize(hint + extra);
+            extra += hint - style()->subControlRect(QStyle::CC_SpinBox, &opt,
+                                                    QStyle::SC_SpinBoxEditField, this).size();
+            hint += extra;
+
+            opt.rect = rect();
+
+            cachedMinimumSizeHint = style()->sizeFromContents(QStyle::CT_SpinBox, &opt, hint, this)
+                                    .expandedTo(QApplication::globalStrut());
+        }
+        return cachedMinimumSizeHint;
+    }
+private:
+    int currentUnit;
+    qint64 singleStep;
+    mutable QSize cachedMinimumSizeHint;
+
+    /**
+     * Parse a string into a number of base monetary units and
+     * return validity.
+     * @note Must return 0 if !valid.
+     */
+    qint64 parse(const QString &text, bool *valid_out=0) const
+    {
+        qint64 val = 0;
+        bool valid = BitcoinUnits::parse(currentUnit, text, &val);
+        if(valid)
+        {
+            if(val < 0 || val > BitcoinUnits::maxMoney())
+                valid = false;
+        }
+        if(valid_out)
+            *valid_out = valid;
+        return valid ? val : 0;
+    }
+
+protected:
+    bool event(QEvent *event)
+    {
+        if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)
+        {
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if (keyEvent->key() == Qt::Key_Comma)
+            {
+                // Translate a comma into a period
+                QKeyEvent periodKeyEvent(event->type(), Qt::Key_Period, keyEvent->modifiers(), ".", keyEvent->isAutoRepeat(), keyEvent->count());
+                return QAbstractSpinBox::event(&periodKeyEvent);
+            }
+        }
+        return QAbstractSpinBox::event(event);
+    }
+
+signals:
+    void valueChanged();
 };
+
+#include "bitcoinamountfield.moc"
 
 BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     QWidget(parent),
-    amount(0),
-    currentUnit(-1)
+    amount(0)
 {
-    nSingleStep = 100000000; // satoshis
-
     amount = new AmountSpinBox(this);
     amount->installEventFilter(this);
     amount->setMaximumWidth(170);
@@ -79,19 +206,11 @@ BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     setFocusProxy(amount);
 
     // If one if the widgets changes, the combined content changes as well
-    connect(amount, SIGNAL(valueChanged(QString)), this, SIGNAL(textChanged()));
+    connect(amount, SIGNAL(valueChanged()), this, SIGNAL(valueChanged()));
     connect(unit, SIGNAL(currentIndexChanged(int)), this, SLOT(unitChanged(int)));
 
     // Set default based on configuration
     unitChanged(unit->currentIndex());
-}
-
-void BitcoinAmountField::setText(const QString &text)
-{
-    if (text.isEmpty())
-        amount->clear();
-    else
-        amount->setValue(QLocale().toDouble(text));
 }
 
 void BitcoinAmountField::clear()
@@ -102,16 +221,9 @@ void BitcoinAmountField::clear()
 
 bool BitcoinAmountField::validate()
 {
-    bool valid = true;
-    if (amount->value() == 0.0)
-        valid = false;
-    else if (!BitcoinUnits::parse(currentUnit, text(), 0))
-        valid = false;
-    else if (amount->value() > BitcoinUnits::maxAmount(currentUnit))
-        valid = false;
-
+    bool valid = false;
+    value(&valid);
     setValid(valid);
-
     return valid;
 }
 
@@ -121,14 +233,6 @@ void BitcoinAmountField::setValid(bool valid)
         amount->setStyleSheet("");
     else
         amount->setStyleSheet(STYLE_INVALID);
-}
-
-QString BitcoinAmountField::text() const
-{
-    if (amount->text().isEmpty())
-        return QString();
-    else
-        return amount->text();
 }
 
 bool BitcoinAmountField::eventFilter(QObject *object, QEvent *event)
@@ -150,18 +254,12 @@ QWidget *BitcoinAmountField::setupTabChain(QWidget *prev)
 
 qint64 BitcoinAmountField::value(bool *valid_out) const
 {
-    qint64 val_out = 0;
-    bool valid = BitcoinUnits::parse(currentUnit, text(), &val_out);
-    if (valid_out)
-    {
-        *valid_out = valid;
-    }
-    return val_out;
+    return amount->value(valid_out);
 }
 
 void BitcoinAmountField::setValue(qint64 value)
 {
-    setText(BitcoinUnits::format(currentUnit, value));
+    amount->setValue(value);
 }
 
 void BitcoinAmountField::setReadOnly(bool fReadOnly)
@@ -178,28 +276,7 @@ void BitcoinAmountField::unitChanged(int idx)
     // Determine new unit ID
     int newUnit = unit->itemData(idx, BitcoinUnits::UnitRole).toInt();
 
-    // Parse current value and convert to new unit
-    bool valid = false;
-    qint64 currentValue = value(&valid);
-
-    currentUnit = newUnit;
-
-    // Set max length after retrieving the value, to prevent truncation
-    amount->setDecimals(BitcoinUnits::decimals(currentUnit));
-    amount->setMaximum(qPow(10, BitcoinUnits::amountDigits(currentUnit)) - qPow(10, -amount->decimals()));
-    amount->setSingleStep((double)nSingleStep / (double)BitcoinUnits::factor(currentUnit));
-
-    if (valid)
-    {
-        // If value was valid, re-place it in the widget with the new unit
-        setValue(currentValue);
-    }
-    else
-    {
-        // If current value is invalid, just clear field
-        setText("");
-    }
-    setValid(true);
+    amount->setDisplayUnit(newUnit);
 }
 
 void BitcoinAmountField::setDisplayUnit(int newUnit)
@@ -209,6 +286,5 @@ void BitcoinAmountField::setDisplayUnit(int newUnit)
 
 void BitcoinAmountField::setSingleStep(qint64 step)
 {
-    nSingleStep = step;
-    unitChanged(unit->currentIndex());
+    amount->setSingleStep(step);
 }

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -8,9 +8,10 @@
 #include <QWidget>
 
 QT_BEGIN_NAMESPACE
-class QDoubleSpinBox;
 class QValueComboBox;
 QT_END_NAMESPACE
+
+class AmountSpinBox;
 
 /** Widget for entering bitcoin amounts.
   */
@@ -18,7 +19,7 @@ class BitcoinAmountField: public QWidget
 {
     Q_OBJECT
 
-    Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY textChanged USER true)
+    Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY valueChanged USER true)
 
 public:
     explicit BitcoinAmountField(QWidget *parent = 0);
@@ -49,20 +50,15 @@ public:
     QWidget *setupTabChain(QWidget *prev);
 
 signals:
-    void textChanged();
+    void valueChanged();
 
 protected:
     /** Intercept focus-in event and ',' key presses */
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
-    QDoubleSpinBox *amount;
+    AmountSpinBox *amount;
     QValueComboBox *unit;
-    int currentUnit;
-    qint64 nSingleStep;
-
-    void setText(const QString &text);
-    QString text() const;
 
 private slots:
     void unitChanged(int idx);

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -143,7 +143,15 @@ QString BitcoinUnits::format(int unit, qint64 n, bool fPlus, bool fTrim, const Q
         quotient_str.insert(0, '-');
     else if (fPlus && n >= 0)
         quotient_str.insert(0, '+');
-    return quotient_str + locale.decimalPoint() + remainder_str;
+
+    // Dogecoin-specific: Handle cases where 0 decimals are valid/required (Koinu)
+    QString final_str;
+    if (num_decimals > 0 && remainder_str.size() > 0)
+        final_str = quotient_str + locale.decimalPoint() + remainder_str;
+    else
+        final_str = quotient_str;
+
+    return final_str;
 }
 
 QString BitcoinUnits::formatWithUnit(int unit, qint64 amount, bool plussign, bool trim, const QLocale &locale)

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -87,18 +87,6 @@ qint64 BitcoinUnits::maxAmount(int unit)
     }
 }
 
-int BitcoinUnits::amountDigits(int unit)
-{
-    switch(unit)
-    {
-    case MDOGE: return 6;  // 900,000 (# digits, without commas)
-    case kDOGE: return 9;  // 900,000,000
-    case DOGE:  return 12; // 900,000,000,000
-    case Koinu: return 19; // 9,000,000,000,000,000,000
-    default: return 0;
-    }
-}
-
 int BitcoinUnits::decimals(int unit)
 {
     switch(unit)

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -4,6 +4,8 @@
 
 #include "bitcoinunits.h"
 
+#include "core.h"
+
 #include <QStringList>
 #include <QLocale>
 
@@ -230,4 +232,9 @@ QVariant BitcoinUnits::data(const QModelIndex &index, int role) const
         }
     }
     return QVariant();
+}
+
+qint64 BitcoinUnits::maxMoney()
+{
+    return MAX_MONEY;
 }

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -48,8 +48,6 @@ public:
     static qint64 factor(int unit);
     //! Max amount per unit
     static qint64 maxAmount(int unit);
-    //! Number of amount digits (to represent max number of coins)
-    static int amountDigits(int unit);
     //! Number of decimals left
     static int decimals(int unit);
     //! Format as string

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -74,6 +74,15 @@ public:
     QVariant data(const QModelIndex &index, int role) const;
     ///@}
 
+    static QString removeSpaces(QString text)
+    {
+        text.remove(' ');
+        return text;
+    }
+
+    //! Return maximum number of base units (Satoshis)
+    static qint64 maxMoney();
+
 private:
     QList<BitcoinUnits::Unit> unitlist;
 };

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -72,7 +72,7 @@ void SendCoinsEntry::setModel(WalletModel *model)
     if (model && model->getOptionsModel())
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
-    connect(ui->payAmount, SIGNAL(textChanged()), this, SIGNAL(payAmountChanged()));
+    connect(ui->payAmount, SIGNAL(valueChanged()), this, SIGNAL(payAmountChanged()));
     connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
     connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));
     connect(ui->deleteButton_s, SIGNAL(clicked()), this, SLOT(deleteClicked()));
@@ -127,6 +127,13 @@ bool SendCoinsEntry::validate()
 
     if (!ui->payAmount->validate())
     {
+        retval = false;
+    }
+
+    // Sending a zero amount is invalid
+    if (ui->payAmount->value(0) <= 0)
+    {
+        ui->payAmount->setValid(false);
         retval = false;
     }
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -34,6 +34,12 @@ SendCoinsEntry::SendCoinsEntry(QWidget *parent) :
     GUIUtil::setupAddressWidget(ui->payTo, this);
     // just a label for displaying bitcoin address(es)
     ui->payTo_is->setFont(GUIUtil::bitcoinAddressFont());
+
+    // Connect signals
+    connect(ui->payAmount, SIGNAL(valueChanged()), this, SIGNAL(payAmountChanged()));
+    connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(ui->deleteButton_s, SIGNAL(clicked()), this, SLOT(deleteClicked()));
 }
 
 SendCoinsEntry::~SendCoinsEntry()
@@ -71,11 +77,6 @@ void SendCoinsEntry::setModel(WalletModel *model)
 
     if (model && model->getOptionsModel())
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
-
-    connect(ui->payAmount, SIGNAL(valueChanged()), this, SIGNAL(payAmountChanged()));
-    connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-    connect(ui->deleteButton_is, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-    connect(ui->deleteButton_s, SIGNAL(clicked()), this, SLOT(deleteClicked()));
 
     clear();
 }

--- a/src/qt/test/bitcoinunitstests.cpp
+++ b/src/qt/test/bitcoinunitstests.cpp
@@ -97,10 +97,10 @@ void BitcoinUnitsTests::formatTests()
     QCOMPARE(BitcoinUnits::format(BitcoinUnits::DOGE, 0, false, true, locale1), QString("0.00"));
     QCOMPARE(BitcoinUnits::format(BitcoinUnits::kDOGE, 0, false, false, locale1), QString("0.00000000000"));
     QCOMPARE(BitcoinUnits::format(BitcoinUnits::MDOGE, 0, false, false, locale1), QString("0.00000000000000"));
-    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 0, false, false, locale1), QString("0.0"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 0, false, false, locale1), QString("0"));
     QCOMPARE(BitcoinUnits::format(BitcoinUnits::DOGE, 0, true, false, locale1), QString("+0.00000000"));
-    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 100000000, false, true, locale1), QString("100,000,000.0"));
-    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 100000000, true, true, locale1), QString("+100,000,000.0"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 100000000, false, true, locale1), QString("100,000,000"));
+    QCOMPARE(BitcoinUnits::format(BitcoinUnits::Koinu, 100000000, true, true, locale1), QString("+100,000,000"));
 
     QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::DOGE, 100000000000000LL, false, true, locale1), QString("1,000,000.00 DOGE"));
     QCOMPARE(BitcoinUnits::formatWithUnit(BitcoinUnits::kDOGE, 100000000000000LL, false, true, locale1), QString("1,000.00 kDOGE"));


### PR DESCRIPTION
From Bitcoin:
- Use fixed-point arithmetic instead of doubles
- Remove 1 unused function from BitcoinUnits
- Move signal connections to constructor where possible.

Dogecoin specific:
- Make "step" for amount field always 1 DOGE (was: 0.001 DOGE)
- Fix unit formatter to support Koinu