### PR TITLE
add missing header end comments

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef _BITCOIN_ADDRMAN
-#define _BITCOIN_ADDRMAN 1
+#define _BITCOIN_ADDRMAN
 
 #include "netbase.h"
 #include "protocol.h"
@@ -503,4 +503,4 @@ public:
     }
 };
 
-#endif
+#endif // _BITCOIN_ADDRMAN

--- a/src/alert.h
+++ b/src/alert.h
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef _BITCOINALERT_H_
-#define _BITCOINALERT_H_ 1
+#define _BITCOINALERT_H_
 
 #include "serialize.h"
 #include "sync.h"
@@ -105,4 +105,4 @@ public:
     static CAlert getAlertByHash(const uint256 &hash);
 };
 
-#endif
+#endif // _BITCOINALERT_H_

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -252,4 +252,4 @@ struct zero_after_free_allocator : public std::allocator<T>
 // This is exactly like std::string, but with a custom allocator.
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
 
-#endif
+#endif // BITCOIN_ALLOCATORS_H

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -91,4 +91,4 @@ public:
     void UpdateEmptyFull();
 };
 
-#endif /* BITCOIN_BLOOM_H */
+#endif // BITCOIN_BLOOM_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -165,4 +165,4 @@ void SelectParams(CBaseChainParams::Network network);
  */
 bool SelectParamsFromCommandLine();
 
-#endif
+#endif // BITCOIN_CHAIN_PARAMS_H

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -55,4 +55,4 @@ bool SelectBaseParamsFromCommandLine();
  */
 bool AreBaseParamsConfigured();
 
-#endif
+#endif // BITCOIN_CHAIN_PARAMS_BASE_H

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -30,4 +30,4 @@ namespace Checkpoints {
 
 } //namespace Checkpoints
 
-#endif
+#endif // BITCOIN_CHECKPOINT_H

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -191,4 +191,4 @@ public:
     }
 };
 
-#endif
+#endif // CHECKQUEUE_H

--- a/src/coins.h
+++ b/src/coins.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2013 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_COINS_H
 #define BITCOIN_COINS_H
 
@@ -379,4 +380,4 @@ private:
     CCoinsMap::const_iterator FetchCoins(const uint256 &txid) const;
 };
 
-#endif
+#endif // BITCOIN_COINS_H

--- a/src/core.h
+++ b/src/core.h
@@ -583,4 +583,4 @@ struct CBlockLocator
     }
 };
 
-#endif
+#endif // BITCOIN_CORE_H

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -127,4 +127,3 @@ vector<unsigned char> ParseHexUV(const UniValue& v, const string& strName)
         throw runtime_error(strName+" must be hexadecimal string (not '"+strHex+"')");
     return ParseHex(strHex);
 }
-

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -90,4 +90,3 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     if (hashBlock != 0)
         entry.pushKV("blockhash", hashBlock.GetHex());
 }
-

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -192,4 +192,4 @@ public:
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
 };
 
-#endif
+#endif // __CRYPTER_H__

--- a/src/dogecoin-tx.cpp
+++ b/src/dogecoin-tx.cpp
@@ -620,4 +620,3 @@ int main(int argc, char* argv[])
     }
     return ret;
 }
-

--- a/src/hash.h
+++ b/src/hash.h
@@ -159,4 +159,4 @@ uint256 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL
 
 unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash);
 
-#endif
+#endif // BITCOIN_HASH_H

--- a/src/init.h
+++ b/src/init.h
@@ -33,4 +33,4 @@ std::string HelpMessage(HelpMessageMode mode);
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 
-#endif
+#endif // BITCOIN_INIT_H

--- a/src/key.h
+++ b/src/key.h
@@ -312,4 +312,4 @@ struct CExtKey {
 /** Check that required EC support is available at runtime */
 bool ECC_InitSanityCheck(void);
 
-#endif
+#endif // BITCOIN_KEY_H

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -114,4 +114,4 @@ public:
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
 typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
 
-#endif
+#endif // BITCOIN_KEYSTORE_H

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -98,4 +98,4 @@ public:
     }
 };
 
-#endif
+#endif // BITCOIN_LIMITEDMAP_H

--- a/src/main.h
+++ b/src/main.h
@@ -1095,4 +1095,4 @@ protected:
     friend void ::UnregisterAllWallets();
 };
 
-#endif
+#endif // BITCOIN_MAIN_H

--- a/src/mruset.h
+++ b/src/mruset.h
@@ -64,4 +64,4 @@ public:
     }
 };
 
-#endif
+#endif // BITCOIN_MRUSET_H

--- a/src/net.h
+++ b/src/net.h
@@ -622,4 +622,4 @@ public:
     bool Read(CAddrMan& addr);
 };
 
-#endif
+#endif // BITCOIN_NET_H

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -185,4 +185,4 @@ bool CloseSocket(SOCKET& hSocket);
 /** Disable or enable blocking-mode for a socket */
 bool SetSocketNonBlocking(SOCKET& hSocket, bool fNonBlocking);
 
