### PR TITLE
Remove CBlockVersion to prepare for BIP9 compatibility

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -110,7 +110,7 @@ CAuxPow::check(const uint256& hashAuxBlock, int nChainId, const Consensus::Param
     if (nIndex != 0)
         return error("AuxPow is not a generate");
 
-    if (params.fStrictChainId && parentBlock.nVersion.GetChainId() == nChainId)
+    if (params.fStrictChainId && parentBlock.GetChainId() == nChainId)
         return error("Aux POW parent has our chain ID");
 
     if (vChainMerkleBranch.size() > 30)

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -15,16 +15,17 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
 {
     CBlockHeader block;
 
+    block.nVersion       = nVersion;
+
     /* The CBlockIndex object's block header is missing the auxpow.
        So if this is an auxpow block, read it from disk instead.  We only
        have to read the actual *header*, not the full block.  */
-    if (nVersion.IsAuxpow())
+    if (block.IsAuxpow())
     {
         ReadBlockHeaderFromDisk(block, this);
         return block;
     }
 
-    block.nVersion       = nVersion;
     if (pprev)
         block.hashPrevBlock = pprev->GetBlockHash();
     block.hashMerkleRoot = hashMerkleRoot;

--- a/src/chain.h
+++ b/src/chain.h
@@ -139,7 +139,7 @@ public:
     unsigned int nStatus;
 
     //! block header
-    CBlockVersion nVersion;
+    int nVersion;
     uint256 hashMerkleRoot;
     unsigned int nTime;
     unsigned int nBits;
@@ -163,7 +163,7 @@ public:
         nStatus = 0;
         nSequenceId = 0;
 
-        nVersion.SetNull();
+        nVersion       = 0;
         hashMerkleRoot = uint256();
         nTime          = 0;
         nBits          = 0;
@@ -269,6 +269,13 @@ public:
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
+
+    /* Analyse the block version.  */
+    inline int GetBaseVersion() const
+    {
+        return CPureBlockHeader::GetBaseVersion(nVersion);
+    }
+
 };
 
 /** Used to marshal pointers into hashes for db storage. */

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -122,7 +122,7 @@ public:
         genesis.vtx.push_back(txNew);
         genesis.hashPrevBlock.SetNull();
         genesis.hashMerkleRoot = genesis.BuildMerkleTree();
-        genesis.nVersion.SetGenesisVersion(1);
+        genesis.nVersion = 1;
         genesis.nTime    = 1386325540;
         genesis.nBits    = 0x1e0ffff0;
         genesis.nNonce   = 99943;

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -89,17 +89,17 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
        the chain ID is correct.  Legacy blocks are not allowed since
        the merge-mining start, which is checked in AcceptBlockHeader
        where the height is known.  */
-    if (!block.nVersion.IsLegacy() && params.fStrictChainId && block.nVersion.GetChainId() != params.nAuxpowChainId)
+    if (!block.IsLegacy() && params.fStrictChainId && block.GetChainId() != params.nAuxpowChainId)
         return error("%s : block does not have our chain ID"
                      " (got %d, expected %d, full nVersion %d)",
                      __func__,
-                     block.nVersion.GetChainId(),
+                     block.GetChainId(),
                      params.nAuxpowChainId,
-                     block.nVersion.GetFullVersion());
+                     block.nVersion);
 
     /* If there is no auxpow, just check the block hash.  */
     if (!block.auxpow) {
-        if (block.nVersion.IsAuxpow())
+        if (block.IsAuxpow())
             return error("%s : no auxpow on block with auxpow version",
                          __func__);
 
@@ -111,10 +111,10 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
 
     /* We have auxpow.  Check it.  */
 
-    if (!block.nVersion.IsAuxpow())
+    if (!block.IsAuxpow())
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
-    if (!block.auxpow->check(block.GetHash(), block.nVersion.GetChainId(), params))
+    if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
         return error("%s : AUX POW is not valid", __func__);
     if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))
         return error("%s : AUX proof of work failed", __func__);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2117,7 +2117,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         const CBlockIndex* pindex = chainActive.Tip();
         for (int i = 0; i < 100 && pindex != NULL; i++)
         {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION)
