### PR TITLE
Update time-based constants

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -37,9 +37,9 @@ public:
 
         // Blocks 0 - 144999 are conventional difficulty calculation
         consensus.nSubsidyHalvingInterval = 100000;
-        consensus.nMajorityEnforceBlockUpgrade = 750;
-        consensus.nMajorityRejectBlockOutdated = 950;
-        consensus.nMajorityWindow = 1000;
+        consensus.nMajorityEnforceBlockUpgrade = 1500;
+        consensus.nMajorityRejectBlockOutdated = 1900;
+        consensus.nMajorityWindow = 2000;
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60; // 1 minute
@@ -181,9 +181,9 @@ public:
         consensus.fDigishieldDifficultyCalculation = false;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
-        consensus.nMajorityEnforceBlockUpgrade = 51;
-        consensus.nMajorityRejectBlockOutdated = 75;
-        consensus.nMajorityWindow = 100;
+        consensus.nMajorityEnforceBlockUpgrade = 501;
+        consensus.nMajorityRejectBlockOutdated = 750;
+        consensus.nMajorityWindow = 1000;
         consensus.fStrictChainId = false;
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;

--- a/src/main.h
+++ b/src/main.h
@@ -131,17 +131,17 @@ extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
-static const signed int MIN_BLOCKS_TO_KEEP = 288;
+static const signed int MIN_BLOCKS_TO_KEEP = 1440;
 
-// Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)
-// At 1MB per block, 288 blocks = 288MB.
-// Add 15% for Undo data = 331MB
-// Add 20% for Orphan block rate = 397MB
-// We want the low water mark after pruning to be at least 397 MB and since we prune in
+// Require that user allocate at least 2,200MB for block & undo files (blk???.dat and rev???.dat)
+// At 1MB per block, 1,440 blocks = 1,440MB.
+// Add 15% for Undo data = 1,656MB
+// Add 20% for Orphan block rate = 1,987MB
+// We want the low water mark after pruning to be at least 1,987 MB and since we prune in
 // full block file chunks, we need the high water mark which triggers the prune to be
-// one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
-// Setting the target to > than 550MB will make it likely we can respect the target.
-static const signed int MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
+// one 128MB block file + added 15% undo data = 147MB greater for a total of 2,134MB
+// Setting the target to > than 2,200MB will make it likely we can respect the target.
+static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 2200ULL * 1024 * 1024;
 
 /** Register with a network node to receive its signals */
 void RegisterNodeSignals(CNodeSignals& nodeSignals);


### PR DESCRIPTION
This updated various time-based constants to more closely reflect values appropriate to Dogecoin:

* Number of blocks to look back for BIP 66 enforcement is doubled on main net (to about a day and a half's worth, vs 5 days on Bitcoin), and raised to 1,000 on testnet (bringing it up to the same quantity
as Bitcoin testnet).
* BIP 66 enforcement cut-offs are scaled up appropriate.
* Minimum number of blocks and blockchain size are increased for pruning. In comparison to Bitcoin this uses 24 hours as a minimum, rather than 48, although given blocks are rarely full this likely reflects a lot longer in reality.