### PR TITLE
apply bitcoin patch for miniupnpc 1.9

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1109,10 +1109,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Applied a patch from bitcoin to fix compilation error with new miniupnpc v.1.9

https://github.com/bitcoin/bitcoin/commit/9f3e48e5219a09b5ddfd6883d1f0498910eff4b6.patch

Fixes this issue:

https://github.com/dogecoin/dogecoin/issues/1292

Hope I did this right... Cheers!