+            if (pindex->GetBaseVersion() > CBlock::CURRENT_VERSION)
                 ++nUpgraded;
             pindex = pindex->pprev;
         }
@@ -2761,14 +2761,14 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // Disallow legacy blocks after merge-mining start.
     if (!consensusParams.fAllowLegacyBlocks
-        && block.nVersion.IsLegacy())
+        && block.IsLegacy())
         return state.DoS(100, error("%s : legacy block after auxpow start at height %d, parameters effective from %d",
                                     __func__, pindexPrev->nHeight + 1, consensusParams.nHeightEffective),
                          REJECT_INVALID, "late-legacy-block");
 
     // Disallow AuxPow blocks before it is activated.
     if (!consensusParams.fAllowAuxPow
-        && block.nVersion.IsAuxpow())
+        && block.IsAuxpow())
         return state.DoS(100, error("%s : auxpow blocks are not allowed at height %d, parameters effective from %d",
                                     __func__, pindexPrev->nHeight + 1, consensusParams.nHeightEffective),
                          REJECT_INVALID, "early-auxpow-block");
@@ -2798,7 +2798,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // Reject block version if it is lower than consensusParams.nMinBlockVersion
     if (block.nVersion < consensusParams.nMinBlockVersion)
-        return state.Invalid(error("%s : rejected nVersion=%d block", __func__, block.nVersion.GetFullVersion() & 0x000000ff),
+        return state.Invalid(error("%s : rejected nVersion=%d block", __func__, block.GetBaseVersion()),
                              REJECT_OBSOLETE, "bad-version");
 
     return true;
@@ -2936,7 +2936,7 @@ static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned 
     unsigned int nFound = 0;
     for (int i = 0; i < consensusParams.nMajorityWindow && nFound < nRequired && pstart != NULL; i++)
     {
-        if (pstart->nVersion >= minVersion)
+        if (pstart->GetBaseVersion() >= minVersion)
             ++nFound;
         pstart = pstart->pprev;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -102,13 +102,13 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     CBlock *pblock = &pblocktemplate->block; // pointer for convenience
 
     /* Initialise the block version.  */
-    pblock->nVersion = CBlockHeader::CURRENT_VERSION;
-    pblock->nVersion.SetChainId(chainparams.GetConsensus(0).nAuxpowChainId);
+    const int32_t nChainId = chainparams.GetConsensus(0).nAuxpowChainId;
+    pblock->SetBaseVersion(CBlockHeader::CURRENT_VERSION, nChainId);
 
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
-    if (Params().MineBlocksOnDemand())
-        pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
+    if (chainparams.MineBlocksOnDemand())
+        pblock->SetBaseVersion(GetArg("-blockversion", pblock->GetBaseVersion()), nChainId);
 
     // Create coinbase tx
     CMutableTransaction txNew;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -15,11 +15,11 @@ void CBlockHeader::SetAuxpow (CAuxPow* apow)
     if (apow)
     {
         auxpow.reset(apow);
-        nVersion.SetAuxpow(true);
+        SetAuxpowVersion(true);
     } else
     {
         auxpow.reset();
-        nVersion.SetAuxpow(false);
+        SetAuxpowVersion(false);
     }
 }
 
@@ -122,7 +122,7 @@ std::string CBlock::ToString() const
     std::stringstream s;
     s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
-        nVersion.GetFullVersion(),
+        nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -37,9 +37,11 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(*(CPureBlockHeader*)this);
-        nVersion = this->nVersion;
 
-        if (this->nVersion.IsAuxpow()) {
+        nVersion = this->GetBaseVersion();
+
+        if (this->IsAuxpow())
+        {
             if (ser_action.ForRead())
                 auxpow.reset(new CAuxPow());
             assert(auxpow);

--- a/src/primitives/pureheader.cpp
+++ b/src/primitives/pureheader.cpp
@@ -21,3 +21,10 @@ uint256 CPureBlockHeader::GetPoWHash() const
     scrypt_1024_1_1_256(BEGIN(nVersion), BEGIN(thash));
     return thash;
 }
+
+void CPureBlockHeader::SetBaseVersion(int32_t nBaseVersion, int32_t nChainId)
+{
+    assert(nBaseVersion >= 1 && nBaseVersion < VERSION_AUXPOW);
+    assert(!IsAuxpow());
+    nVersion = nBaseVersion | (nChainId * VERSION_CHAIN_START);
+}

--- a/src/primitives/pureheader.h
+++ b/src/primitives/pureheader.h
@@ -10,11 +10,13 @@
 #include "uint256.h"
 
 /**
- * Encapsulate a block version.  This takes care of building it up
- * from a base version, the modifier flags (like auxpow) and
- * also the auxpow chain ID.
+ * A block header without auxpow information.  This "intermediate step"
+ * in constructing the full header is useful, because it breaks the cyclic
+ * dependency between auxpow (referencing a parent block header) and
+ * the block header (referencing an auxpow).  The parent block header
+ * does not have auxpow itself, so it is a pure header.
  */
-class CBlockVersion
+class CPureBlockHeader
 {
 private:
     /* Modifiers to the version.  */
@@ -23,11 +25,17 @@ private:
     /** Bits above are reserved for the auxpow chain ID.  */
     static const int32_t VERSION_CHAIN_START = (1 << 16);
 
-    /** The version as integer.  Should not be accessed directly.  */
-    int nVersion;
-
 public:
-    inline CBlockVersion()
+    // header
+    static const int32_t CURRENT_VERSION=3;
+    int32_t nVersion;
+    uint256 hashPrevBlock;
+    uint256 hashMerkleRoot;
+    uint32_t nTime;
+    uint32_t nBits;
+    uint32_t nNonce;
+
+    CPureBlockHeader()
     {
         SetNull();
     }
@@ -38,12 +46,65 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
         READWRITE(this->nVersion);
+        nVersion = this->GetBaseVersion();
+        READWRITE(hashPrevBlock);
+        READWRITE(hashMerkleRoot);
+        READWRITE(nTime);
+        READWRITE(nBits);
+        READWRITE(nNonce);
     }
 
-    inline void SetNull()
+    void SetNull()
     {
         nVersion = 0;
+        hashPrevBlock.SetNull();
+        hashMerkleRoot.SetNull();
+        nTime = 0;
+        nBits = 0;
+        nNonce = 0;
     }
+
+    bool IsNull() const
+    {
+        return (nBits == 0);
+    }
+
+    uint256 GetHash() const;
+
+    uint256 GetPoWHash() const;
+
+    int64_t GetBlockTime() const
+    {
+        return (int64_t)nTime;
+    }
+
+    /* Below are methods to interpret the version with respect to
+       auxpow data and chain ID.  This used to be in the CBlockVersion
+       class, but was moved here when we switched back to nVersion being
+       a pure int member as preparation to undoing the "abuse" and
+       allowing BIP9 to work.  */
+
+    /**
+     * Extract the base version (without modifiers and chain ID).
+     * @return The base version./
+     */
+    inline int32_t GetBaseVersion() const
+    {
+        return GetBaseVersion(nVersion);
+    }
+    static inline int32_t GetBaseVersion(int32_t ver)
+    {
+        return ver % VERSION_AUXPOW;
+    }
+
+    /**
+     * Set the base version (apart from chain ID and auxpow flag) to
+     * the one given.  This should only be called when auxpow is not yet
+     * set, to initialise a block!
+     * @param nBaseVersion The base version.
+     * @param nChainId The auxpow chain ID.
+     */
+    void SetBaseVersion(int32_t nBaseVersion, int32_t nChainId);
 
     /**
      * Extract the chain ID.
@@ -65,25 +126,6 @@ public:
     }
 
     /**
-     * Extract the full version.  Used for RPC results and debug prints.
-     * @return The full version.
-     */
-    inline int32_t GetFullVersion() const
-    {
-        return nVersion;
-    }
-
-    /**
-     * Set the genesis block version.  This must be a literal write
-     * through, to get the correct historic version.
-     * @param nGenesisVersion The version to set.
-     */
-    inline void SetGenesisVersion(int32_t nGenesisVersion)
-    {
-        nVersion = nGenesisVersion;
-    }
-
-    /**
      * Check if the auxpow flag is set in the version.
      * @return True iff this block version is marked as auxpow.
      */
@@ -96,7 +138,7 @@ public:
      * Set the auxpow flag.  This is used for testing.
      * @param auxpow Whether to mark auxpow as true.
      */
-    inline void SetAuxpow(bool auxpow)
+    inline void SetAuxpowVersion(bool auxpow)
     {
         if (auxpow)
             nVersion |= VERSION_AUXPOW;
@@ -114,88 +156,6 @@ public:
             || (nVersion == 2 && GetChainId() == 0);
     }
 
-    CBlockVersion& operator=(const CBlockVersion& other)
-    {
-        nVersion = other.nVersion;
-        return *this;
-    }
-
-    CBlockVersion& operator=(const int nBaseVersion)
-    {
-        nVersion = (nBaseVersion & 0x000000ff) | (nVersion & 0xffffff00);
-        return *this;
-    }
-
-    operator int() { return nVersion & 0x000000ff; }
-    friend inline bool operator==(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) == b; }
-    friend inline bool operator!=(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) != b; }
-    friend inline bool operator>(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) > b; }
-    friend inline bool operator<(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) < b; }
-    friend inline bool operator>=(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) >= b; }
-    friend inline bool operator<=(const CBlockVersion a, const int b) { return (a.nVersion & 0x000000ff) <= b; }
-};
-
-/**
- * A block header without auxpow information.  This "intermediate step"
- * in constructing the full header is useful, because it breaks the cyclic
- * dependency between auxpow (referencing a parent block header) and
- * the block header (referencing an auxpow).  The parent block header
- * does not have auxpow itself, so it is a pure header.
- */
-class CPureBlockHeader
-{
-public:
-    // header
-    static const int32_t CURRENT_VERSION = 3;
-    CBlockVersion nVersion;
-    uint256 hashPrevBlock;
-    uint256 hashMerkleRoot;
-    uint32_t nTime;
-    uint32_t nBits;
-    uint32_t nNonce;
-
-    CPureBlockHeader()
-    {
-        SetNull();
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(hashPrevBlock);
-        READWRITE(hashMerkleRoot);
-        READWRITE(nTime);
-        READWRITE(nBits);
-        READWRITE(nNonce);
-    }
-
-    void SetNull()
-    {
-        nVersion.SetNull();
-        hashPrevBlock.SetNull();
-        hashMerkleRoot.SetNull();
-        nTime = 0;
-        nBits = 0;
-        nNonce = 0;
-    }
-
-    bool IsNull() const
-    {
-        return (nBits == 0);
-    }
-
-    uint256 GetHash() const;
-
-    uint256 GetPoWHash() const;
-
-    int64_t GetBlockTime() const
-    {
-        return (int64_t)nTime;
-    }
 };
 
 #endif // BITCOIN_PRIMITIVES_PUREHEADER_H

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -83,6 +83,33 @@ static Object auxpowToJSON(const CAuxPow& auxpow)
     return result;
 }
 
