### PR TITLE
Add detailed network info to getnetworkinfo RPC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -260,7 +260,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -maxreceivebuffer=<n>  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 5000)") + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
     strUsage += "  -onion=<ip:port>       " + _("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)") + "\n";
-    strUsage += "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (IPv4, IPv6 or Onion)") + "\n";
+    strUsage += "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)") + "\n";
     strUsage += "  -permitbaremultisig    " + _("Relay non-P2SH multisig (default: 1)") + "\n";
     strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 22556 or testnet: 44556)") + "\n";
     strUsage += "  -proxy=<ip:port>       " + _("Connect through SOCKS5 proxy") + "\n";

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -338,6 +338,26 @@ Value getnettotals(const Array& params, bool fHelp)
     return obj;
 }
 
+static Array GetNetworksInfo()
+{
+    Array networks;
+    for(int n=0; n<NET_MAX; ++n)
+    {
+        enum Network network = static_cast<enum Network>(n);
+        if(network == NET_UNROUTABLE)
+            continue;
+        proxyType proxy;
+        Object obj;
+        GetProxy(network, proxy);
+        obj.push_back(Pair("name", GetNetworkName(network)));
+        obj.push_back(Pair("limited", IsLimited(network)));
+        obj.push_back(Pair("reachable", IsReachable(network)));
+        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.ToStringIPPort() : string()));
+        networks.push_back(obj);
+    }
+    return networks;
+}
+
 Value getnetworkinfo(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -351,7 +371,13 @@ Value getnetworkinfo(const Array& params, bool fHelp)
             "  \"localservices\": \"xxxxxxxxxxxxxxxx\",   (string) the services we offer to the network\n"
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
-            "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
+            "  \"networks\": [               (array) information per network\n"
+            "      \"name\": \"xxx\",        (string) network (ipv4, ipv6 or onion)\n"
+            "      \"limited\": xxx,         (boolean) is the network limited using -onlynet?\n"
+            "      \"reachable\": xxx,       (boolean) is the network reachable?\n"
+            "      \"proxy\": \"host:port\"  (string) the proxy that is used for this network, or empty if none\n"
+            "    },\n"
+            "  ],\n"
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in btc/kb\n"
             "  \"localaddresses\": [,        (array) list of local addresses\n"
             "    \"address\": \"xxxx\",      (string) network address\n"
@@ -364,16 +390,13 @@ Value getnetworkinfo(const Array& params, bool fHelp)
             + HelpExampleRpc("getnetworkinfo", "")
         );
 
-    proxyType proxy;
-    GetProxy(NET_IPV4, proxy);
-
     Object obj;
     obj.push_back(Pair("version",       (int)CLIENT_VERSION));
     obj.push_back(Pair("protocolversion",(int)PROTOCOL_VERSION));
     obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("networks",      GetNetworksInfo()));
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
     Array localAddresses;
     {


### PR DESCRIPTION
This commit adds per-network information to the
getnetworkinfo RPC call:

- Is the network limited?
- Is the network reachable
- Which proxy is used for this network, if any

Inspired by bitcoin/bitcoin #2575.