### PR TITLE
Revert "Disable payment protocol certificate unit tests"

### DIFF
--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -79,8 +79,6 @@ void PaymentServerTests::paymentServerTests()
 
     // Now feed PaymentRequests to server, and observe signals it produces
 
-    /* Disable certificate tests as we don't touch this code, and building test
-       data would take significant effort. Also pending discussion on spec
     // This payment request validates directly against the
     // caCert1 certificate authority:
     data = DecodeBase64(paymentrequest1_cert1_BASE64);
@@ -104,7 +102,7 @@ void PaymentServerTests::paymentServerTests()
     data = DecodeBase64(paymentrequest4_cert1_BASE64);
     r = handleRequest(server, data);
     r.paymentRequest.getMerchant(caStore, merchant);
-    QCOMPARE(merchant, QString("")); */
+    QCOMPARE(merchant, QString(""));
 
     // Validly signed, but by a CA not in our root CA list:
     data = DecodeBase64(paymentrequest5_cert1_BASE64);


### PR DESCRIPTION
For some reason I didn't have to do anything to make those pass. Did I miss anything?

```
$ src/qt/test/test_dogecoin-qt 
********* Start testing of URITests *********
Config: Using QtTest library 5.2.1, Qt 5.2.1
PASS   : URITests::initTestCase()
PASS   : URITests::uriTests()
PASS   : URITests::cleanupTestCase()
Totals: 3 passed, 0 failed, 0 skipped
********* Finished testing of URITests *********
********* Start testing of PaymentServerTests *********
Config: Using QtTest library 5.2.1, Qt 5.2.1
PASS   : PaymentServerTests::initTestCase()
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::initNetManager: No active proxy server found. 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Secure payment request from  "testmerchant.org" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: Payment request: certificate expired or not yet active:  QSslCertificate( "3" , "03" , "LxHILx+N3qwVoAcCmQ5cyw==" , () , ("Expired Test Merchant") , QMap() , QDateTime("2013-02-23 21:26:43.000 UTC Qt::UTC") , QDateTime("2013-02-24 21:26:43.000 UTC Qt::UTC") ) 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Insecure payment request to  "DJkvsVmdCTtpeTG1ChQuQ3Q1A8mMbKdAaL" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: Payment request: certificate expired or not yet active:  QSslCertificate( "3" , "03" , "LxHILx+N3qwVoAcCmQ5cyw==" , () , ("Expired Test Merchant") , QMap() , QDateTime("2013-02-23 21:26:43.000 UTC Qt::UTC") , QDateTime("2013-02-24 21:26:43.000 UTC Qt::UTC") ) 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Secure payment request from  "testmerchant8.org" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: Payment request: certificate expired or not yet active:  QSslCertificate( "3" , "06" , "MiZaQ+g9lSHZGuHWkXZG+g==" , () , ("Payment Request Intermediate 5") , QMap() , QDateTime("2013-02-23 22:59:51.000 UTC Qt::UTC") , QDateTime("2013-02-24 22:59:51.000 UTC Qt::UTC") ) 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Insecure payment request to  "DJkvsVmdCTtpeTG1ChQuQ3Q1A8mMbKdAaL" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: Payment request: certificate expired or not yet active:  QSslCertificate( "3" , "06" , "MiZaQ+g9lSHZGuHWkXZG+g==" , () , ("Payment Request Intermediate 5") , QMap() , QDateTime("2013-02-23 22:59:51.000 UTC Qt::UTC") , QDateTime("2013-02-24 22:59:51.000 UTC Qt::UTC") ) 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: SSL error:  certificate signature failure 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Insecure payment request to  "DJkvsVmdCTtpeTG1ChQuQ3Q1A8mMbKdAaL" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: SSL error:  certificate signature failure 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: SSL error:  unable to get local issuer certificate 
QDEBUG : PaymentServerTests::paymentServerTests() PaymentServer::processPaymentRequest: Insecure payment request to  "DJkvsVmdCTtpeTG1ChQuQ3Q1A8mMbKdAaL" 
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: SSL error:  unable to get local issuer certificate 
QWARN  : PaymentServerTests::paymentServerTests() "PaymentServer::verifyNetwork: Payment request network "test" doesn't match client network "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"." 
QWARN  : PaymentServerTests::paymentServerTests() "PaymentServer::verifyExpired: Payment request expired "1970-01-01 00:00:01"." 
QWARN  : PaymentServerTests::paymentServerTests() "PaymentServer::verifyExpired: Payment request expired "1970-01-01 00:00:00"." 
QWARN  : PaymentServerTests::paymentServerTests() "PaymentServer::readPaymentRequestFromFile: Payment request /tmp/Bitcoin-Qt-test.S10256 is too large (50001 bytes, allowed 50000 bytes)." 
PASS   : PaymentServerTests::paymentServerTests()
PASS   : PaymentServerTests::cleanupTestCase()
Totals: 3 passed, 0 failed, 0 skipped
********* Finished testing of PaymentServerTests *********
```