### PR TITLE
Remove auxpow header from index

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -111,9 +111,6 @@ public:
     //! pointer to the index of some further predecessor of this block
     CBlockIndex* pskip;
 
-    //! pointer to the AuxPoW header, if this block has one
-    boost::shared_ptr<CAuxPow> pauxpow;
-
     //! height of the entry in the chain. The genesis block has height 0
     int nHeight;
 
@@ -148,9 +145,6 @@ public:
     unsigned int nBits;
     unsigned int nNonce;
 
-    // Dogecoin: Keep the Scrypt hash as well as SHA256
-    uint256 hashBlockPoW;
-
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
@@ -159,7 +153,6 @@ public:
         phashBlock = NULL;
         pprev = NULL;
         pskip = NULL;
-        pauxpow.reset();
         nHeight = 0;
         nFile = 0;
         nDataPos = 0;
@@ -175,7 +168,6 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
-        hashBlockPoW   = uint256();
     }
 
     CBlockIndex()
@@ -192,7 +184,6 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
-        hashBlockPoW   = block.GetPoWHash();
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -318,14 +309,6 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
-        READWRITE(hashBlockPoW);
-        if (this->nVersion.IsAuxpow()) {
-            if (ser_action.ForRead())
-                pauxpow.reset(new CAuxPow());
-            assert(pauxpow);
-            READWRITE(*pauxpow);
-        } else if (ser_action.ForRead())
-            pauxpow.reset();
     }
 
     uint256 GetBlockHash() const

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -114,12 +114,6 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
     if (!block.nVersion.IsAuxpow())
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
-    /* Temporary check:  Disallow parent blocks with auxpow version.  This is
-       for compatibility with the old client.  */
-    /* FIXME: Remove this check with a hardfork later on.  */
-    if (block.auxpow->getParentBlock().nVersion.IsAuxpow())
-        return error("%s : auxpow parent block has auxpow version", __func__);
-
     if (!block.auxpow->check(block.GetHash(), block.nVersion.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
     if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -114,6 +114,12 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
     if (!block.nVersion.IsAuxpow())
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
+    /* Temporary check:  Disallow parent blocks with auxpow version.  This is
+       for compatibility with the old client.  */
+    /* FIXME: Remove this check with a hardfork later on.  */
+    if (block.auxpow->getParentBlock().nVersion.IsAuxpow())
+        return error("%s : auxpow parent block has auxpow version", __func__);
+
     if (!block.auxpow->check(block.GetHash(), block.nVersion.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
     if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2531,11 +2531,6 @@ CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
         pindexNew->BuildSkip();
     }
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
-    // Dogecoin: Add AuxPoW
-    if (block.nVersion.IsAuxpow()) {
-        pindexNew->pauxpow = block.auxpow;
-        assert(NULL != pindexNew->pauxpow.get());
-    }
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == NULL || pindexBestHeader->nChainWork < pindexNew->nChainWork)
         pindexBestHeader = pindexNew;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -215,7 +215,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 // Construct block index object
                 CBlockIndex* pindexNew = InsertBlockIndex(diskindex.GetBlockHash());
                 pindexNew->pprev          = InsertBlockIndex(diskindex.hashPrev);
-                pindexNew->pauxpow        = diskindex.pauxpow;
                 pindexNew->nHeight        = diskindex.nHeight;
                 pindexNew->nFile          = diskindex.nFile;
                 pindexNew->nDataPos       = diskindex.nDataPos;
@@ -227,16 +226,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nNonce         = diskindex.nNonce;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
-                pindexNew->hashBlockPoW   = diskindex.hashBlockPoW;
 
-                if (pindexNew->nVersion.IsAuxpow()) {
-                    if (!diskindex.pauxpow->check(diskindex.GetBlockHash(), pindexNew->nVersion.GetChainId(), Params().GetConsensus(pindexNew->nHeight))) {
-                        return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
-                    }
-                } else {
-                    if (!CheckProofOfWork(pindexNew->hashBlockPoW, pindexNew->nBits, Params().GetConsensus(pindexNew->nHeight)))
-                        return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
-                }
+                /* Bitcoin checks the PoW here.  We don't do this because
+                   the CDiskBlockIndex does not contain the auxpow.
+                   This check isn't important, since the data on disk should
+                   already be valid and can be trusted.  */
 
                 pcursor->Next();
             } else {


### PR DESCRIPTION
The only reason the auxpow header is stored in the blockindex is to verify if the PoW is right when loading from that index. While it is of course super-safe to do that, it leads to very inefficient memory usage: over 200% increase of resident memory on linux and OSX. This change was introduced in 1.10.0, with #1206.

I'm reverting the commit in question which makes my dogecoind on linux go from 1050MB resident memory to about 450MB. A re-index isn't mandatory but saved another 65MB for me, plus it makes paged memory smaller.

Please note that a consensus param from Namecoin was removed in this commit as well, so after reversal of the original commit, I'm re-removing it in a separate commit, so that that can be pulled into any rework for later versions, without needing to include the entire reversed chain.