### PR TITLE
Update fork detection parameters for Dogecoin block time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1257,12 +1257,12 @@ void CheckForkWarningConditions()
     if (IsInitialBlockDownload())
         return;
 
-    // If our best fork is no longer within 72 blocks (+/- 12 hours if no one mines it)
+    // If our best fork is no longer within 360 blocks (+/- 6 hours if no one mines it)
     // of our head, drop it
-    if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 72)
+    if (pindexBestForkTip && chainActive.Height() - pindexBestForkTip->nHeight >= 360)
         pindexBestForkTip = NULL;
 
-    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (GetBlockProof(*chainActive.Tip()) * 6)))
+    if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > chainActive.Tip()->nChainWork + (GetBlockProof(*chainActive.Tip()) * 30)))
     {
         if (!fLargeWorkForkFound && pindexBestForkBase)
         {


### PR DESCRIPTION
I've multiplied fork detection parameters by 5 - the wall clock time elapsed for "long" forks is therefore half that of Bitcoin, but IMHO those figures are excessive for a chain with 1 minute block times.

Addresses #566 