### PR TITLE
Replace Bitcoin mentions with Dogecoin in INSTALL.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
-Building Bitcoin
+Building Dogecoin
 
-See doc/build-*.md for instructions on building bitcoind,
+See doc/build-*.md for instructions on building dogecoind,
 the intended-for-services, no-graphical-interface, reference
-implementation of Bitcoin.
+implementation of Dogecoin.


### PR DESCRIPTION
These were fixed in #546 but did not get included in 1.10. So fixed again, maybe this time they stay. :tada: 