### PR TITLE
Add Scrypt hash and AuxPoW header to index database

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -111,6 +111,9 @@ public:
     //! pointer to the index of some further predecessor of this block
     CBlockIndex* pskip;
 
+    //! pointer to the AuxPoW header, if this block has one
+    boost::shared_ptr<CAuxPow> pauxpow;
+
     //! height of the entry in the chain. The genesis block has height 0
     int nHeight;
 
@@ -145,6 +148,9 @@ public:
     unsigned int nBits;
     unsigned int nNonce;
 
+    // Dogecoin: Keep the Scrypt hash as well as SHA256
+    uint256 hashBlockPoW;
+
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
@@ -153,6 +159,7 @@ public:
         phashBlock = NULL;
         pprev = NULL;
         pskip = NULL;
+        pauxpow.reset();
         nHeight = 0;
         nFile = 0;
         nDataPos = 0;
@@ -168,6 +175,7 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
+        hashBlockPoW   = uint256();
     }
 
     CBlockIndex()
@@ -184,6 +192,7 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+        hashBlockPoW   = block.GetPoWHash();
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -309,6 +318,14 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+        READWRITE(hashBlockPoW);
+        if (this->nVersion.IsAuxpow()) {
+            if (ser_action.ForRead())
+                pauxpow.reset(new CAuxPow());
+            assert(pauxpow);
+            READWRITE(*pauxpow);
+        } else if (ser_action.ForRead())
+            pauxpow.reset();
     }
 
     uint256 GetBlockHash() const

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -113,12 +113,6 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
     if (!block.nVersion.IsAuxpow())
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
-    /* Temporary check:  Disallow parent blocks with auxpow version.  This is
-       for compatibility with the old client.  */
-    /* FIXME: Remove this check with a hardfork later on.  */
-    if (block.auxpow->getParentBlock().nVersion.IsAuxpow())
-        return error("%s : auxpow parent block has auxpow version", __func__);
-
     if (!block.auxpow->check(block.GetHash(), block.nVersion.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
     if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2531,6 +2531,11 @@ CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
         pindexNew->BuildSkip();
     }
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
+    // Dogecoin: Add AuxPoW
+    if (block.nVersion.IsAuxpow()) {
+        pindexNew->pauxpow = block.auxpow;
+        assert(NULL != pindexNew->pauxpow.get());
+    }
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == NULL || pindexBestHeader->nChainWork < pindexNew->nChainWork)
         pindexBestHeader = pindexNew;


### PR DESCRIPTION
Add Scrypt hash and AuxPoW header to index database so that index can be validated (a check that both Litecoin and Namecoin disable for simplicity). The index format is incompatible with 1.8, as a result, however, and guidelines on performing the upgrade will need to be prepared.

Given scope of the change, it may be advisable for services to prepare bootstrap files and destroy existing index databases entirely before reindexing. To discuss.
