### PR TITLE
Change BIP65/66 enforcement to match Dogecoin

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -71,7 +71,9 @@ public:
     CMainParams() {
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 100000;
-        // XXX: BIP heights and hashes all need to be updated to Dogecoin values
+        consensus.nMajorityEnforceBlockUpgrade = 1500;
+        consensus.nMajorityRejectBlockOutdated = 1900;
+        consensus.nMajorityWindow = 2000;
         consensus.BIP34Height = 139314;
         consensus.BIP34Hash = uint256S("0x2c23095473d1afabfb630d41a395364e69da264a73c04dbcb4756c7d36c9b994");
         // consensus.BIP65Height = 1032483; // Not enabled in Doge yet
@@ -182,6 +184,9 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 100000;
+        consensus.nMajorityEnforceBlockUpgrade = 1500;
+        consensus.nMajorityRejectBlockOutdated = 1900;
+        consensus.nMajorityWindow = 2000;
         // XXX: BIP heights and hashes all need to be updated to Dogecoin values
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
@@ -280,6 +285,9 @@ public:
     CRegTestParams() {
         strNetworkID = "regtest";
         consensus.nSubsidyHalvingInterval = 150;
+        consensus.nMajorityEnforceBlockUpgrade = 750;
+        consensus.nMajorityRejectBlockOutdated = 950;
+        consensus.nMajorityWindow = 1000;
         consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
         consensus.BIP34Hash = uint256();
         // consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,10 +72,10 @@ public:
         strNetworkID = "main";
         consensus.nSubsidyHalvingInterval = 100000;
         // XXX: BIP heights and hashes all need to be updated to Dogecoin values
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.BIP34Height = 139314;
+        consensus.BIP34Hash = uint256S("0x2c23095473d1afabfb630d41a395364e69da264a73c04dbcb4756c7d36c9b994");
+        consensus.BIP65Height = 1032483; // I have no idea, this is a wild guess
+        consensus.BIP66Height = 1032483; // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the v3 block after the last v2 block, may be too low
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60; // 1 minute

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -77,7 +77,7 @@ public:
         consensus.BIP34Height = 139314;
         consensus.BIP34Hash = uint256S("0x2c23095473d1afabfb630d41a395364e69da264a73c04dbcb4756c7d36c9b994");
         // consensus.BIP65Height = 1032483; // Not enabled in Doge yet
-        consensus.BIP66Height = 1032483; // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the v3 block after the last v2 block, may be too low
+        consensus.BIP66Height = 1034383; // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the last block that could be v2, 1900 blocks past the last v2 block
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60; // 1 minute
@@ -191,7 +191,7 @@ public:
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         // consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-        consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        consensus.BIP66Height = 708658; // 21b8b97dcdb94caa67c7f8f6dbf22e61 - After this v2 Dogecoin blocks are rejected
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60; // 1 minute

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,8 +74,9 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 1500;
         consensus.nMajorityRejectBlockOutdated = 1900;
         consensus.nMajorityWindow = 2000;
-        consensus.BIP34Height = 139314;
-        consensus.BIP34Hash = uint256S("0x2c23095473d1afabfb630d41a395364e69da264a73c04dbcb4756c7d36c9b994");
+        // BIP34 is never enforced in Dogecoin v2 blocks, so we enforce from v3
+        consensus.BIP34Height = 1034383;
+        consensus.BIP34Hash = uint256S("0x80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a");
         // consensus.BIP65Height = 1032483; // Not enabled in Doge yet
         consensus.BIP66Height = 1034383; // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the last block that could be v2, 1900 blocks past the last v2 block
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
@@ -187,11 +188,11 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 1500;
         consensus.nMajorityRejectBlockOutdated = 1900;
         consensus.nMajorityWindow = 2000;
-        // XXX: BIP heights and hashes all need to be updated to Dogecoin values
-        consensus.BIP34Height = 21111;
-        consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
+        // BIP34 is never enforced in Dogecoin v2 blocks, so we enforce from v3
+        consensus.BIP34Height = 708658;
+        consensus.BIP34Hash = uint256S("0x21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38");
         // consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-        consensus.BIP66Height = 708658; // 21b8b97dcdb94caa67c7f8f6dbf22e61 - After this v2 Dogecoin blocks are rejected
+        consensus.BIP66Height = 708658; // 21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38 - this is the last block that could be v2, 1900 blocks past the last v2 block
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60; // 1 minute

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,7 +74,7 @@ public:
         // XXX: BIP heights and hashes all need to be updated to Dogecoin values
         consensus.BIP34Height = 139314;
         consensus.BIP34Hash = uint256S("0x2c23095473d1afabfb630d41a395364e69da264a73c04dbcb4756c7d36c9b994");
-        consensus.BIP65Height = 1032483; // I have no idea, this is a wild guess
+        // consensus.BIP65Height = 1032483; // Not enabled in Doge yet
         consensus.BIP66Height = 1032483; // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the v3 block after the last v2 block, may be too low
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
@@ -185,7 +185,7 @@ public:
         // XXX: BIP heights and hashes all need to be updated to Dogecoin values
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
-        consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+        // consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
@@ -282,7 +282,7 @@ public:
         consensus.nSubsidyHalvingInterval = 150;
         consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
+        // consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.powLimit = uint256S("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -185,9 +185,9 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.nSubsidyHalvingInterval = 100000;
-        consensus.nMajorityEnforceBlockUpgrade = 1500;
-        consensus.nMajorityRejectBlockOutdated = 1900;
-        consensus.nMajorityWindow = 2000;
+        consensus.nMajorityEnforceBlockUpgrade = 501;
+        consensus.nMajorityRejectBlockOutdated = 750;
+        consensus.nMajorityWindow = 1000;
         // BIP34 is never enforced in Dogecoin v2 blocks, so we enforce from v3
         consensus.BIP34Height = 708658;
         consensus.BIP34Hash = uint256S("0x21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38");

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -39,6 +39,11 @@ struct BIP9Deployment {
 struct Params {
     uint256 hashGenesisBlock;
     int nSubsidyHalvingInterval;
+    /** Used to check majorities for block version upgrade */
+    int nMajorityEnforceBlockUpgrade;
+    int nMajorityRejectBlockOutdated;
+    int nMajorityWindow;
+    int nCoinbaseMaturity;
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -43,7 +43,7 @@ struct Params {
     int BIP34Height;
     uint256 BIP34Hash;
     /** Block height at which BIP65 becomes active */
-    int BIP65Height;
+    // int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
     /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1065,7 +1065,20 @@ static UniValue SoftForkMajorityDesc(int version, CBlockIndex* pindex, const Con
             activated = pindex->nHeight >= consensusParams.BIP66Height;
             break;
         case 4:
-            activated = pindex->nHeight >= consensusParams.BIP65Height;
+            int nFound = 0;
+            int nRequired = consensusParams.nMajorityRejectBlockOutdated;
+            CBlockIndex* pstart = pindex;
+            for (int i = 0; i < consensusParams.nMajorityWindow && pstart != NULL; i++)
+            {
+                if (pstart->nVersion >= version)
+                    ++nFound;
+                pstart = pstart->pprev;
+            }
+
+            activated = nFound >= nRequired;
+            rv.push_back(Pair("found", nFound));
+            rv.push_back(Pair("required", nRequired));
+            rv.push_back(Pair("window", consensusParams.nMajorityWindow));
             break;
     }
     rv.push_back(Pair("status", activated));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1865,7 +1865,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4
     // blocks, when 75% of the network has upgraded:
-    if (block.nVersion >= 4 && IsSuperMajority(4, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
+    if (block.GetBaseVersion() >= 4 && IsSuperMajority(4, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus())) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
@@ -3033,7 +3033,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
                                  strprintf("rejected nVersion=0x%08x block", block.GetBaseVersion()));
 
     // Dogecoin: Introduce supermajority rules for v4 blocks
-    if (block.nVersion < 4 && IsSuperMajority(4, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
+    if (block.GetBaseVersion() < 4 && IsSuperMajority(4, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
         return state.Invalid(error("%s : rejected nVersion=3 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1859,9 +1859,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // Start enforcing CHECKLOCKTIMEVERIFY (BIP65) rule
-    if (pindex->nHeight >= chainparams.GetConsensus().BIP65Height) {
-        flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
-    }
+    // Dogecoin: This needs to be supermajority based
+    // if (pindex->nHeight >= chainparams.GetConsensus().BIP65Height) {
+    //     flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+    // }
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = 0;
@@ -3022,10 +3023,11 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     // Dogecoin: Version 2 enforcement was never used
-    if((block.GetBaseVersion() < 3 && nHeight >= consensusParams.BIP66Height) ||
-       (block.GetBaseVersion() < 4 && nHeight >= consensusParams.BIP65Height))
+    if((block.GetBaseVersion() < 3 && nHeight >= consensusParams.BIP66Height))
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.GetBaseVersion()),
                                  strprintf("rejected nVersion=0x%08x block", block.GetBaseVersion()));
+
+    // Dogecoin: Introduce supermajority rules for v4 blocks
 
     return true;
 }


### PR DESCRIPTION
Introduce estimated BIP66 enforcement height (TBC), and switch BIP65 enforcement to supermajority rather than height based as Dogecoin doesn't have it yet.
