### PR TITLE
[QT] small Qt-only include cleanup

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -15,11 +15,11 @@
 #include "optionsmodel.h"
 
 #include "main.h" // for MAX_SCRIPTCHECK_THREADS
+#include "netbase.h"
+#include "txdb.h" // for -dbcache defaults
 #ifdef ENABLE_WALLET
 #include "wallet.h" // for CWallet::minTxFee
 #endif
-#include "netbase.h"
-#include "txdb.h" // for -dbcache defaults
 
 #include <boost/thread.hpp>
 #include <QDir>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -11,12 +11,12 @@
 #include "db.h"
 #include "main.h"
 #include "paymentserver.h"
+#include "script.h"
 #include "transactionrecord.h"
 #include "timedata.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "wallet.h"
-#include "script.h"
 
 #include <stdint.h>
 #include <string>

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -5,6 +5,8 @@
 #ifndef TRANSACTIONTABLEMODEL_H
 #define TRANSACTIONTABLEMODEL_H
 
+#include "bitcoinunits.h"
+
 #include <QAbstractTableModel>
 #include <QStringList>
 


### PR DESCRIPTION
* Excluded changes in transactiontablemodel.cpp due to the choice made not to implement SI-style. See #822 