### PR TITLE
Introduce Params.NetBlockTimeout()

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -154,6 +154,7 @@ public:
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = false;
+        nNetBlockTimeout = 500000 * 60; // half the block target (30 seconds)
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
@@ -286,6 +287,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
+        nNetBlockTimeout = 500000 * 60; // half the block target (30 seconds)
 
         checkpointData = (Checkpoints::CCheckpointData) {
             boost::assign::map_list_of
@@ -378,6 +380,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
         fTestnetToBeDeprecatedFieldRPC = false;
+        nNetBlockTimeout = 500000 * 60; // half the mainnet block target (30 seconds)
 
         checkpointData = (Checkpoints::CCheckpointData){
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -83,6 +83,8 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
     bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
+    /** The time in microseconds we allow an incoming block to be in transit */
+    int NetBlockTimeout() const { return nNetBlockTimeout; }
     /** Return the BIP70 network string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
@@ -112,6 +114,7 @@ protected:
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
     bool fTestnetToBeDeprecatedFieldRPC;
+    int nNetBlockTimeout;
     Checkpoints::CCheckpointData checkpointData;
 };
 


### PR DESCRIPTION
Currently, the time that a block can be in transit is calculated relative to `Consensus.nPowTargetSpacing`. While this is convenient when you have 10 minute blocks, at our regtest target spacing of 1 second this does not make much sense. This change decouples the timeout value from the target spacing, allowing us to tune this parameter independent of target spacing and consensus params, per chain.

Timeout values for mainnet and testnet chains remain unchanged in this commit, but regtest now reflects the same absolute value as mainnet and testnet, 30 seconds.

Previously the base timeout value in microseconds was calculated as `500000 * targetSpacing`, setting a 500ms timeout on our regtest chain. I have ran into issues where my test VM was under heavy load and regtest nodes needed more than 500ms to transfer big blocks.

NOTE: I am not sure if 30 seconds is a good value but it reflects the value on mainnet before this change. 