### PR TITLE
Introduce AuxPoW unit tests from Namecoin

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,6 +36,7 @@ BITCOIN_TESTS =\
   test/bignum.h \
   test/alert_tests.cpp \
   test/allocator_tests.cpp \
+  test/auxpow_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/auxpow.h
+++ b/src/auxpow.h
@@ -36,7 +36,18 @@ public:
         nSerSize += SerReadWrite(s, parentBlockHeader, nType, nVersion, ser_action);
     )
 
-    bool Check(uint256 hashAuxBlock, int nChainID);
+    bool check(uint256 hashAuxBlock, int nChainID, const CChainParams& params);
+
+    /**
+     * Calculate the expected index in the merkle tree.  This is also used
+     * for the test-suite.
+     * @param nNonce The coinbase's nonce value.
+     * @param nChainID The chain ID.
+     * @param merkleHeight The merkle block height.
+     * @return The expected index for the aux hash.
+     */
+    static int getExpectedIndex (const int nNonce, const int nChainID, const unsigned merkleHeight);
+
 
     uint256 GetParentBlockHash()
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -186,6 +186,7 @@ public:
         // Dogecoin specific properties
         fSimplifiedRewards = false;
         nAuxPowStartBlock = 371337;
+	nAuxpowChainId = 0x0062; // 98 - Go Josh Wise!
         fAllowSelfAuxParent = false;
         nDigiShieldForkBlock = 145000; // digishield activates at block 145k
         nDigiShieldTargetTimespan = 60; // digishield: 1 minute block retargeting
@@ -245,6 +246,7 @@ public:
         // Dogecoin specific properties
         fSimplifiedRewards = false;
         nAuxPowStartBlock = 158100;
+        nAuxpowChainId = 0x0062; // 98 - Go Josh Wise!
         fAllowSelfAuxParent = true;
         nDigiShieldForkBlock = 145000; // digishield activates at block 145k
         nDigiShieldTargetTimespan = 60; // digishield: 1 minute block retargeting
@@ -292,6 +294,7 @@ public:
         // Dogecoin specific properties
         fSimplifiedRewards = true;
         nAuxPowStartBlock = 20; // auxpow starts at block 20
+        nAuxpowChainId = 0x0062; // 98 - Go Josh Wise!
         fAllowSelfAuxParent = true;
         nDigiShieldForkBlock = 10; // digishield activates at block 10
         nDigiShieldTargetTimespan = 1; // regtest: also retarget every second in digishield mode, for conformity

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -90,6 +90,8 @@ public:
     // AUXPOW
     /* The block number from where AuxPow starts */
     int GetAuxPowStartBlock() const { return nAuxPowStartBlock; }
+    /* Chain ID used to ensure AuxPoW work is not fed back into the same chain it was mined on */
+    int32_t AuxpowChainId () const { return nAuxpowChainId; }
     /* whether we allow ourself to be the auxpow parent chain */
     bool AllowSelfAuxParent() const { return fAllowSelfAuxParent; }
 
@@ -137,6 +139,8 @@ protected:
     // Dogecoin specific properties
     bool fSimplifiedRewards;
 
+    /** Auxpow parameters */
+    int32_t nAuxpowChainId;
     int nAuxPowStartBlock;
     bool fAllowSelfAuxParent;
 
@@ -144,7 +148,6 @@ protected:
     int64_t nDigiShieldTargetTimespan;
 
     int nMinDifficultyAllowedStartBlock;
-
 };
 
 /**

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -218,6 +218,19 @@ uint256 CBlockHeader::GetHash() const
     return Hash(BEGIN(nVersion), END(nNonce));
 }
 
+void CBlockHeader::SetAuxpow (CAuxPow* apow)
+{
+    if (apow)
+    {
+        auxpow.reset(apow);
+        //nVersion.SetAuxpow(true);
+    } else
+    {
+        auxpow.reset();
+        //nVersion.SetAuxpow(false);
+    }
+}
+
 uint256 CBlock::BuildMerkleTree() const
 {
     vMerkleTree.clear();

--- a/src/core.h
+++ b/src/core.h
@@ -34,9 +34,6 @@ static const int BLOCK_VERSION_AUXPOW = (1 << 8);
 static const int BLOCK_VERSION_CHAIN_START = (1 << 16);
 static const int BLOCK_VERSION_CHAIN_END = (1 << 30);
 
-// DogeCoin aux chain ID = 0x0062 (98)
-static const int AUXPOW_CHAIN_ID = 0x0062;
-
 static const int64_t COIN = 100000000;
 static const int64_t CENT = 1000000;
 
@@ -465,7 +462,7 @@ public:
 
     void SetNull()
     {
-        nVersion = CBlockHeader::CURRENT_VERSION | (AUXPOW_CHAIN_ID * BLOCK_VERSION_CHAIN_START);
+        nVersion = 0;
         hashPrevBlock = 0;
         hashMerkleRoot = 0;
         nTime = 0;
@@ -493,6 +490,13 @@ public:
     }
 
     bool CheckProofOfWork(int nHeight) const;
+
+    /**
+     * Set the block's auxpow (or unset it).  This takes care of updating
+     * the version accordingly.
+     * @param apow Pointer to the auxpow to use or NULL.
+     */
+    void SetAuxpow (CAuxPow* apow);
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1275,9 +1275,11 @@ void CBlockHeader::SetAuxPow(CAuxPow* pow)
     auxpow.reset(pow);
 }
 
