### PR TITLE
Change default soft block size limit to hard max

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -48,7 +48,7 @@ class CValidationState;
 struct CNodeStateStats;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;


### PR DESCRIPTION
Fairly straight forward.  Changes the default configuration of a mining node from mining 750kB blocks to mining the max of 1MB blocks.  Pros:  During a hypothetical spam attack miners would be set up by default to handle 25% more transactions, would clear mempool that much faster, would cost that much more in fees to cause disruption to regular users.  Cons:  More hard drive space and bandwidth would be required, possibly leading to higher orphan rates during spam attack.  Ultimately though, it's just a default setting and miners are free to adjust their own personal soft-limit down to whatever size blocks they want to mine.