### PR TITLE
Make low-s verification mandatory for standard script verification

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -50,7 +50,8 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_MINIMALDATA |
                                                          SCRIPT_VERIFY_NULLDUMMY |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
-                                                         SCRIPT_VERIFY_CLEANSTACK;
+                                                         SCRIPT_VERIFY_CLEANSTACK |
+                                                         SCRIPT_VERIFY_LOW_S;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;


### PR DESCRIPTION
This change makes a node only accept transactions with low-s signature encoding for relay and mining, but allows transactions with high-s signature encoding in mined blocks (no blocks will be rejected)

I'm intending this to be applied against 1.10.0 as we have a soft-fork in there, so older (Dogecoin Core) clients will get reminders about being on an outdated version because of that anyway, which should result in better adoption. We could also consider doing the softfork now, together with BIP66, to not have to do a consensus fork every other release. Thoughts?

Pros:
- If deployed by all miners, this will eliminate this particular malleability attack.
- There is no impact on consensus

Cons:
- Wallets that do not implement low-s signature encoding will see their transactions be rejected by growing numbers of peers and ultimately not be able to get any transaction mined.

Follow ups:
- Eventually, this verification needs to be confirmed through a consensus rule (enforcement of BIP62 for block validation) which will probably be another soft-fork

---
Constraints for hard implementation:
- [x] Majority of "standard" libraries should implement low-s
  - [x] bitcoinj (since 0.11)
  - [x] bitcoinjs (since 1.0.0)
  - [x] bitcoin-ruby (since 0.0.7)
  - [x] python-bitcoinlib
  - [ ] bitcoin-lib-php (not implemented)
- [x] Majority of wallets should implement low-s
  - [x] Dogecoin Core (since 1.7)
  - [x] Multidoge (since 0.1.5)
  - [x] Android
  - [x] Doughwallet (iOS)
  - [x] Web-wallets
    - [x] dogechain.info
    - [x] block.io
    - [x] redeempaper.com
    - [x] dogeparty wallet => live wallet updated, patch submitted to upstream
- [x] 95% of transactions over last 100k blocks must have low-s encoding