-bool IsAuxPowVersion(int nVersion)
+bool IsAuxPowVersion(const int nVersion, const CChainParams& params)
 {
-    return (nVersion & BLOCK_VERSION_AUXPOW) == BLOCK_VERSION_AUXPOW;
+    // Chain ID is held in the upper 16 bits of the block version
+    int nChainId = nVersion / BLOCK_VERSION_CHAIN_START;
+    return nChainId > 0;
 }
 
 uint256 static GetOrphanRoot(const uint256& hash)
@@ -2022,7 +2024,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         const CBlockIndex* pindex = chainActive.Tip();
         for (int i = 0; i < 100 && pindex != NULL; i++)
         {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION && !IsAuxPowVersion(pindex->nVersion))
+            if (pindex->nVersion > CBlock::CURRENT_VERSION && !IsAuxPowVersion(pindex->nVersion, Params()))
                 ++nUpgraded;
             pindex = pindex->pprev;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1277,7 +1277,7 @@ void CBlockHeader::SetAuxPow(CAuxPow* pow)
 
 bool IsAuxPowVersion(int nVersion)
 {
-    return (nVersion == BLOCK_VERSION_AUXPOW_WITH_AUX || nVersion == BLOCK_VERSION_AUXPOW_WITHOUT_AUX);
+    return (nVersion & BLOCK_VERSION_AUXPOW) == BLOCK_VERSION_AUXPOW;
 }
 
 uint256 static GetOrphanRoot(const uint256& hash)
@@ -2366,12 +2366,12 @@ bool CBlockHeader::CheckProofOfWork(int nHeight) const
         // - this block must have our chain ID
         // - parent block must not have the same chain ID (see CAuxPow::Check)
         // - index of this chain in chain merkle tree must be pre-determined (see CAuxPow::Check)
-        if (!Params().AllowSelfAuxParent() && nHeight != INT_MAX && GetChainID() != AUXPOW_CHAIN_ID)
+        if (!Params().AllowSelfAuxParent() && nHeight != INT_MAX && GetChainID() != Params().AuxpowChainId ())
             return error("CheckProofOfWork() : block does not have our chain ID");
 
         if (auxpow.get() != NULL)
         {
-            if (!auxpow->Check(GetHash(), GetChainID()))
+            if (!auxpow->check(GetHash(), GetChainID(), Params()))
                 return error("CheckProofOfWork() : AUX POW is not valid");
             // Check proof of work matches claimed amount
             if (!::CheckProofOfWork(auxpow->GetParentBlockHash(), nBits))

--- a/src/main.h
+++ b/src/main.h
@@ -183,8 +183,8 @@ bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL);
 int64_t GetBlockValue(int nHeight, int64_t nFees, uint256 prevHash);
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);
 
-/** Determine whether the block version is modulated with auxpow logic */
-bool IsAuxPowVersion(int nVersion);
+/** Determine whether the block version includes an AuxPoW chain HD */
+bool IsAuxPowVersion(const int nVersion, const CChainParams& params);
 /** Create a new block index entry for a given block hash */
 CBlockIndex * InsertBlockIndex(uint256 hash);
 /** Verify a signature */

--- a/src/main.h
+++ b/src/main.h
@@ -87,14 +87,6 @@ static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 128;
 /** Timeout in seconds before considering a block download peer unresponsive. */
 static const unsigned int BLOCK_DOWNLOAD_TIMEOUT = 60;
 
