### PR TITLE
Revised payment request handling to use genesis block hash

### DIFF
--- a/src/qt/paymentrequest.proto
+++ b/src/qt/paymentrequest.proto
@@ -1,22 +1,23 @@
 //
-// Simple Bitcoin Payment Protocol messages
+// Simple Dogecoin Payment Protocol messages
+// Derived fromthe Bitcoin Payment Protocol
 //
 // Use fields 100+ for extensions;
-// to avoid conflicts, register extensions at:
-// https://en.bitcoin.it/wiki/Payment_Request
+// to avoid conflicts, register extensions via pull-req at:
+// https://github.com/dogecoin/dips
 //
 
 package payments;
-option java_package = "org.bitcoin.protocols.payments";
+option java_package = "com.dogecoin.protocols.payments";
 option java_outer_classname = "Protos";
 
-// Generalized form of "send payment to this/these bitcoin addresses"
+// Generalized form of "send payment to this/these dogecoin addresses"
 message Output {
-	optional uint64 amount = 1 [default = 0]; // amount is integer-number-of-satoshis
-	required bytes script = 2; // usually one of the standard Script forms
+        optional uint64 amount = 1 [default = 0]; // amount is integer-number-of-satoshis
+        required bytes script = 2; // usually one of the standard Script forms
 }
 message PaymentDetails {
-        optional string network = 1 [default = "main"]; // "main" or "test"
+        optional string genesis = 1 [default = "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"]; // Hash of the network genesis block
         repeated Output outputs = 2;        // Where payment should be sent
         required uint64 time = 3;           // Timestamp; when payment request created
         optional uint64 expires = 4;        // Timestamp; when this request should be considered invalid

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -241,11 +241,11 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
             PaymentRequestPlus request;
             if (readPaymentRequestFromFile(arg, request))
             {
-                if (request.getDetails().network() == "main")
+                if (request.getDetails().genesis() == "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691")
                 {
                     SelectParams(CBaseChainParams::MAIN);
                 }
-                else if (request.getDetails().network() == "test")
+                else if (request.getDetails().genesis() == "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e")
                 {
                     SelectParams(CBaseChainParams::TESTNET);
                 }
@@ -770,12 +770,13 @@ void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
 
 bool PaymentServer::verifyNetwork(const payments::PaymentDetails& requestDetails)
 {
-    bool fVerified = requestDetails.network() == Params().NetworkIDString();
+    Consensus::Params consensus = Params().GetConsensus(0);
+    bool fVerified = requestDetails.genesis() == consensus.hashGenesisBlock.GetHex();
     if (!fVerified) {
         qWarning() << QString("PaymentServer::%1: Payment request network \"%2\" doesn't match client network \"%3\".")
             .arg(__func__)
-            .arg(QString::fromStdString(requestDetails.network()))
-            .arg(QString::fromStdString(Params().NetworkIDString()));
+            .arg(QString::fromStdString(requestDetails.genesis()))
+            .arg(QString::fromStdString(consensus.hashGenesisBlock.GetHex()));
     }
     return fVerified;
 }


### PR DESCRIPTION
Revised payment request handling to use genesis block hash instead of network name, enabling
support for more networks that just Bitcoin main and test net.