### PR TITLE
[depends] fix multiple depends url issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_script:
     - unset CC; unset CXX
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/install-deps.sh; fi
-    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then wget $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -O depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
+    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
 script:

--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -7,7 +7,7 @@ build_darwin_OTOOL: = $(shell xcrun -f otool)
 build_darwin_NM: = $(shell xcrun -f nm)
 build_darwin_INSTALL_NAME_TOOL:=$(shell xcrun -f install_name_tool)
 build_darwin_SHA256SUM = shasum -a 256
-build_darwin_DOWNLOAD = curl --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
+build_darwin_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
 darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION)

--- a/depends/builders/linux.mk
+++ b/depends/builders/linux.mk
@@ -1,2 +1,2 @@
 build_linux_SHA256SUM = sha256sum
-build_linux_DOWNLOAD = wget --timeout=$(DOWNLOAD_CONNECT_TIMEOUT) --tries=$(DOWNLOAD_RETRIES) -nv -O
+build_linux_DOWNLOAD = curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -L -o

--- a/depends/packages/dbus.mk
+++ b/depends/packages/dbus.mk
@@ -1,6 +1,6 @@
 package=dbus
 $(package)_version=1.8.6
-$(package)_download_path=http://dbus.freedesktop.org/releases/dbus
+$(package)_download_path=https://dbus.freedesktop.org/releases/dbus
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=eded83ca007b719f32761e60fd8b9ffd0f5796a4caf455b01b5a5ef740ebd23f
 $(package)_dependencies=expat

--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,6 +1,6 @@
 package=native_ccache
 $(package)_version=3.1.9
-$(package)_download_path=http://samba.org/ftp/ccache
+$(package)_download_path=https://www.samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
 $(package)_sha256_hash=04d3e2e438ac8d4cc4b110b68cdd61bd59226c6588739a4a386869467f5ced7c
 

--- a/depends/packages/native_protobuf.mk
+++ b/depends/packages/native_protobuf.mk
@@ -1,6 +1,6 @@
 package=native_protobuf
 $(package)_version=2.5.0
-$(package)_download_path=https://protobuf.googlecode.com/files
+$(package)_download_path=https://github.com/google/protobuf/releases/download/v$($(package)_version)
 $(package)_file_name=protobuf-$($(package)_version).tar.bz2
 $(package)_sha256_hash=13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677
 


### PR DESCRIPTION
- *Fetches protobuf 2.5.0 from github instead of googlecode because the old link seems to be dead.*
- *Fixes samba.org url from http://samba.org to https://www.samba.org*
- *Pulls in* `c01f08d`, `5d1148c` and `1ecbb3b` *from upstream to switch to curl instead of wget*
- *Fixes dbus url to be https by default*

Ultimately resolving: 
- secondary issue in #1356
- travis killing each and every build

Requesting against the maint branch directly because this is only relevant for users that compile their own code. No binary release required. Once reviewed could also PR this against 1.10.1-dev, or update dependencies altogether, or both, or none.... whatever is preferred.