### PR TITLE
Minor AuxPoW fixes

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -103,6 +103,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
     /* Initialise the block version.  */
     pblock->nVersion = CBlockHeader::CURRENT_VERSION;
+    pblock->nVersion.SetChainId(chainparams.GetConsensus(0).nAuxpowChainId);
 
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios

--- a/src/primitives/pureheader.h
+++ b/src/primitives/pureheader.h
@@ -114,6 +114,12 @@ public:
             || (nVersion == 2 && GetChainId() == 0);
     }
 
+    CBlockVersion& operator=(const CBlockVersion& other)
+    {
+        nVersion = other.nVersion;
+        return *this;
+    }
+
     CBlockVersion& operator=(const int nBaseVersion)
     {
         nVersion = (nBaseVersion & 0x000000ff) | (nVersion & 0xffffff00);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -767,11 +767,11 @@ Value getauxblock(const Array& params, bool fHelp)
 
     if (vNodes.empty() && !Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED,
-                           "Namecoin is not connected!");
+                           "Dogecoin is not connected!");
 
     if (IsInitialBlockDownload() && !Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD,
-                           "Namecoin is downloading blocks...");
+                           "Dogecoin is downloading blocks...");
     
     /* The variables below are used to keep track of created and not yet
        submitted auxpow blocks.  Lock them, just in case.  In principle


### PR DESCRIPTION
Replaced references to Namecoin with Dogecoin
Set chain ID when constructing a new block to be mined
Added assignment overload so that assigning one BlockVersion to another does a full copy.