-#endif
+#endif // BITCOIN_NETBASE_H

--- a/src/noui.h
+++ b/src/noui.h
@@ -7,4 +7,4 @@
 
 extern void noui_connect();
 
-#endif
+#endif // BITCOIN_NOUI_H

--- a/src/pow.h
+++ b/src/pow.h
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
@@ -25,4 +24,4 @@ void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
 
 uint256 GetProofIncrement(unsigned int nBits);
 
-#endif
+#endif // BITCOIN_POW_H

--- a/src/rpcclient.h
+++ b/src/rpcclient.h
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef _BITCOINRPC_CLIENT_H_
-#define _BITCOINRPC_CLIENT_H_ 1
+#define _BITCOINRPC_CLIENT_H_
 
 #include "json/json_spirit_reader_template.h"
 #include "json/json_spirit_utils.h"
@@ -12,4 +12,4 @@
 
 json_spirit::Array RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams);
 
-#endif
+#endif // _BITCOINRPC_CLIENT_H_

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef _BITCOINRPC_PROTOCOL_H_
-#define _BITCOINRPC_PROTOCOL_H_ 1
+#define _BITCOINRPC_PROTOCOL_H_
 
 #include <list>
 #include <map>
@@ -159,4 +159,4 @@ json_spirit::Object JSONRPCReplyObj(const json_spirit::Value& result, const json
 std::string JSONRPCReply(const json_spirit::Value& result, const json_spirit::Value& error, const json_spirit::Value& id);
 json_spirit::Object JSONRPCError(int code, const std::string& message);
 
-#endif
+#endif // _BITCOINRPC_PROTOCOL_H_

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef _BITCOINRPC_SERVER_H_
-#define _BITCOINRPC_SERVER_H_ 1
+#define _BITCOINRPC_SERVER_H_
 
 #include "uint256.h"
 #include "rpcprotocol.h"
@@ -210,4 +210,4 @@ extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value verifychain(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getchaintips(const json_spirit::Array& params, bool fHelp);
 
-#endif
+#endif // _BITCOINRPC_SERVER_H_

--- a/src/script.h
+++ b/src/script.h
@@ -833,4 +833,4 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 // combine them intelligently and return the result.
 CScript CombineSignatures(CScript scriptPubKey, const CTransaction& txTo, unsigned int nIn, const CScript& scriptSig1, const CScript& scriptSig2);
 
-#endif
+#endif // H_BITCOIN_SCRIPT

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1405,4 +1405,4 @@ public:
     }
 };
 
-#endif
+#endif // BITCOIN_SERIALIZE_H

--- a/src/sync.h
+++ b/src/sync.h
@@ -260,5 +260,5 @@ public:
         return fHaveGrant;
     }
 };
-#endif
 
+#endif // BITCOIN_SYNC_H

--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -51,4 +51,5 @@
 #define SHARED_LOCKS_REQUIRED(...)
 #define NO_THREAD_SAFETY_ANALYSIS
 #endif  // __GNUC__
+
 #endif  // BITCOIN_THREADSAFETY_H

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -73,4 +73,4 @@ int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nTime);
 
-#endif
+#endif // BITCOIN_TIMEDATA_H

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2013 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
@@ -140,4 +141,4 @@ public:
     bool HaveCoins(const uint256 &txid) const;
 };
 
-#endif /* BITCOIN_TXMEMPOOL_H */
+#endif // BITCOIN_TXMEMPOOL_H

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -109,4 +109,4 @@ inline std::string _(const char* psz)
     return rv ? (*rv) : psz;
 }
 
-#endif
+#endif // BITCOIN_UI_INTERFACE_H

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -326,4 +326,4 @@ public:
     uint64_t GetHash(const uint256& salt) const;
 };
 
-#endif
+#endif // BITCOIN_UINT256_H

--- a/src/util.h
+++ b/src/util.h
@@ -225,4 +225,4 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
     }
 }
 
-#endif
+#endif // BITCOIN_UTIL_H

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -17,4 +17,4 @@ void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
 
-#endif
+#endif // BITCOIN_UTILTIME_H

--- a/src/version.h
+++ b/src/version.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2014 The Inutoshi developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_VERSION_H
 #define BITCOIN_VERSION_H
 
@@ -53,4 +54,4 @@ static const int MEMPOOL_GD_VERSION = 60002;
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 
-#endif
+#endif // BITCOIN_VERSION_H

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -3,6 +3,7 @@
 // Copyright (c)      2014 The Dogecoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_WALLET_H
 #define BITCOIN_WALLET_H
 
@@ -954,4 +955,4 @@ private:
     std::vector<char> _ssExtra;
 };
 
-#endif
+#endif // BITCOIN_WALLET_H

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2013 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_WALLETDB_H
 #define BITCOIN_WALLETDB_H
 


### PR DESCRIPTION
- ensures a consistent usage in header files
- also add a blank line after the copyright header where missing
- also remove orphan new-lines at the end of some files