+Object blockheaderToJSON(const CBlockIndex* blockindex)
+{
+    Object result;
+    result.push_back(Pair("hash", blockindex->GetBlockHash().GetHex()));
+    int confirmations = -1;
+    // Only report confirmations if the block is on the main chain
+    if (chainActive.Contains(blockindex))
+        confirmations = chainActive.Height() - blockindex->nHeight + 1;
+    result.push_back(Pair("confirmations", confirmations));
+    result.push_back(Pair("height", blockindex->nHeight));
+    result.push_back(Pair("version", blockindex->nVersion));
+    result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
+    result.push_back(Pair("time", (int64_t)blockindex->nTime));
+    result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
+    result.push_back(Pair("nonce", (uint64_t)blockindex->nNonce));
+    result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
+    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
+    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+
+    if (blockindex->pprev)
+        result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
+    CBlockIndex *pnext = chainActive.Next(blockindex);
+    if (pnext)
+        result.push_back(Pair("nextblockhash", pnext->GetBlockHash().GetHex()));
+    return result;
+}
+
 Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false)
 {
     Object result;
@@ -94,7 +121,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDe
     result.push_back(Pair("confirmations", confirmations));
     result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
     result.push_back(Pair("height", blockindex->nHeight));
-    result.push_back(Pair("version", block.nVersion.GetFullVersion()));
+    result.push_back(Pair("version", block.nVersion));
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
     Array txs;
     BOOST_FOREACH(const CTransaction&tx, block.vtx)

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -570,7 +570,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
 
     Object result;
     result.push_back(Pair("capabilities", aCaps));
-    result.push_back(Pair("version", pblock->nVersion.GetFullVersion()));
+    result.push_back(Pair("version", pblock->nVersion));
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
@@ -821,8 +821,8 @@ Value getauxblockbip22(const Array& params, bool fHelp)
             // Finalise it by setting the version and building the merkle root
             CBlock* pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
-            pblock->nVersion.SetAuxpow(true);
             pblock->hashMerkleRoot = pblock->BuildMerkleTree();
+            pblock->SetAuxpowVersion(true);
 
             // Save
             mapNewBlock[pblock->GetHash()] = pblock;
@@ -840,7 +840,7 @@ Value getauxblockbip22(const Array& params, bool fHelp)
 
         json_spirit::Object result;
         result.push_back(Pair("hash", block.GetHash().GetHex()));
-        result.push_back(Pair("chainid", block.nVersion.GetChainId()));
+        result.push_back(Pair("chainid", block.GetChainId()));
         result.push_back(Pair("previousblockhash", block.hashPrevBlock.GetHex()));
         result.push_back(Pair("coinbasevalue", (int64_t)block.vtx[0].vout[0].nValue));
         result.push_back(Pair("bits", strprintf("%08x", block.nBits)));

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -111,8 +111,7 @@ public:
 CAuxpowBuilder::CAuxpowBuilder(int baseVersion, int chainId)
     : auxpowChainIndex(-1)
 {
-    parentBlock.nVersion = baseVersion;
-    parentBlock.nVersion.SetChainId(chainId);
+    parentBlock.SetBaseVersion(baseVersion, chainId);
 }
 
 void
@@ -222,9 +221,9 @@ BOOST_AUTO_TEST_CASE(check_auxpow)
 
     /* The parent chain can't have the same chain ID.  */
     CAuxpowBuilder builder2(builder);
-    builder2.parentBlock.nVersion.SetChainId(100);
+    builder2.parentBlock.SetChainId(100);
     BOOST_CHECK(builder2.get().check(hashAux, ourChainId, params));
-    builder2.parentBlock.nVersion.SetChainId(ourChainId);
+    builder2.parentBlock.SetChainId(ourChainId);
     BOOST_CHECK(!builder2.get().check(hashAux, ourChainId, params));
 
     /* Disallow too long merkle branches.  */
@@ -356,34 +355,33 @@ BOOST_AUTO_TEST_CASE(auxpow_pow)
 
     /* Verify the block version checks.  */
 
-    block.nVersion.SetGenesisVersion(1);
+    block.nVersion = 1;
     mineBlock(block, true);
     BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
 
     // Dogecoin block version 2 can be both AuxPoW and regular, so test 3
 
-    block.nVersion.SetGenesisVersion(3);
+    block.nVersion = 3;
     mineBlock(block, true);
     BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
 
-    block.nVersion = 2;
-    block.nVersion.SetChainId(params.nAuxpowChainId);
+    block.SetBaseVersion (2, params.nAuxpowChainId);
     mineBlock(block, true);
     BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
 
-    block.nVersion.SetChainId(params.nAuxpowChainId + 1);
+    block.SetChainId(params.nAuxpowChainId + 1);
     mineBlock(block, true);
     BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
 
     /* Check the case when the block does not have auxpow (this is true
      right now).  */
 
-    block.nVersion.SetChainId(params.nAuxpowChainId);
-    block.nVersion.SetAuxpow(true);
+    block.SetChainId(params.nAuxpowChainId);
+    block.SetAuxpowVersion(true);
     mineBlock(block, true);
     BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
 
-    block.nVersion.SetAuxpow(false);
+    block.SetAuxpowVersion(false);
     mineBlock(block, true);
     BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
     mineBlock(block, false);
@@ -401,7 +399,7 @@ BOOST_AUTO_TEST_CASE(auxpow_pow)
     std::vector<unsigned char> auxRoot, data;
 
     /* Valid auxpow, PoW check of parent block.  */
-    block.nVersion.SetAuxpow(true);
+    block.SetAuxpowVersion(true);
     auxRoot = builder.buildAuxpowChain(block.GetHash(), height, index);
     data = CAuxpowBuilder::buildCoinbaseData(true, auxRoot, height, nonce);
     builder.setCoinbase(CScript() << data);
@@ -416,7 +414,7 @@ BOOST_AUTO_TEST_CASE(auxpow_pow)
      block.SetAuxpow sets also the version and that we want to ensure
      that the block hash itself doesn't change due to version changes.
      This requires some work arounds.  */
-    block.nVersion.SetAuxpow(false);
+    block.SetAuxpowVersion(false);
     const uint256 hashAux = block.GetHash();
     auxRoot = builder.buildAuxpowChain(hashAux, height, index);
     data = CAuxpowBuilder::buildCoinbaseData(true, auxRoot, height, nonce);
@@ -424,12 +422,12 @@ BOOST_AUTO_TEST_CASE(auxpow_pow)
     mineBlock(builder.parentBlock, true, block.nBits);
     block.SetAuxpow(new CAuxPow(builder.get()));
     BOOST_CHECK(hashAux != block.GetHash());
-    block.nVersion.SetAuxpow(false);
+    block.SetAuxpowVersion(false);
     BOOST_CHECK(hashAux == block.GetHash());
     BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
 
     /* Modifying the block invalidates the PoW.  */
-    block.nVersion.SetAuxpow(true);
+    block.SetAuxpowVersion(true);
     auxRoot = builder.buildAuxpowChain(block.GetHash(), height, index);
     data = CAuxpowBuilder::buildCoinbaseData(true, auxRoot, height, nonce);
     builder.setCoinbase(CScript() << data);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     {
 
         CBlock *pblock = &pblocktemplate->block; // pointer for convenience
-        pblock->nVersion.SetGenesisVersion(1);
+        pblock->nVersion = 1;
 
         // Replaced chainActive.Tip()->GetMedianTimePast()+1 with an actual 60 second block
         // interval because median([1,2,2,3,3,3,4,4,4,4]) will eventually be problematic re:


### PR DESCRIPTION
Backported from namecore.

This makes nVersion an int32 again and re-implements AuxPow determination logic on CBlock instead of CBlockVersion, so that we can easily manipulate this logic later on when we fork to stop abusing the nVersion attribute.
