### PR TITLE
[Qt] [minor] Add textual descriptor for NODE_BLOOM service flag

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -883,6 +883,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_GETUTXO:
                 strList.append("GETUTXO");
                 break;
+            case NODE_BLOOM:
+                strList.append("BLOOM");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
Displays `NODE_BLOOM` service as `"BLOOM"` instead of `"UNKNOWN[2]"` in qt->debug->peers

Pulling against `1.10-dev` because it's an extension of #1269