### PR TITLE
[tests] fix partition alerts for Dogecoin

### DIFF
--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
 {
     // Test PartitionCheck
     CCriticalSection csDummy;
-    CBlockIndex indexDummy[100];
+    CBlockIndex indexDummy[800];
     CChainParams& params = Params(CBaseChainParams::MAIN);
     int64_t nPowTargetSpacing = params.GetConsensus().nPowTargetSpacing;
 
@@ -209,26 +209,26 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     // an arbitrary time:
     int64_t now = 1427379054;
     SetMockTime(now);
-    for (int i = 0; i < 100; i++)
+    for (int i = 0; i < 800; i++)
     {
         indexDummy[i].phashBlock = NULL;
         if (i == 0) indexDummy[i].pprev = NULL;
         else indexDummy[i].pprev = &indexDummy[i-1];
         indexDummy[i].nHeight = i;
-        indexDummy[i].nTime = now - (100-i)*nPowTargetSpacing;
+        indexDummy[i].nTime = now - (800-i)*nPowTargetSpacing;
         // Other members don't matter, the partition check code doesn't
         // use them
     }
 
     // Test 1: chain with blocks every nPowTargetSpacing seconds,
     // as normal, no worries:
-    PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
+    PartitionCheck(falseFunc, csDummy, &indexDummy[799], nPowTargetSpacing);
     BOOST_CHECK(strMiscWarning.empty());
 
     // Test 2: go 3.5 hours without a block, expect a warning:
     now += 3*60*60+30*60;
     SetMockTime(now);
-    PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
+    PartitionCheck(falseFunc, csDummy, &indexDummy[799], nPowTargetSpacing);
     BOOST_CHECK(!strMiscWarning.empty());
     BOOST_TEST_MESSAGE(std::string("Got alert text: ")+strMiscWarning);
     strMiscWarning = "";
@@ -237,16 +237,16 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     // code:
     now += 60*10;
     SetMockTime(now);
-    PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
+    PartitionCheck(falseFunc, csDummy, &indexDummy[799], nPowTargetSpacing);
     BOOST_CHECK(strMiscWarning.empty());
 
     // Test 4: get 2.5 times as many blocks as expected:
     now += 60*60*24; // Pretend it is a day later
     SetMockTime(now);
     int64_t quickSpacing = nPowTargetSpacing*2/5;
-    for (int i = 0; i < 100; i++) // Tweak chain timestamps:
-        indexDummy[i].nTime = now - (100-i)*quickSpacing;
-    PartitionCheck(falseFunc, csDummy, &indexDummy[99], nPowTargetSpacing);
+    for (int i = 0; i < 800; i++) // Tweak chain timestamps:
+        indexDummy[i].nTime = now - (800-i)*quickSpacing;
+    PartitionCheck(falseFunc, csDummy, &indexDummy[799], nPowTargetSpacing);
     BOOST_CHECK(!strMiscWarning.empty());
     BOOST_TEST_MESSAGE(std::string("Got alert text: ")+strMiscWarning);
     strMiscWarning = "";


### PR DESCRIPTION
Partitioning is tested over 4h and 100 blocks are insufficient to test this for Dogecoin. We need 640 blocks in 4h for the "abnormally high" alert test, I've found a set of 800 blocks to test over providing sufficient margin.

this PR should also make travis usable again.
