### PR TITLE
rename libbitcoinconsensus to libdogecoinconsensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,4 +112,4 @@ qa/pull-tester/test.*/*
 
 /doc/doxygen/
 
-libbitcoinconsensus.pc
+libdogecoinconsensus.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ GZIP_ENV="-9n"
 
 if BUILD_BITCOIN_LIBS
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libbitcoinconsensus.pc
+pkgconfig_DATA = libdogecoinconsensus.pc
 endif
 
 BITCOIND_BIN=$(top_builddir)/src/dogecoind$(EXEEXT)

--- a/configure.ac
+++ b/configure.ac
@@ -709,7 +709,7 @@ AC_MSG_CHECKING([whether to build libraries])
 AM_CONDITIONAL([BUILD_BITCOIN_LIBS], [test x$build_bitcoin_libs = xyes])
 if test x$build_bitcoin_libs = xyes; then
   AC_DEFINE(HAVE_CONSENSUS_LIB, 1, [Define this symbol if the consensus lib has been built])
-  AC_CONFIG_FILES([libbitcoinconsensus.pc:libbitcoinconsensus.pc.in])
+  AC_CONFIG_FILES([libdogecoinconsensus.pc:libdogecoinconsensus.pc.in])
 fi
 AC_MSG_RESULT($build_bitcoin_libs)
 

--- a/libdogecoinconsensus.pc.in
+++ b/libdogecoinconsensus.pc.in
@@ -3,9 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: Bitcoin Core consensus library
-Description: Library for the Bitcoin consensus protocol.
+Name: Dogecoin Core consensus library
+Description: Library for the Dogecoin consensus protocol.
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lbitcoinconsensus
+Libs: -L${libdir} -ldogecoinconsensus
 Cflags: -I${includedir}
 Requires.private: libcrypto

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,8 +50,8 @@ EXTRA_LIBRARIES += libbitcoin_wallet.a
 endif
 
 if BUILD_BITCOIN_LIBS
-lib_LTLIBRARIES = libbitcoinconsensus.la
-LIBBITCOIN_CONSENSUS=libbitcoinconsensus.la
+lib_LTLIBRARIES = libdogecoinconsensus.la
+LIBBITCOIN_CONSENSUS=libdogecoinconsensus.la
 else
 LIBBITCOIN_CONSENSUS=
 endif
@@ -375,10 +375,10 @@ dogecoin_tx_LDADD = \
 dogecoin_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
 #
 
-# bitcoinconsensus library #
+# dogecoinconsensus library #
 if BUILD_BITCOIN_LIBS
-include_HEADERS = script/bitcoinconsensus.h
-libbitcoinconsensus_la_SOURCES = \
+include_HEADERS = script/dogecoinconsensus.h
+libdogecoinconsensus_la_SOURCES = \
   crypto/hmac_sha512.cpp \
   crypto/ripemd160.cpp \
   crypto/scrypt.cpp \
@@ -390,19 +390,19 @@ libbitcoinconsensus_la_SOURCES = \
   hash.cpp \
   primitives/transaction.cpp \
   pubkey.cpp \
-  script/bitcoinconsensus.cpp \
+  script/dogecoinconsensus.cpp \
   script/interpreter.cpp \
   script/script.cpp \
   uint256.cpp \
   utilstrencodings.cpp
 
 if GLIBC_BACK_COMPAT
-  libbitcoinconsensus_la_SOURCES += compat/glibc_compat.cpp
+  libdogecoinconsensus_la_SOURCES += compat/glibc_compat.cpp
 endif
 
-libbitcoinconsensus_la_LDFLAGS = -no-undefined $(RELDFLAGS)
-libbitcoinconsensus_la_LIBADD = $(CRYPTO_LIBS)
-libbitcoinconsensus_la_CPPFLAGS = $(CRYPTO_CFLAGS) -I$(builddir)/obj -DBUILD_BITCOIN_INTERNAL
+libdogecoinconsensus_la_LDFLAGS = -no-undefined $(RELDFLAGS)
+libdogecoinconsensus_la_LIBADD = $(CRYPTO_LIBS)
+libdogecoinconsensus_la_CPPFLAGS = $(CRYPTO_CFLAGS) -I$(builddir)/obj -DBUILD_BITCOIN_INTERNAL
 
 endif
 #

--- a/src/script/dogecoinconsensus.cpp
+++ b/src/script/dogecoinconsensus.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "bitcoinconsensus.h"
+#include "dogecoinconsensus.h"
 
 #include "primitives/transaction.h"
 #include "script/interpreter.h"
@@ -53,7 +53,7 @@ private:
     size_t m_remaining;
 };
 
-inline int set_error(bitcoinconsensus_error* ret, bitcoinconsensus_error serror)
+inline int set_error(dogecoinconsensus_error* ret, dogecoinconsensus_error serror)
 {
     if (ret)
         *ret = serror;
@@ -62,30 +62,30 @@ inline int set_error(bitcoinconsensus_error* ret, bitcoinconsensus_error serror)
 
 } // anon namespace
 
-int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
+int dogecoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
                                     const unsigned char *txTo        , unsigned int txToLen,
-                                    unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err)
+                                    unsigned int nIn, unsigned int flags, dogecoinconsensus_error* err)
 {
     try {
         TxInputStream stream(SER_NETWORK, PROTOCOL_VERSION, txTo, txToLen);
         CTransaction tx;
         stream >> tx;
         if (nIn >= tx.vin.size())
-            return set_error(err, bitcoinconsensus_ERR_TX_INDEX);
+            return set_error(err, dogecoinconsensus_ERR_TX_INDEX);
         if (tx.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION) != txToLen)
-            return set_error(err, bitcoinconsensus_ERR_TX_SIZE_MISMATCH);
+            return set_error(err, dogecoinconsensus_ERR_TX_SIZE_MISMATCH);
 
          // Regardless of the verification result, the tx did not error.
-         set_error(err, bitcoinconsensus_ERR_OK);
+         set_error(err, dogecoinconsensus_ERR_OK);
 
         return VerifyScript(tx.vin[nIn].scriptSig, CScript(scriptPubKey, scriptPubKey + scriptPubKeyLen), flags, TransactionSignatureChecker(&tx, nIn), NULL);
     } catch (const std::exception&) {
-        return set_error(err, bitcoinconsensus_ERR_TX_DESERIALIZE); // Error deserializing
+        return set_error(err, dogecoinconsensus_ERR_TX_DESERIALIZE); // Error deserializing
     }
 }
 
-unsigned int bitcoinconsensus_version()
+unsigned int dogecoinconsensus_version()
 {
     // Just use the API version for now
-    return BITCOINCONSENSUS_API_VER;
+    return DOGECOINCONSENSUS_API_VER;
 }

--- a/src/script/dogecoinconsensus.h
+++ b/src/script/dogecoinconsensus.h
@@ -31,33 +31,33 @@
 extern "C" {
 #endif
 
-#define BITCOINCONSENSUS_API_VER 0
+#define DOGECOINCONSENSUS_API_VER 0
 
-typedef enum bitcoinconsensus_error_t
+typedef enum dogecoinconsensus_error_t
 {
-    bitcoinconsensus_ERR_OK = 0,
-    bitcoinconsensus_ERR_TX_INDEX,
-    bitcoinconsensus_ERR_TX_SIZE_MISMATCH,
-    bitcoinconsensus_ERR_TX_DESERIALIZE,
-} bitcoinconsensus_error;
+    dogecoinconsensus_ERR_OK = 0,
+    dogecoinconsensus_ERR_TX_INDEX,
+    dogecoinconsensus_ERR_TX_SIZE_MISMATCH,
+    dogecoinconsensus_ERR_TX_DESERIALIZE,
+} dogecoinconsensus_error;
 
 /** Script verification flags */
 enum
 {
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NONE      = 0,
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH      = (1U << 0), // evaluate P2SH (BIP16) subscripts
-    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG    = (1U << 2), // enforce strict DER (BIP66) compliance
+    dogecoinconsensus_SCRIPT_FLAGS_VERIFY_NONE      = 0,
+    dogecoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH      = (1U << 0), // evaluate P2SH (BIP16) subscripts
+    dogecoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG    = (1U << 2), // enforce strict DER (BIP66) compliance
 };
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by
 /// txTo correctly spends the scriptPubKey pointed to by scriptPubKey under
 /// the additional constraints specified by flags.
 /// If not NULL, err will contain an error/success code for the operation
