### PR TITLE
Stop sending a Bitcoin alert to Dogecoin clients

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1367,12 +1367,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         AddTimeData(pfrom->addr, nTimeOffset);
 
         // If the peer is old enough to have the old alert system, send it the final alert.
-        // XXX: Decide how to handle alert migration in Dogecoin and either make this a Dogecoin
-        //      alert or re-introduce the system
-        if (pfrom->nVersion <= 70012) {
+        /* if (pfrom->nVersion <= 70012) {
+            // TODO: Replace this with a valid Dogecoin alert
+            // Disabled meantime as the remote client considers the nonsense alert a hack and drops the connection
             CDataStream finalAlert(ParseHex("60010000000000000000000000ffffff7f00000000ffffff7ffeffff7f01ffffff7f00000000ffffff7f00ffffff7f002f555247454e543a20416c657274206b657920636f6d70726f6d697365642c2075706772616465207265717569726564004630440220653febd6410f470f6bae11cad19c48413becb1ac2c17f908fd0fd53bdc3abd5202206d0e9c96fe88d4a0f01ed9dedae2b6f9e00da94cad0fecaae66ecf689bf71b50"), SER_NETWORK, PROTOCOL_VERSION);
             connman.PushMessage(pfrom, CNetMsgMaker(nSendVersion).Make("alert", finalAlert));
-        }
+        } */
 
         // Feeler connections exist only to verify if address is online.
         if (pfrom->fFeeler) {


### PR DESCRIPTION
This fixes the tendency for 1.10 client connections to fail (because entirely reasonably they reject the nonsense alert).
