### PR TITLE
Make getauxblock rpc test work for Dogecoin

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -17,6 +17,7 @@ fi
 
 testScripts=(
     'auxpow.py'
+    'getauxblock.py'
     'wallet.py'
     'listtransactions.py'
     'mempool_resurrect_test.py'


### PR DESCRIPTION
We havent enabled this rpc test for some reason unknown to me, but since it was easy to make it work, I want to pull this in early, so that we can actually test regressions and make expected outcomes visible for changes to come.
