### PR TITLE
Fixed setaccount accepting foreign address

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -231,15 +231,20 @@ Value setaccount(const Array& params, bool fHelp)
     if (params.size() > 1)
         strAccount = AccountFromValue(params[1]);
 
-    // Detect when changing the account of an address that is the 'unused current key' of another account:
-    if (pwalletMain->mapAddressBook.count(address.Get()))
+    // Only add the account if the address is yours.
+    if (IsMine(*pwalletMain, address.Get()))
     {
-        string strOldAccount = pwalletMain->mapAddressBook[address.Get()].name;
-        if (address == GetAccountAddress(strOldAccount))
-            GetAccountAddress(strOldAccount, true);
+        // Detect when changing the account of an address that is the 'unused current key' of another account:
+        if (pwalletMain->mapAddressBook.count(address.Get()))
+        {
+            string strOldAccount = pwalletMain->mapAddressBook[address.Get()].name;
+            if (address == GetAccountAddress(strOldAccount))
+                GetAccountAddress(strOldAccount, true);
+        }
+        pwalletMain->SetAddressBook(address.Get(), strAccount, "receive");
     }
-
-    pwalletMain->SetAddressBook(address.Get(), strAccount, "receive");
+    else
+        throw JSONRPCError(RPC_MISC_ERROR, "setaccount can only be used with own address");
 
     return Value::null;
 }

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -80,11 +80,15 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
 		walletdb.WriteAccount(strAccount, account);
 	});
 
-
+    CPubKey setaccountDemoPubkey = pwalletMain->GenerateNewKey();
+        CBitcoinAddress setaccountDemoAddress = CBitcoinAddress(CTxDestination(setaccountDemoPubkey.GetID()));
+        
 	/*********************************
 	 * 			setaccount
 	 *********************************/
-	BOOST_CHECK_NO_THROW(CallRPC("setaccount DEaT9KZM6b6oDZMr8pj7pWTLZSdtYZFAx8 nullaccount"));
+	BOOST_CHECK_NO_THROW(CallRPC("setaccount " + setaccountDemoAddress.ToString() + " nullaccount"));
+	/* DEaT9KZM6b6oDZMr8pj7pWTLZSdtYZFAx8 is not owned by the test wallet. */
+	BOOST_CHECK_THROW(CallRPC("setaccount DEaT9KZM6b6oDZMr8pj7pWTLZSdtYZFAx8 nullaccount"), runtime_error);
 	BOOST_CHECK_THROW(CallRPC("setaccount"), runtime_error);
 	/* DEaT9KZM6b6oDZMr8pj7pWTLZSdtYZFAx (33 chars) is an illegal address (should be 34 chars) */
 	BOOST_CHECK_THROW(CallRPC("setaccount DEaT9KZM6b6oDZMr8pj7pWTLZSdtYZFAx nullaccount"), runtime_error);


### PR DESCRIPTION
Fixed issue bitcoin/bitcoin#4209 where using setaccount with a foreign address causes the address to be added to your receiving addresses.

*Dogecoin specific changes