### PR TITLE
Add -strictprotocolversion to limit peer connections to our or greater protocol version

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -320,6 +320,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), 1));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
+    strUsage += HelpMessageOpt("-strictprotoversion", strprintf(_("Only allow connections from peers with protocol version equal to or greater than ours (default: %u)"), false));
     strUsage += HelpMessageOpt("-timeout=<n>", strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"), DEFAULT_CONNECT_TIMEOUT));
     strUsage += HelpMessageOpt("-bloomfilters", _("Allow peers to set bloom filters (default: 1)"));
 #ifdef USE_UPNP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3987,12 +3987,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CAddress addrFrom;
         uint64_t nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
-        if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
+
+        int nMinProtoVersion = GetBoolArg("-strictprotoversion", false) ?
+            PROTOCOL_VERSION : MIN_PEER_PROTO_VERSION;
+
+        if (pfrom->nVersion < nMinProtoVersion)
         {
             // disconnect from peers older than this proto version
             LogPrintf("peer=%d using obsolete version %i; disconnecting\n", pfrom->id, pfrom->nVersion);
             pfrom->PushMessage("reject", strCommand, REJECT_OBSOLETE,
-                               strprintf("Version must be %d or greater", MIN_PEER_PROTO_VERSION));
+                               strprintf("Version must be %d or greater", nMinProtoVersion));
             pfrom->fDisconnect = true;
             return false;
         }


### PR DESCRIPTION
Enables node admins to set the minimum protocol version to the protocol version implemented by this client and reject otherwise compatible protocol versions. This is useful when old nodes are forking the chain, preventing sync.
