### PR TITLE
build: fix osx+homebrew+qt5 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,7 +236,7 @@ case $host in
 
        AC_CHECK_PROG([BREW],brew, brew)
        if test x$BREW = xbrew; then
-         dnl These Homebrew packages may be bottled, meaning that they won't be found
+         dnl These Homebrew packages may be keg-only, meaning that they won't be found
          dnl in expected paths because they may conflict with system files. Ask
          dnl Homebrew where each one is located, then adjust paths accordingly.
          dnl It's safe to add these paths even if the functionality is disabled by

--- a/configure.ac
+++ b/configure.ac
@@ -236,12 +236,25 @@ case $host in
 
        AC_CHECK_PROG([BREW],brew, brew)
        if test x$BREW = xbrew; then
-         dnl add default homebrew paths
-         openssl_prefix=`$BREW --prefix openssl`
-         bdb_prefix=`$BREW --prefix berkeley-db5`
-         export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
-         CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
-         LIBS="$LIBS -L$bdb_prefix/lib"
+         dnl These Homebrew packages may be bottled, meaning that they won't be found
+         dnl in expected paths because they may conflict with system files. Ask
+         dnl Homebrew where each one is located, then adjust paths accordingly.
+         dnl It's safe to add these paths even if the functionality is disabled by
+         dnl the user (--without-wallet or --without-gui for example).
+
+         openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
+         bdb_prefix=`$BREW --prefix berkeley-db5 2>/dev/null`
+         qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
+         if test x$openssl_prefix != x; then
+           export PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+         fi
+         if test x$bdb_prefix != x; then
+           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
+           LIBS="$LIBS -L$bdb_prefix/lib"
+         fi
+         if test x$qt5_prefix != x; then
+           export PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+         fi
        fi
      else
        case $build_os in

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -398,7 +398,7 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
             # Deploy the script plugins only if QtScript is in use
             if not deploymentInfo.usesFramework("QtScript"):
                 continue
-        elif pluginDirectory == "qmltooling":
+        elif pluginDirectory == "qmltooling" or pluginDirectory == "qml1tooling":
             # Deploy the qml plugins only if QtDeclarative is in use
             if not deploymentInfo.usesFramework("QtDeclarative"):
                 continue
@@ -406,7 +406,23 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
             # Deploy the bearer plugins only if QtNetwork is in use
             if not deploymentInfo.usesFramework("QtNetwork"):
                 continue
-        
+        elif pluginDirectory == "position":
+            # Deploy the position plugins only if QtPositioning is in use
+            if not deploymentInfo.usesFramework("QtPositioning"):
+                continue
+        elif pluginDirectory == "sensors" or pluginDirectory == "sensorgestures":
+            # Deploy the sensor plugins only if QtSensors is in use
+            if not deploymentInfo.usesFramework("QtSensors"):
+                continue
+        elif pluginDirectory == "audio" or pluginDirectory == "playlistformats":
+            # Deploy the audio plugins only if QtMultimedia is in use
+            if not deploymentInfo.usesFramework("QtMultimedia"):
+                continue
+        elif pluginDirectory == "mediaservice":
+            # Deploy the mediaservice plugins only if QtMultimediaWidgets is in use
+            if not deploymentInfo.usesFramework("QtMultimediaWidgets"):
+                continue
+
         for pluginName in filenames:
             pluginPath = os.path.join(pluginDirectory, pluginName)
             if pluginName.endswith("_debug.dylib"):
@@ -424,7 +440,11 @@ def deployPlugins(appBundleInfo, deploymentInfo, strip, verbose):
                 # Deploy the opengl graphicssystem plugin only if QtOpenGL is in use
                 if not deploymentInfo.usesFramework("QtOpenGL"):
                     continue
-            
+            elif pluginPath == "accessible/libqtaccessiblequick.dylib":
+                # Deploy the accessible qtquick plugin only if QtQuick is in use
+                if not deploymentInfo.usesFramework("QtQuick"):
+                    continue
+
             plugins.append((pluginDirectory, pluginName))
     
     for pluginDirectory, pluginName in plugins:

--- a/src/m4/bitcoin_qt.m4
+++ b/src/m4/bitcoin_qt.m4
@@ -155,6 +155,13 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   fi
   CPPFLAGS=$TEMP_CPPFLAGS
   ])
+
+  if test x$use_pkgconfig$qt_bin_path = xyes; then
+    if test x$bitcoin_qt_got_major_vers = x5; then
+      qt_bin_path="`$PKG_CONFIG --variable=host_bins Qt5Core 2>/dev/null`"
+    fi
+  fi
+
   BITCOIN_QT_PATH_PROGS([MOC], [moc-qt${bitcoin_qt_got_major_vers} moc${bitcoin_qt_got_major_vers} moc], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([UIC], [uic-qt${bitcoin_qt_got_major_vers} uic${bitcoin_qt_got_major_vers} uic], $qt_bin_path)
   BITCOIN_QT_PATH_PROGS([RCC], [rcc-qt${bitcoin_qt_got_major_vers} rcc${bitcoin_qt_got_major_vers} rcc], $qt_bin_path)


### PR DESCRIPTION
Qt5 is keg-only, so configure won't find it without some help. Use brew to find out its prefix.

Also, qt5 added the host_bins variable to pkg-config, use it.

Language change to homebrew included as well.

*Dogecoin specific db change

(No yelling at me for changed wording on the thingy >_> Blame @langerhans he said to change it)
