### PR TITLE
Add chain height when fetching consensus parameters in initialization

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1422,7 +1422,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     StartNode(threadGroup, scheduler);
 
     // Monitor the chain, and alert if we get blocks much quicker or slower than expected
-    int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;
+    int64_t nPowTargetSpacing = Params().GetConsensus(chainActive.Height()).nPowTargetSpacing;
     CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
                                          boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
     scheduler.scheduleEvery(f, nPowTargetSpacing);


### PR DESCRIPTION
Minor fix that I accidentally dropped from #1207 :

Add chain height when fetching consensus parameters in initialization, this code was missed in the first patch as it was disabled at the time.