### PR TITLE
[regtest] make digishield and auxpow forks early

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -271,7 +271,7 @@ public:
         nToCheckBlockUpgradeMajority = 1000;
         nMinerThreads = 1;
         nTargetTimespan = 4 * 60 * 60;
-        nTargetSpacing = 60;
+        nTargetSpacing = 1; // regtest: 1 second blocks
         bnProofOfWorkLimit = ~uint256(0) >> 1;
         genesis.nTime = 1296688602;
         genesis.nBits = 0x207fffff;
@@ -291,10 +291,10 @@ public:
 
         // Dogecoin specific properties
         fSimplifiedRewards = true;
-        nAuxPowStartBlock = 5000;
+        nAuxPowStartBlock = 20; // auxpow starts at block 20
         fAllowSelfAuxParent = true;
-        nDigiShieldForkBlock = 145000; // digishield activates at block 145k
-        nDigiShieldTargetTimespan = 60; // digishield: 1 minute block retargeting
+        nDigiShieldForkBlock = 10; // digishield activates at block 10
+        nDigiShieldTargetTimespan = 1; // regtest: also retarget every second in digishield mode, for conformity
         nMinDifficultyAllowedStartBlock = 1;
     }
 };


### PR DESCRIPTION
In order to autmatically test new possibly breaking changes, we need to be able to test against digishield and auxpow earlier in the regtest chain.

Changes to the regtest chain:
- Perform the digishield fork at block 10
- Perform the auxpow fork at block 20
- Set block timing to 1 second
- Set digishield re-targeting to 1 second, to retain per-block re-targeting

The block timing change is (in my opinion) needed to keep regtest speedy. Before this change, re-targeting would only kick in after 1400 blocks (making regtest VERY slow after that point, wasting tons of cpu time on meeting block difficulty.) The choice is between either changing block timing or setting digishield re-targeting to a much higher value too. Since the latter would essentially make regtest targeting behave differently from the main chain, i decided against that, but consider this up for discussion anyway.