### PR TITLE
Bring back "target" property of getauxblock

### DIFF
--- a/qa/rpc-tests/test_framework/auxpow.py
+++ b/qa/rpc-tests/test_framework/auxpow.py
@@ -63,7 +63,7 @@ def mineAuxpowBlock (node):
   """
 
   auxblock = node.getauxblock ()
-  target = reverseHex (auxblock['_target'])
+  target = reverseHex (auxblock['target'])
   apow = computeAuxpow (auxblock['hash'], target, True)
   res = node.getauxblock (auxblock['hash'], apow)
   assert res

--- a/qa/rpc-tests/test_framework/scrypt_auxpow.py
+++ b/qa/rpc-tests/test_framework/scrypt_auxpow.py
@@ -72,7 +72,7 @@ def mineScryptAux (node, chainid, ok):
   """
 
   auxblock = node.getauxblock ()
-  target = auxpow.reverseHex (auxblock['_target'])
+  target = auxpow.reverseHex (auxblock['target'])
 
   apow = computeAuxpowWithChainId (auxblock['hash'], target, chainid, ok)
   res = node.getauxblock (auxblock['hash'], apow)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -752,7 +752,7 @@ Value getauxblockbip22(const Array& params, bool fHelp)
             "  \"coinbasevalue\"      (numeric) value of the block's coinbase\n"
             "  \"bits\"               (string) compressed target of the block\n"
             "  \"height\"             (numeric) height of the block\n"
-            "  \"_target\"            (string) target in reversed byte order, deprecated\n"
+            "  \"target\"             (string) target in reversed byte order\n"
             "}\n"
             "\nResult (with arguments):\n"
             "xxxxx        (boolean) whether the submitted block was correct\n"
@@ -845,7 +845,7 @@ Value getauxblockbip22(const Array& params, bool fHelp)
         result.push_back(Pair("coinbasevalue", (int64_t)block.vtx[0].vout[0].nValue));
         result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
         result.push_back(Pair("height", static_cast<int64_t> (pindexPrev->nHeight + 1)));
-        result.push_back(Pair("_target", HexStr(BEGIN(target), END(target))));
+        result.push_back(Pair("target", HexStr(BEGIN(target), END(target))));
 
         return result;
     }


### PR DESCRIPTION
Marked as deprecated but still used in many pool implementations, as well as rpc-tests. 

This restores backward AuxPoW compatibility to 100% against 1.8.2