### PR TITLE
Adding snap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,8 @@ qa/pull-tester/test.*/*
 /doc/doxygen/
 
 libbitcoinconsensus.pc
+
+parts/
+prime/
+stage/
+*.snap

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -222,3 +222,13 @@ In this case there is no dependency on Berkeley DB 4.8.
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call, not `getwork`.
 
+Snap
+====
+
+Dogecoin is now also available as a Snap, via the Snap Store. On a system with snapd installed, install via:
+
+    sudo snap install dogecoin-core
+
+The GUI for the Snap version is built with QT4, and requires the process-control plug to be manually enabled:
+
+    sudo snap connect dogecoin-core:process-control core:process-control

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -222,23 +222,21 @@ In this case there is no dependency on Berkeley DB 4.8.
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call, not `getwork`.
 
-Snap
+Snapcraft
 ====
 
-Dogecoin is now also available as a [Snap](https://www.ubuntu.com/desktop/snappy). On compatible systems, install via:
+You can also build Dogecoin Core with [Snapcraft](https://snapcraft.io/) on supported systems by pulling the source repo, and running 'snapcraft' within the root of the master branch.
 
-    sudo snap install dogecoin-core
+The resulting .snap file can then be installed locally via:
 
-The GUI for the Snap version is built with QT4, and requires the process-control plug to be manually enabled:
+    sudo snap install --dangerous <filename>
+
+The GUI for the Snap version will be built with QT4, and requires the process-control plug to be manually enabled:
 
     sudo snap connect dogecoin-core:process-control core:process-control
 
-The Snap is built with Berkeley DB, protobuf and libqrencode, but without miniupnp due to compatibility issues.
+It's built with Berkeley DB, protobuf and libqrencode, but without miniupnp due to compatibility issues.
 
 All user data files are stored in the $SNAP_USER_COMMON directory, normally $HOME/snap/dogecoin-core/common, rather than the versioned SNAP_USER_DATA directories in order to avoid duplication of potentially ~20GB+ of blockchain data on every upgrade.
 
-Be aware that uninstalling the Snap will automatically remove its data, including the wallet file!  The Snap can write to home directories in order to facilitate wallet exports, but this requires the home plug to be manually enabled:
-
-    sudo snap connect dogecoin-core:home core:home
-
-You can build the Snap yourself with [Snapcraft](https://snapcraft.io/) by pulling the source repo, and running 'snapcraft' within the root of the master branch.
+Be aware that uninstalling the Snap will automatically remove its data, including the wallet file!

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -225,10 +225,20 @@ call, not `getwork`.
 Snap
 ====
 
-Dogecoin is now also available as a Snap, via the Snap Store. On a system with snapd installed, install via:
+Dogecoin is now also available as a [Snap](https://www.ubuntu.com/desktop/snappy). On compatible systems, install via:
 
     sudo snap install dogecoin-core
 
 The GUI for the Snap version is built with QT4, and requires the process-control plug to be manually enabled:
 
     sudo snap connect dogecoin-core:process-control core:process-control
+
+The Snap is built with Berkeley DB, protobuf and libqrencode, but without miniupnp due to compatibility issues.
+
+All user data files are stored in the $SNAP_USER_COMMON directory, normally $HOME/snap/dogecoin-core/common, rather than the versioned SNAP_USER_DATA directories in order to avoid duplication of potentially ~20GB+ of blockchain data on every upgrade.
+
+Be aware that uninstalling the Snap will automatically remove its data, including the wallet file!  The Snap can write to home directories in order to facilitate wallet exports, but this requires the home plug to be manually enabled:
+
+    sudo snap connect dogecoin-core:home core:home
+
+You can build the Snap yourself with [Snapcraft](https://snapcraft.io/) by pulling the source repo, and running 'snapcraft' within the root of the master branch.

--- a/snap_cli_app_wrapper
+++ b/snap_cli_app_wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$SNAP/bin/dogecoin-cli -datadir=$SNAP_USER_COMMON "$@"

--- a/snap_cli_app_wrapper
+++ b/snap_cli_app_wrapper
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-$SNAP/bin/dogecoin-cli -datadir=$SNAP_USER_COMMON "$@"

--- a/snap_gui_app_wrapper
+++ b/snap_gui_app_wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$SNAP/bin/dogecoin-qt -datadir=$SNAP_USER_COMMON "$@"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,12 +12,6 @@ apps:
     command: qt4-launch bin/dogecoin-qt.wrapper
     desktop: usr/share/applications/dogecoin-qt.desktop
     plugs: [network, network-bind, unity7, home, process-control]
-  dogecoin-cli:
-    command: bin/dogecoin-cli.wrapper
-    plugs:
-      - network
-  dogecoin-tx:
-    command: bin/dogecoin-tx
 
 parts:
   dogecoin:
@@ -51,14 +45,11 @@ parts:
     prepare: |
       sed 's|Icon=dogecoin128|Icon=/snap/dogecoin-core/current/meta/gui/icon.png|' -i contrib/debian/dogecoin-qt.desktop
     organize:
-      snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
       snap_gui_app_wrapper: bin/dogecoin-qt.wrapper
       contrib/debian/dogecoin-qt.desktop: usr/share/applications/dogecoin-qt.desktop
     stage:
-      - bin/dogecoin-cli.wrapper
       - bin/dogecoin-qt.wrapper
       - usr/share/applications/dogecoin-qt.desktop
     prime:
-      - bin/dogecoin-cli.wrapper
       - bin/dogecoin-qt.wrapper
       - usr/share/applications/dogecoin-qt.desktop

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -46,10 +46,19 @@ parts:
       - libqtgui4
     after: [qt4conf]
   fold-ins:
-    after: [dogecoin]
     plugin: dump
     source: .
+    prepare: |
+      sed 's|Icon=dogecoin128|Icon=$SNAP/meta/gui/icon.svg|' -i contrib/debian/dogecoin-qt.desktop
     organize:
       snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
       snap_gui_app_wrapper: bin/dogecoin-qt.wrapper
       contrib/debian/dogecoin-qt.desktop: usr/share/applications/dogecoin-qt.desktop
+    stage:
+      - bin/dogecoin-cli.wrapper
+      - bin/dogecoin-qt.wrapper
+      - usr/share/applications/dogecoin-qt.desktop
+    prime:
+      - bin/dogecoin-cli.wrapper
+      - bin/dogecoin-qt.wrapper
+      - usr/share/applications/dogecoin-qt.desktop

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ apps:
   dogecoin-qt:
     command: qt4-launch bin/dogecoin-qt.wrapper
     desktop: usr/share/applications/dogecoin-qt.desktop
-    plugs: [network, network-bind, unity7, process-control]
+    plugs: [network, network-bind, unity7, home, process-control]
   dogecoin-cli:
     command: bin/dogecoin-cli.wrapper
     plugs:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -30,6 +30,7 @@ parts:
     build-packages:
       - autoconf
       - autotools-dev
+      - bsdmainutils
       - build-essential
       - libboost-all-dev                                                       
       - libdb++-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,7 @@ description: Dogecoin Core is the reference Dogecoin client and it builds the ba
 confinement: strict
 grade: stable
 type: app
-icon: src/qt/res/src/bitcoin.svg
+icon: src/qt/res/icons/bitcoin.png
 
 apps:
   dogecoin-qt:
@@ -49,7 +49,7 @@ parts:
     plugin: dump
     source: .
     prepare: |
-      sed 's|Icon=dogecoin128|Icon=/snap/dogecoin-core/current/meta/gui/icon.svg|' -i contrib/debian/dogecoin-qt.desktop
+      sed 's|Icon=dogecoin128|Icon=/snap/dogecoin-core/current/meta/gui/icon.png|' -i contrib/debian/dogecoin-qt.desktop
     organize:
       snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
       snap_gui_app_wrapper: bin/dogecoin-qt.wrapper

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -3,13 +3,14 @@ version: "1.10"
 summary: Dogecoin Core
 description: Dogecoin Core is the reference Dogecoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Dogecoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 confinement: strict
-grade: devel
+grade: stable
+type: app
 icon: src/qt/res/src/bitcoin.svg
-#icon: meta/gui/icon.svg
 
 apps:
   dogecoin-qt:
     command: qt4-launch bin/dogecoin-qt.wrapper
+    desktop: usr/share/applications/dogecoin-qt.desktop
     plugs: [network, network-bind, unity7, home, process-control]
   dogecoin-cli:
     command: bin/dogecoin-cli.wrapper
@@ -45,18 +46,10 @@ parts:
       - libqtgui4
     after: [qt4conf]
   fold-ins:
+    after: [dogecoin]
     plugin: dump
     source: .
     organize:
       snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
       snap_gui_app_wrapper: bin/dogecoin-qt.wrapper
-      src/qt/res/src/bitcoin.svg: meta/gui/icon.svg
-      contrib/debian/dogecoin-qt.desktop: meta/gui/dogecoin.desktop
-    stage:
-      - bin/dogecoin-cli.wrapper
-      - bin/dogecoin-qt.wrapper
-      - meta/gui/dogecoin.desktop
-    prime:
-      - bin/dogecoin-cli.wrapper
-      - bin/dogecoin-qt.wrapper
-      - meta/gui/dogecoin.desktop
+      contrib/debian/dogecoin-qt.desktop: usr/share/applications/dogecoin-qt.desktop

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@ apps:
   dogecoin-qt:
     command: qt4-launch bin/dogecoin-qt.wrapper
     desktop: usr/share/applications/dogecoin-qt.desktop
-    plugs: [network, network-bind, unity7, home, process-control]
+    plugs: [network, network-bind, unity7, process-control]
   dogecoin-cli:
     command: bin/dogecoin-cli.wrapper
     plugs:
@@ -49,7 +49,7 @@ parts:
     plugin: dump
     source: .
     prepare: |
-      sed 's|Icon=dogecoin128|Icon=$SNAP/meta/gui/icon.svg|' -i contrib/debian/dogecoin-qt.desktop
+      sed 's|Icon=dogecoin128|Icon=/snap/dogecoin-core/current/meta/gui/icon.svg|' -i contrib/debian/dogecoin-qt.desktop
     organize:
       snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
       snap_gui_app_wrapper: bin/dogecoin-qt.wrapper

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,61 @@
+name: dogecoin-core
+version: "1.10"
+summary: Dogecoin Core
+description: Dogecoin Core is the reference Dogecoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Dogecoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
+confinement: strict
+grade: devel
+icon: src/qt/res/src/bitcoin.svg
+#icon: meta/gui/icon.svg
+
+apps:
+  dogecoin-qt:
+    command: qt4-launch bin/dogecoin-qt.wrapper
+    plugs: [network, network-bind, unity7, home, process-control]
+  dogecoin-cli:
+    command: bin/dogecoin-cli.wrapper
+    plugs:
+      - network
+  dogecoin-tx:
+    command: bin/dogecoin-tx
+
+parts:
+  dogecoin:
+    plugin: autotools
+    source: .
+    configflags:
+      - --with-gui=qt4
+      - --with-incompatible-bdb
+      - --with-miniupnpc=no
+      - --without-tests
+    build-packages:
+      - autoconf
+      - autotools-dev
+      - build-essential
+      - libboost-all-dev                                                       
+      - libdb++-dev
+      - libprotobuf-dev
+      - libqrencode-dev
+      - libqt4-dev
+      - libssl-dev
+      - libtool
+      - pkg-config
+      - protobuf-compiler
+    stage-packages:
+      - libqtgui4
+    after: [qt4conf]
+  fold-ins:
+    plugin: dump
+    source: .
+    organize:
+      snap_cli_app_wrapper: bin/dogecoin-cli.wrapper
+      snap_gui_app_wrapper: bin/dogecoin-qt.wrapper
+      src/qt/res/src/bitcoin.svg: meta/gui/icon.svg
+      contrib/debian/dogecoin-qt.desktop: meta/gui/dogecoin.desktop
+    stage:
+      - bin/dogecoin-cli.wrapper
+      - bin/dogecoin-qt.wrapper
+      - meta/gui/dogecoin.desktop
+    prime:
+      - bin/dogecoin-cli.wrapper
+      - bin/dogecoin-qt.wrapper
+      - meta/gui/dogecoin.desktop


### PR DESCRIPTION
Hi,

I've added a simple Snapcraft setup to the repo, which will automatically build a (sandboxed) version of the GUI app. Documentation added to the UNIX build page.

Currently this will build a QT4 version of the GUI app, but doesn't include the CLI utils (although they could certainly be added). I did have to disable UPnP support due to some assumptions the library makes about where it can open sockets. Otherwise though, it seems to work well.

I've also set up a (currently private/unpublished) registration for this in the Snap Store, which would  enable users on supported systems to be able to install the latest Dogecoin Core with a single command. Let me know if you'd be interested in supporting this, I'd be happy to transfer the registration over.