### PR TITLE
[Qt] Disable milli and micro units, introduce kilo and mega units

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -19,8 +19,10 @@ QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits()
 {
     QList<BitcoinUnits::Unit> unitlist;
     unitlist.append(BTC);
-    unitlist.append(mBTC);
-    unitlist.append(uBTC);
+    unitlist.append(kBTC);
+    unitlist.append(MBTC);
+    //unitlist.append(mBTC);
+    //unitlist.append(uBTC);
     return unitlist;
 }
 
@@ -28,10 +30,12 @@ bool BitcoinUnits::valid(int unit)
 {
     switch(unit)
     {
+    case MBTC:
+    case kBTC:
     case BTC:
+        return true;
     case mBTC:
     case uBTC:
-        return true;
     default:
         return false;
     }
@@ -41,6 +45,8 @@ QString BitcoinUnits::name(int unit)
 {
     switch(unit)
     {
+    case MBTC: return QString("MDOGE");
+    case kBTC: return QString("kDOGE");
     case BTC: return QString("DOGE");
     case mBTC: return QString("mDOGE");
     case uBTC: return QChar(0x03BC) + QString("DOGE");
@@ -52,6 +58,8 @@ QString BitcoinUnits::description(int unit)
 {
     switch(unit)
     {
+    case MBTC: return tr("Mega-Dogecoins (1,000,000)");
+    case kBTC: return tr("Kilo-Dogecoins (1,000)");
     case BTC: return tr("Dogecoins");
     case mBTC: return tr("Milli-Dogecoins (1 / 1,000)");
     case uBTC: return tr("Micro-Dogecoins (1 / 1,000,000)");
@@ -63,6 +71,8 @@ qint64 BitcoinUnits::factor(int unit)
 {
     switch(unit)
     {
+    case MBTC: return 100000000000000;
+    case kBTC: return 100000000000;
     case BTC:  return 100000000;
     case mBTC: return 100000;
     case uBTC: return 100;
@@ -74,6 +84,8 @@ qint64 BitcoinUnits::maxAmount(int unit)
 {
     switch(unit)
     {
+    case MBTC: return Q_INT64_C(900000);
+    case kBTC: return Q_INT64_C(900000000);
     case BTC:  return Q_INT64_C(900000000000);    //less than the coin supply until the year 2170
     case mBTC: return Q_INT64_C(900000000000000);
     case uBTC: return Q_INT64_C(900000000000000000); // Slightly under max value for int64
@@ -85,6 +97,8 @@ int BitcoinUnits::decimals(int unit)
 {
     switch(unit)
     {
+    case MBTC: return 14;
+    case kBTC: return 11;
     case BTC: return 8;
     case mBTC: return 5;
     case uBTC: return 2;

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -57,6 +57,8 @@ public:
      */
     enum Unit
     {
+        MBTC,
+        kBTC,
         BTC,
         mBTC,
         uBTC


### PR DESCRIPTION
milli- and micro-Dogecoins are below dust threshold so do not make any sense as display units. Instead, kilo- and mega-dogecoins are probably more useful, as those make common amounts easier to read
instead of harder.