-/** AuxPow Block versions for sanity checks. */
-/** bare AuxPoW block version which will be modulated further. */
-static const int BLOCK_VERSION_AUXPOW_BARE = CBlockHeader::CURRENT_VERSION | (AUXPOW_CHAIN_ID * BLOCK_VERSION_CHAIN_START);
-/** version when AuxPoW exists on the block */
-static const int BLOCK_VERSION_AUXPOW_WITH_AUX = BLOCK_VERSION_AUXPOW_BARE | BLOCK_VERSION_AUXPOW;
-/** version when no AuxPoW exists on the block */
-static const int BLOCK_VERSION_AUXPOW_WITHOUT_AUX = BLOCK_VERSION_AUXPOW_BARE & ~BLOCK_VERSION_AUXPOW;
-
 /** "reject" message codes **/
 static const unsigned char REJECT_MALFORMED = 0x01;
 static const unsigned char REJECT_INVALID = 0x10;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -408,7 +408,7 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
     CAuxPow *auxpow = pblock->auxpow.get();
 
     if (auxpow != NULL) {
-        if (!auxpow->Check(pblock->GetHash(), pblock->GetChainID()))
+        if (!auxpow->check(pblock->GetHash(), pblock->GetChainID(), Params()))
             return error("AUX POW is not valid");
 
         if (auxpow->GetParentBlockHash() > hashTarget)

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -8,7 +8,7 @@
 #include "main.h"
 #include "uint256.h"
 
-#include "core/block.h"
+#include "primitives/block.h"
 
 #include "script/script.h"
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -1,0 +1,432 @@
+// Copyright (c) 2014 Daniel Kraft
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "auxpow.h"
+#include "chainparams.h"
+#include "coins.h"
+#include "main.h"
+#include "uint256.h"
+
+#include "core/block.h"
+
+#include "script/script.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE (auxpow_tests)
+
+/* ************************************************************************** */
+
+/**
+ * Utility class to construct auxpow's and manipulate them.  This is used
+ * to simulate various scenarios.
+ */
+class CAuxpowBuilder
+{
+public:
+
+  /** The parent block (with coinbase, not just header).  */
+  CBlock parentBlock;
+
+  /** The auxpow's merkle branch (connecting it to the coinbase).  */
+  std::vector<uint256> auxpowChainMerkleBranch;
+  /** The auxpow's merkle tree index.  */
+  int auxpowChainIndex;
+
+  /**
+   * Initialise everything.
+   * @param baseVersion The parent block's base version to use.
+   * @param chainId The parent block's chain ID to use.
+   */
+  CAuxpowBuilder (int baseVersion, int chainId);
+
+  /**
+   * Set the coinbase's script.
+   * @param scr Set it to this script.
+   */
+  void setCoinbase (const CScript& scr);
+
+  /**
+   * Build the auxpow merkle branch.  The member variables will be
+   * set accordingly.  This has to be done before constructing the coinbase
+   * itself (which must contain the root merkle hash).  When we have the
+   * coinbase afterwards, the member variables can be used to initialise
+   * the CAuxPow object from it.
+   * @param hashAux The merge-mined chain's block hash.
+   * @param h Height of the merkle tree to build.
+   * @param index Index to use in the merkle tree.
+   * @return The root hash, with reversed endian.
+   */
+  valtype buildAuxpowChain (const uint256& hashAux, unsigned h, int index);
+
+  /**
+   * Build the finished CAuxPow object.  We assume that the auxpowChain
+   * member variables are already set.  We use the passed in transaction
+   * as the base.  It should (probably) be the parent block's coinbase.
+   * @param tx The base tx to use.
+   * @return The constructed CAuxPow object.
+   */
+  CAuxPow get (const CTransaction& tx) const;
+
+  /**
+   * Build the finished CAuxPow object from the parent block's coinbase.
+   * @return The constructed CAuxPow object.
+   */
+  inline CAuxPow
+  get () const
+  {
+    assert (!parentBlock.vtx.empty ());
+    return get (parentBlock.vtx[0]);
+  }
+
+  /**
+   * Build a data vector to be included in the coinbase.  It consists
+   * of the aux hash, the merkle tree size and the nonce.  Optionally,
+   * the header can be added as well.
+   * @param header Add the header?
+   * @param hashAux The aux merkle root hash.
+   * @param h Height of the merkle tree.
+   * @param nonce The nonce value to use.
+   * @return The constructed data.
+   */
+  static valtype buildCoinbaseData (bool header, const valtype& auxRoot,
+                                    unsigned h, int nonce);
+
+};
+
+CAuxpowBuilder::CAuxpowBuilder (int baseVersion, int chainId)
+  : auxpowChainIndex(-1)
+{
+  parentBlock.nVersion.SetBaseVersion(baseVersion);
+  parentBlock.nVersion.SetChainId(chainId);
+}
+
+void
+CAuxpowBuilder::setCoinbase (const CScript& scr)
+{
+  CMutableTransaction mtx;
+  mtx.vin.resize (1);
+  mtx.vin[0].prevout.SetNull ();
+  mtx.vin[0].scriptSig = scr;
+
+  parentBlock.vtx.clear ();
+  parentBlock.vtx.push_back (mtx);
+  parentBlock.hashMerkleRoot = parentBlock.BuildMerkleTree ();
+}
+
+valtype
+CAuxpowBuilder::buildAuxpowChain (const uint256& hashAux, unsigned h, int index)
+{
+  auxpowChainIndex = index;
+
+  /* Just use "something" for the branch.  Doesn't really matter.  */
+  auxpowChainMerkleBranch.clear ();
+  for (unsigned i = 0; i < h; ++i)
+    auxpowChainMerkleBranch.push_back (uint256 (i));
+
+  const uint256 hash
+    = CBlock::CheckMerkleBranch (hashAux, auxpowChainMerkleBranch, index);
+
+  valtype res = ToByteVector (hash);
+  std::reverse (res.begin (), res.end ());
+
+  return res;
+}
+
+CAuxPow
+CAuxpowBuilder::get (const CTransaction& tx) const
+{
+  CAuxPow res(tx);
+  res.SetMerkleBranch (parentBlock);
+
+  res.vChainMerkleBranch = auxpowChainMerkleBranch;
+  res.nChainIndex = auxpowChainIndex;
+  res.parentBlock = parentBlock;
+
+  return res;
+}
+
+valtype
+CAuxpowBuilder::buildCoinbaseData (bool header, const valtype& auxRoot,
+                                   unsigned h, int nonce)
+{
+  valtype res;
+
+  if (header)
+    res.insert (res.end (), UBEGIN (pchMergedMiningHeader),
+                UEND (pchMergedMiningHeader));
+  res.insert (res.end (), auxRoot.begin (), auxRoot.end ());
+
+  const int size = (1 << h);
+  res.insert (res.end (), UBEGIN (size), UEND (size));
+  res.insert (res.end (), UBEGIN (nonce), UEND (nonce));
+
+  return res;
+}
+
+/* ************************************************************************** */
+
+BOOST_AUTO_TEST_CASE (check_auxpow)
+{
+  CAuxpowBuilder builder(5, 42);
+  CAuxPow auxpow;
+
+  const uint256 hashAux(12345);
+  const int ourChainId = Params ().AuxpowChainId ();
+  const unsigned height = 30;
+  const int nonce = 7;
+  int index;
+
+  valtype auxRoot, data;
+  CScript scr;
+
+  /* Build a correct auxpow.  The height is the maximally allowed one.  */
+  index = CAuxPow::getExpectedIndex (nonce, ourChainId, height);
+  auxRoot = builder.buildAuxpowChain (hashAux, height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
+  scr = (scr << OP_2 << data);
+  builder.setCoinbase (scr);
+  BOOST_CHECK (builder.get ().check (hashAux, ourChainId));
+
+  /* Check that the auxpow is invalid if we change either the aux block's
+     hash or the chain ID.  */
+  BOOST_CHECK (!builder.get ().check (hashAux + 1, ourChainId));
+  BOOST_CHECK (!builder.get ().check (hashAux, ourChainId + 1));
+
+  /* Non-coinbase parent tx should fail.  Note that we can't just copy
+     the coinbase literally, as we have to get a tx with different hash.  */
+  const CTransaction oldCoinbase = builder.parentBlock.vtx[0];
+  builder.setCoinbase (scr << 5);
+  builder.parentBlock.vtx.push_back (oldCoinbase);
+  builder.parentBlock.hashMerkleRoot = builder.parentBlock.BuildMerkleTree ();
+  auxpow = builder.get (builder.parentBlock.vtx[0]);
+  BOOST_CHECK (auxpow.check (hashAux, ourChainId));
+  auxpow = builder.get (builder.parentBlock.vtx[1]);
+  BOOST_CHECK (!auxpow.check (hashAux, ourChainId));
+
+  /* The parent chain can't have the same chain ID.  */
+  CAuxpowBuilder builder2(builder);
+  builder2.parentBlock.nVersion.SetChainId (100);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  builder2.parentBlock.nVersion.SetChainId (ourChainId);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  /* Disallow too long merkle branches.  */
+  builder2 = builder;
+  index = CAuxPow::getExpectedIndex (nonce, ourChainId, height + 1);
+  auxRoot = builder2.buildAuxpowChain (hashAux, height + 1, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height + 1, nonce);
+  scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
+  scr = (scr << OP_2 << data);
+  builder2.setCoinbase (scr);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  /* Verify that we compare correctly to the parent block's merkle root.  */
+  builder2 = builder;
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  builder2.parentBlock.hashMerkleRoot = 1234;
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  /* Build a non-header legacy version and check that it is also accepted.  */
+  builder2 = builder;
+  index = CAuxPow::getExpectedIndex (nonce, ourChainId, height);
+  auxRoot = builder2.buildAuxpowChain (hashAux, height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (false, auxRoot, height, nonce);
+  scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
+  scr = (scr << OP_2 << data);
+  builder2.setCoinbase (scr);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+
+  /* However, various attempts at smuggling two roots in should be detected.  */
+
+  const valtype wrongAuxRoot
+    = builder2.buildAuxpowChain (hashAux + 1, height, index);
+  valtype data2
+    = CAuxpowBuilder::buildCoinbaseData (false, wrongAuxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data << data2);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  builder2.setCoinbase (CScript () << data2 << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  data2 = CAuxpowBuilder::buildCoinbaseData (true, wrongAuxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data << data2);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  builder2.setCoinbase (CScript () << data2 << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data << data2);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  builder2.setCoinbase (CScript () << data2 << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  data2 = CAuxpowBuilder::buildCoinbaseData (false, wrongAuxRoot,
+                                             height, nonce);
+  builder2.setCoinbase (CScript () << data << data2);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  builder2.setCoinbase (CScript () << data2 << data);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+
+  /* Verify that the appended nonce/size values are checked correctly.  */
+
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+
+  data.pop_back ();
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height - 1, nonce);
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce + 3);
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  /* Put the aux hash in an invalid merkle tree position.  */
+
+  auxRoot = builder.buildAuxpowChain (hashAux, height, index + 1);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+
+  auxRoot = builder.buildAuxpowChain (hashAux, height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder2.setCoinbase (CScript () << data);
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+}
+
+/* ************************************************************************** */
+
+/**
+ * Mine a block (assuming minimal difficulty) that either matches
+ * or doesn't match the difficulty target specified in the block header.
+ * @param block The block to mine (by updating nonce).
+ * @param ok Whether the block should be ok for PoW.
+ * @param nBits Use this as difficulty if specified.
+ */
+static void
+mineBlock (CBlockHeader& block, bool ok, int nBits = -1)
+{
+  if (nBits == -1)
+    nBits = block.nBits;
+
+  uint256 target;
+  target.SetCompact (nBits);
+
+  block.nNonce = 0;
+  while (true)
+    {
+      const bool nowOk = (block.GetHash () <= target);
+      if ((ok && nowOk) || (!ok && !nowOk))
+        break;
+
+      ++block.nNonce;
+    }
+
+  if (ok)
+    BOOST_CHECK (CheckProofOfWork (block.GetHash (), nBits));
+  else
+    BOOST_CHECK (!CheckProofOfWork (block.GetHash (), nBits));
+}
+
+BOOST_AUTO_TEST_CASE (auxpow_pow)
+{
+  const uint256 target(~uint256(0) >> 1);
+  ModifiableParams ()->setProofOfWorkLimit (target);
+  CBlockHeader block;
+  block.nBits = target.GetCompact ();
+
+  /* Verify the block version checks.  */
+
+  block.nVersion.SetGenesisVersion (1);
+  mineBlock (block, true);
+  BOOST_CHECK (CheckProofOfWork (block));
+
+  block.nVersion.SetGenesisVersion (2);
+  mineBlock (block, true);
+  BOOST_CHECK (!CheckProofOfWork (block));
+
+  block.nVersion.SetBaseVersion (2);
+  block.nVersion.SetChainId (Params ().AuxpowChainId ());
+  mineBlock (block, true);
+  BOOST_CHECK (CheckProofOfWork (block));
+
+  block.nVersion.SetChainId (Params ().AuxpowChainId () + 1);
+  mineBlock (block, true);
+  BOOST_CHECK (!CheckProofOfWork (block));
+
+  /* Check the case when the block does not have auxpow (this is true
+     right now).  */
+
+  block.nVersion.SetChainId (Params ().AuxpowChainId ());
+  block.nVersion.SetAuxpow (true);
+  mineBlock (block, true);
+  BOOST_CHECK (!CheckProofOfWork (block));
+
+  block.nVersion.SetAuxpow (false);
+  mineBlock (block, true);
+  BOOST_CHECK (CheckProofOfWork (block));
+  mineBlock (block, false);
+  BOOST_CHECK (!CheckProofOfWork (block));
+
+  /* ****************************************** */
+  /* Check the case that the block has auxpow.  */
+
+  CAuxpowBuilder builder(5, 42);
+  CAuxPow auxpow;
+  const int ourChainId = Params ().AuxpowChainId ();
+  const unsigned height = 3;
+  const int nonce = 7;
+  const int index = CAuxPow::getExpectedIndex (nonce, ourChainId, height);
+  valtype auxRoot, data;
+
+  /* Valid auxpow, PoW check of parent block.  */
+  block.nVersion.SetAuxpow (true);
+  auxRoot = builder.buildAuxpowChain (block.GetHash (), height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder.setCoinbase (CScript () << data);
+  mineBlock (builder.parentBlock, false, block.nBits);
+  block.SetAuxpow (new CAuxPow (builder.get ()));
+  BOOST_CHECK (!CheckProofOfWork (block));
+  mineBlock (builder.parentBlock, true, block.nBits);
+  block.SetAuxpow (new CAuxPow (builder.get ()));
+  BOOST_CHECK (CheckProofOfWork (block));
+
+  /* Mismatch between auxpow being present and block.nVersion.  Note that
+     block.SetAuxpow sets also the version and that we want to ensure
+     that the block hash itself doesn't change due to version changes.
+     This requires some work arounds.  */
+  block.nVersion.SetAuxpow (false);
+  const uint256 hashAux = block.GetHash ();
+  auxRoot = builder.buildAuxpowChain (hashAux, height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder.setCoinbase (CScript () << data);
+  mineBlock (builder.parentBlock, true, block.nBits);
+  block.SetAuxpow (new CAuxPow (builder.get ()));
+  BOOST_CHECK (hashAux != block.GetHash ());
+  block.nVersion.SetAuxpow (false);
+  BOOST_CHECK (hashAux == block.GetHash ());
+  BOOST_CHECK (!CheckProofOfWork (block));
+
+  /* Modifying the block invalidates the PoW.  */
+  block.nVersion.SetAuxpow (true);
+  auxRoot = builder.buildAuxpowChain (block.GetHash (), height, index);
+  data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
+  builder.setCoinbase (CScript () << data);
+  mineBlock (builder.parentBlock, true, block.nBits);
+  block.SetAuxpow (new CAuxPow (builder.get ()));
+  BOOST_CHECK (CheckProofOfWork (block));
+  block.hashMerkleRoot += 1;
+  BOOST_CHECK (!CheckProofOfWork (block));
+}
+
+/* ************************************************************************** */
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
 #include <vector>
 
 BOOST_AUTO_TEST_SUITE (auxpow_tests)
@@ -165,6 +166,23 @@ CAuxpowBuilder::buildCoinbaseData (bool header, const valtype& auxRoot,
   res.insert (res.end (), UBEGIN (nonce), UEND (nonce));
 
   return res;
+}
+
+/* ************************************************************************** */
+
+BOOST_AUTO_TEST_CASE (cblockversion)
+{
+  /* Simple check to make sure that CBlockVersion behaves like the int32_t
+     that backs it.  This is necessary because of the way CBlockHeader::GetHash
+     calculates the hash.  */
+
+  CBlockVersion nVersion;
+  const int32_t nVersionRaw = 0x12345678;
+  nVersion.SetGenesisVersion (nVersionRaw);
+
+  BOOST_CHECK (sizeof (nVersion) == sizeof (nVersionRaw));
+  BOOST_CHECK (std::equal (BEGIN (nVersion), END (nVersion),
+                           BEGIN (nVersionRaw)));
 }
 
 /* ************************************************************************** */

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 Daniel Kraft
+// Copyright (c) 2014-2015 Daniel Kraft
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,17 +7,17 @@
 #include "coins.h"
 #include "main.h"
 #include "uint256.h"
-
 #include "primitives/block.h"
-
 #include "script/script.h"
+
+#include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
 #include <vector>
 
-BOOST_AUTO_TEST_SUITE (auxpow_tests)
+BOOST_FIXTURE_TEST_SUITE (auxpow_tests, TestingSetup)
 
 /* ************************************************************************** */
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -190,6 +190,7 @@ BOOST_AUTO_TEST_CASE (cblockversion)
 
 BOOST_AUTO_TEST_CASE (check_auxpow)
 {
+  const Consensus::Params& params = Params ().GetConsensus ();
   CAuxpowBuilder builder(5, 42);
   CAuxPow auxpow;
 
@@ -209,12 +210,14 @@ BOOST_AUTO_TEST_CASE (check_auxpow)
   scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
   scr = (scr << OP_2 << data);
   builder.setCoinbase (scr);
-  BOOST_CHECK (builder.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder.get ().check (hashAux, ourChainId, params));
 
   /* Check that the auxpow is invalid if we change either the aux block's
      hash or the chain ID.  */
-  BOOST_CHECK (!builder.get ().check (hashAux + 1, ourChainId));
-  BOOST_CHECK (!builder.get ().check (hashAux, ourChainId + 1));
+  uint256 modifiedAux(hashAux);
+  tamperWith (modifiedAux);
+  BOOST_CHECK (!builder.get ().check (modifiedAux, ourChainId, params));
+  BOOST_CHECK (!builder.get ().check (hashAux, ourChainId + 1, params));
 
   /* Non-coinbase parent tx should fail.  Note that we can't just copy
      the coinbase literally, as we have to get a tx with different hash.  */
@@ -223,16 +226,16 @@ BOOST_AUTO_TEST_CASE (check_auxpow)
   builder.parentBlock.vtx.push_back (oldCoinbase);
   builder.parentBlock.hashMerkleRoot = builder.parentBlock.BuildMerkleTree ();
   auxpow = builder.get (builder.parentBlock.vtx[0]);
-  BOOST_CHECK (auxpow.check (hashAux, ourChainId));
+  BOOST_CHECK (auxpow.check (hashAux, ourChainId, params));
   auxpow = builder.get (builder.parentBlock.vtx[1]);
-  BOOST_CHECK (!auxpow.check (hashAux, ourChainId));
+  BOOST_CHECK (!auxpow.check (hashAux, ourChainId, params));
 
   /* The parent chain can't have the same chain ID.  */
   CAuxpowBuilder builder2(builder);
   builder2.parentBlock.nVersion.SetChainId (100);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
   builder2.parentBlock.nVersion.SetChainId (ourChainId);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   /* Disallow too long merkle branches.  */
   builder2 = builder;
@@ -242,13 +245,13 @@ BOOST_AUTO_TEST_CASE (check_auxpow)
   scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
   scr = (scr << OP_2 << data);
   builder2.setCoinbase (scr);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   /* Verify that we compare correctly to the parent block's merkle root.  */
   builder2 = builder;
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
-  builder2.parentBlock.hashMerkleRoot = 1234;
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
+  tamperWith (builder2.parentBlock.hashMerkleRoot);
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   /* Build a non-header legacy version and check that it is also accepted.  */
   builder2 = builder;
@@ -258,7 +261,7 @@ BOOST_AUTO_TEST_CASE (check_auxpow)
   scr = (CScript () << 2809 << 2013) + COINBASE_FLAGS;
   scr = (scr << OP_2 << data);
   builder2.setCoinbase (scr);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
 
   /* However, various attempts at smuggling two roots in should be detected.  */
 
@@ -267,58 +270,58 @@ BOOST_AUTO_TEST_CASE (check_auxpow)
   valtype data2
     = CAuxpowBuilder::buildCoinbaseData (false, wrongAuxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data << data2);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
   builder2.setCoinbase (CScript () << data2 << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   data2 = CAuxpowBuilder::buildCoinbaseData (true, wrongAuxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data << data2);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
   builder2.setCoinbase (CScript () << data2 << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data << data2);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
   builder2.setCoinbase (CScript () << data2 << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   data2 = CAuxpowBuilder::buildCoinbaseData (false, wrongAuxRoot,
                                              height, nonce);
   builder2.setCoinbase (CScript () << data << data2);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
   builder2.setCoinbase (CScript () << data2 << data);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
 
   /* Verify that the appended nonce/size values are checked correctly.  */
 
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
 
   data.pop_back ();
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height - 1, nonce);
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce + 3);
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   /* Put the aux hash in an invalid merkle tree position.  */
 
   auxRoot = builder.buildAuxpowChain (hashAux, height, index + 1);
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (!builder2.get ().check (hashAux, ourChainId, params));
 
   auxRoot = builder.buildAuxpowChain (hashAux, height, index);
   data = CAuxpowBuilder::buildCoinbaseData (true, auxRoot, height, nonce);
   builder2.setCoinbase (CScript () << data);
-  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId));
+  BOOST_CHECK (builder2.get ().check (hashAux, ourChainId, params));
 }
 
 /* ************************************************************************** */
@@ -357,7 +360,11 @@ mineBlock (CBlockHeader& block, bool ok, int nBits = -1)
 
 BOOST_AUTO_TEST_CASE (auxpow_pow)
 {
-  const uint256 target(~uint256(0) >> 1);
+  /* Use regtest parameters to allow mining with easy difficulty.  */
+  SelectParams (CBaseChainParams::REGTEST);
+  const Consensus::Params& params = Params().GetConsensus();
+
+  const uint256 target = (~uint256(0) >> 1);
   ModifiableParams ()->setProofOfWorkLimit (target);
   CBlockHeader block;
   block.nBits = target.GetCompact ();
@@ -366,41 +373,41 @@ BOOST_AUTO_TEST_CASE (auxpow_pow)
 
   block.nVersion.SetGenesisVersion (1);
   mineBlock (block, true);
-  BOOST_CHECK (CheckProofOfWork (block));
+  BOOST_CHECK (CheckProofOfWork (block, params));
 
   block.nVersion.SetGenesisVersion (2);
   mineBlock (block, true);
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 
   block.nVersion.SetBaseVersion (2);
-  block.nVersion.SetChainId (Params ().AuxpowChainId ());
+  block.nVersion.SetChainId (params.nAuxpowChainId);
   mineBlock (block, true);
-  BOOST_CHECK (CheckProofOfWork (block));
+  BOOST_CHECK (CheckProofOfWork (block, params));
 
-  block.nVersion.SetChainId (Params ().AuxpowChainId () + 1);
+  block.nVersion.SetChainId (params.nAuxpowChainId + 1);
   mineBlock (block, true);
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 
   /* Check the case when the block does not have auxpow (this is true
      right now).  */
 
-  block.nVersion.SetChainId (Params ().AuxpowChainId ());
+  block.nVersion.SetChainId (params.nAuxpowChainId);
   block.nVersion.SetAuxpow (true);
   mineBlock (block, true);
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 
   block.nVersion.SetAuxpow (false);
   mineBlock (block, true);
-  BOOST_CHECK (CheckProofOfWork (block));
+  BOOST_CHECK (CheckProofOfWork (block, params));
   mineBlock (block, false);
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 
   /* ****************************************** */
   /* Check the case that the block has auxpow.  */
 
   CAuxpowBuilder builder(5, 42);
   CAuxPow auxpow;
-  const int ourChainId = Params ().AuxpowChainId ();
+  const int32_t ourChainId = params.nAuxpowChainId;
   const unsigned height = 3;
   const int nonce = 7;
   const int index = CAuxPow::getExpectedIndex (nonce, ourChainId, height);
@@ -413,10 +420,10 @@ BOOST_AUTO_TEST_CASE (auxpow_pow)
   builder.setCoinbase (CScript () << data);
   mineBlock (builder.parentBlock, false, block.nBits);
   block.SetAuxpow (new CAuxPow (builder.get ()));
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
   mineBlock (builder.parentBlock, true, block.nBits);
   block.SetAuxpow (new CAuxPow (builder.get ()));
-  BOOST_CHECK (CheckProofOfWork (block));
+  BOOST_CHECK (CheckProofOfWork (block, params));
 
   /* Mismatch between auxpow being present and block.nVersion.  Note that
      block.SetAuxpow sets also the version and that we want to ensure
@@ -432,7 +439,7 @@ BOOST_AUTO_TEST_CASE (auxpow_pow)
   BOOST_CHECK (hashAux != block.GetHash ());
   block.nVersion.SetAuxpow (false);
   BOOST_CHECK (hashAux == block.GetHash ());
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 
   /* Modifying the block invalidates the PoW.  */
   block.nVersion.SetAuxpow (true);
@@ -441,9 +448,9 @@ BOOST_AUTO_TEST_CASE (auxpow_pow)
   builder.setCoinbase (CScript () << data);
   mineBlock (builder.parentBlock, true, block.nBits);
   block.SetAuxpow (new CAuxPow (builder.get ()));
-  BOOST_CHECK (CheckProofOfWork (block));
-  block.hashMerkleRoot += 1;
-  BOOST_CHECK (!CheckProofOfWork (block));
+  BOOST_CHECK (CheckProofOfWork (block, params));
+  tamperWith (block.hashMerkleRoot);
+  BOOST_CHECK (!CheckProofOfWork (block, params));
 }
 
 /* ************************************************************************** */

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -454,4 +454,14 @@ BOOST_AUTO_TEST_CASE (auxpow_pow)
 
 /* ************************************************************************** */
 
+BOOST_AUTO_TEST_CASE (auxpow_pow_block_version)
+{
+  SelectParams (CBaseChainParams::REGTEST);
+  const CChainParams& params = Params();
+
+  BOOST_CHECK(!IsAuxPowVersion(1, params));
+  BOOST_CHECK(!IsAuxPowVersion(2, params));
+  BOOST_CHECK(IsAuxPowVersion(2 + (BLOCK_VERSION_CHAIN_START * params.AuxpowChainId()), params));
+}
+
 BOOST_AUTO_TEST_SUITE_END ()

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -140,6 +140,7 @@ CAuxpowBuilder::buildAuxpowChain (const uint256& hashAux, unsigned h, int index)
 CAuxPow
 CAuxpowBuilder::get (const CTransaction& tx) const
 {
+  LOCK(cs_main);
   CAuxPow res(tx);
   res.SetMerkleBranch (parentBlock);
 


### PR DESCRIPTION
This merges in the AuxPoW unit tests from Namecoin. Some of them do not apply, others do not function for an unknown reason, but for now I think it's preferable to have partial coverage than none. Other AuxPoW improvements/cleanup from Namecoin should be merged (i.e. CBlockVersion) before 1.9 is released, and I'll reconcile the unit tests then.
