### PR TITLE
changing CAmount (is a int64_t) to arith_uint256 for nTotalAmount 

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -10,6 +10,7 @@
 #include "memusage.h"
 #include "serialize.h"
 #include "uint256.h"
+#include "arith_uint256.h"
 
 #include <assert.h>
 #include <stdint.h>
@@ -305,7 +306,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
-    CAmount nTotalAmount;
+    arith_uint256 nTotalAmount;
 
     CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}
 };

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -140,6 +140,13 @@ Value ValueFromAmount(const CAmount& amount)
     return (double)amount / (double)COIN;
 }
 
+Value ValueFromAmount(const arith_uint256& amount)
+{
+    return amount.getdouble() / (double)COIN;
+}
+
+
+
 uint256 ParseHashV(const Value& v, string strName)
 {
     string strHex;

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -9,6 +9,7 @@
 #include "amount.h"
 #include "rpcprotocol.h"
 #include "uint256.h"
+#include "arith_uint256.h"
 
 #include <list>
 #include <map>
@@ -139,6 +140,7 @@ extern void ShutdownRPCMining();
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const json_spirit::Value& value);
 extern json_spirit::Value ValueFromAmount(const CAmount& amount);
+extern json_spirit::Value ValueFromAmount(const arith_uint256& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(std::string methodname, std::string args);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -10,6 +10,7 @@
 #include "main.h"
 #include "pow.h"
 #include "uint256.h"
+#include "arith_uint256.h"
 
 #include <stdint.h>
 
@@ -110,7 +111,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = GetBestBlock();
     ss << stats.hashBlock;
-    CAmount nTotalAmount = 0;
+    arith_uint256 nTotalAmount = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         try {


### PR DESCRIPTION
Changing CAmount (is a int64_t) to arith_uint256 for nTotalAmount in CCoinsStats to prevent overflow

fix for https://github.com/dogecoin/dogecoin/issues/1203