### PR TITLE
Backport protocol 70004 to 1.8.3

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -66,6 +66,7 @@ enum
 {
     NODE_NETWORK = (1 << 0),
     NODE_BLOOM = (1 << 1),
+    NODE_GETUTXO = (1 << 2), // not implemented, added for reference
 };
 
 /** A CService with information about it as peer */

--- a/src/version.h
+++ b/src/version.h
@@ -27,7 +27,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 70003;
+static const int PROTOCOL_VERSION = 70004;
 
 // intial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Implements the `NODE_GETUTXO` service bit in 1.8.x for protocol compatibility, but doesn't implement the actual service, as done in 1.10. Updates the protocol version to `70004`.