### PR TITLE
Changing nTotalAmount of CCoinsStats to uint256 from int64_t

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -248,7 +248,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
-    int64_t nTotalAmount;
+    uint256 nTotalAmount;
 
     CCoinsStats() : nHeight(0), hashBlock(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), hashSerialized(0), nTotalAmount(0) {}
 };

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -99,6 +99,11 @@ Value ValueFromAmount(int64_t amount)
     return (double)amount / (double)COIN;
 }
 
+Value ValueFromAmount(uint256 amount)
+{
+    return amount.getdouble() / (double)COIN;
+}
+
 std::string HexBits(unsigned int nBits)
 {
     union {

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -105,6 +105,7 @@ extern void ShutdownRPCMining();
 extern int64_t nWalletUnlockTime;
 extern int64_t AmountFromValue(const json_spirit::Value& value);
 extern json_spirit::Value ValueFromAmount(int64_t amount);
+extern json_spirit::Value ValueFromAmount(uint256 amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HexBits(unsigned int nBits);
 extern std::string HelpRequiringPassphrase();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -125,7 +125,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = GetBestBlock();
     ss << stats.hashBlock;
-    int64_t nTotalAmount = 0;
+    uint256 nTotalAmount = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         try {


### PR DESCRIPTION
Fix for Issue 1203 (Currently existing coins exceed int64_t)
https://github.com/dogecoin/dogecoin/issues/1203

overzealous size, but uint256 has tests and is commonly used elsewhere in the code
