### PR TITLE
[auxpow] Check for auxpow fork strictly

### DIFF
--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -58,9 +58,6 @@ class RESTTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        auxpow.mineAuxpowBlock(self.nodes[0])
-        self.sync_all()
-
         url = urlparse.urlparse(self.nodes[0].url)
         print "Mining blocks..."
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -50,6 +50,7 @@ public:
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true;
+        consensus.fAllowAuxPow = false;
         consensus.nHeightEffective = 0;
         consensus.fDigishieldDifficultyCalculation = false;
         consensus.nCoinbaseMaturity = 30;
@@ -66,6 +67,7 @@ public:
         auxpowConsensus = digishieldConsensus;
         auxpowConsensus.nHeightEffective = 371337;
         auxpowConsensus.fAllowLegacyBlocks = false;
+        auxpowConsensus.fAllowAuxPow = true;
 
         // Assemble the binary search tree of consensus parameters
         pConsensusRoot = &digishieldConsensus;
@@ -188,6 +190,7 @@ public:
         consensus.fStrictChainId = false;
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;
+        consensus.fAllowAuxPow = false;
 
         // Reset links before we copy parameters
         consensus.pLeft = NULL;
@@ -213,6 +216,7 @@ public:
         auxpowConsensus.nHeightEffective = 158100;
         auxpowConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
         auxpowConsensus.fAllowLegacyBlocks = false;
+        auxpowConsensus.fAllowAuxPow = true;
 
         // Assemble the binary search tree of parameters
         pConsensusRoot = &digishieldConsensus;
@@ -286,7 +290,8 @@ public:
         consensus.nPowTargetSpacing = 1; // regtest: 1 second blocks
         consensus.powLimit = uint256S("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1;
         consensus.fStrictChainId = true;
-        consensus.fAllowLegacyBlocks = false; // Never allow legacy blocks on RegTest
+        consensus.fAllowLegacyBlocks = true;
+        consensus.fAllowAuxPow = false;
         consensus.fSimplifiedRewards = true;
         consensus.nCoinbaseMaturity = 60; // For easier testability in RPC tests
 
@@ -300,6 +305,8 @@ public:
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
 
         auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.fAllowLegacyBlocks = false;
+        auxpowConsensus.fAllowAuxPow = true;
         auxpowConsensus.nHeightEffective = 20;
 
         // Assemble the binary search tree of parameters

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,7 @@ struct Params {
 
     /** Auxpow parameters */
     int16_t nAuxpowChainId;
+    bool fAllowAuxPow;
     bool fStrictChainId;
     bool fAllowLegacyBlocks;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2768,6 +2768,13 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
                                     __func__, pindexPrev->nHeight + 1, consensusParams.nHeightEffective),
                          REJECT_INVALID, "late-legacy-block");
 
+    // Disallow AuxPow blocks before it is activated.
+    if (!consensusParams.fAllowAuxPow
+        && block.nVersion.IsAuxpow())
+        return state.DoS(100, error("%s : auxpow blocks are not allowed at height %d, parameters effective from %d",
+                                    __func__, pindexPrev->nHeight + 1, consensusParams.nHeightEffective),
+                         REJECT_INVALID, "early-auxpow-block");
+
     // Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.DoS(100, error("%s: incorrect proof of work at height %d", __func__, nHeight),


### PR DESCRIPTION
Disallows any auxpow block before the blockheight where auxpow gets enabled.

- introduces chainparam fAllowAuxPow
- re-enables legacy headers on regtest for consistency with main/testnet
- disables mining an auxpow block at height 1 in rest.py (which was previously defunct anyway)