### PR TITLE
fix for travis generating an extra build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 
 os: linux
 language: cpp
+compiler: gcc
 env:
   global:
     - MAKEJOBS=-j3
@@ -82,6 +83,8 @@ matrix:
             - libcap-dev
             - zlib1g-dev
             - libbz2-dev
+  exclude:
+    - compiler: gcc
 before_script:
     - unset CC; unset CXX
     - mkdir -p depends/SDKs depends/sdk-sources


### PR DESCRIPTION
Excludes the default travis job, see https://github.com/travis-ci/travis-ci/issues/4681

(cherry-picked from bitcoin master.)