-EXPORT_SYMBOL int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
+EXPORT_SYMBOL int dogecoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen,
                                     const unsigned char *txTo        , unsigned int txToLen,
-                                    unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
+                                    unsigned int nIn, unsigned int flags, dogecoinconsensus_error* err);
 
-EXPORT_SYMBOL unsigned int bitcoinconsensus_version();
+EXPORT_SYMBOL unsigned int dogecoinconsensus_version();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -16,7 +16,7 @@
 #include "test/test_bitcoin.h"
 
 #if defined(HAVE_CONSENSUS_LIB)
-#include "script/bitcoinconsensus.h"
+#include "script/dogecoinconsensus.h"
 #endif
 
 #include <fstream>
@@ -99,7 +99,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, int flags, bo
 #if defined(HAVE_CONSENSUS_LIB)
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;
-    BOOST_CHECK_MESSAGE(bitcoinconsensus_verify_script(begin_ptr(scriptPubKey), scriptPubKey.size(), (const unsigned char*)&stream[0], stream.size(), 0, flags, NULL) == expect,message);
+    BOOST_CHECK_MESSAGE(dogecoinconsensus_verify_script(begin_ptr(scriptPubKey), scriptPubKey.size(), (const unsigned char*)&stream[0], stream.size(), 0, flags, NULL) == expect,message);
 #endif
 }
 


### PR DESCRIPTION
Changes all consensus library name tags from bitcoinconsensus to dogecoinconsensus to prevent packagers from having to deal with our shared library and headers having the same name as Bitcoin's.

Also changes all exported names to create incompatibility between the two libraries, so that one cannot accidentally link code for bitcoin consensus but instead get dogecoin consensus.

fixes #1325