### PR TITLE
Change count type used by `gettxoutsetinfo`

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -808,7 +808,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
-    CAmount nTotalAmount;
+    arith_uint256 nTotalAmount;
 
     CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}
 };
@@ -825,7 +825,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
         stats.nHeight = mapBlockIndex.find(stats.hashBlock)->second->nHeight;
     }
     ss << stats.hashBlock;
-    CAmount nTotalAmount = 0;
+    arith_uint256 nTotalAmount = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         uint256 key;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -143,6 +143,16 @@ UniValue ValueFromAmount(const CAmount& amount)
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
 }
 
+UniValue ValueFromAmount(const arith_uint256& amount)
+{
+    bool sign = amount < 0;
+    arith_uint256 n_abs = (sign ? -amount : amount);
+    arith_uint256 quotient = n_abs / COIN;
+    arith_uint256 remainder = n_abs - (quotient * COIN);
+    return UniValue(UniValue::VNUM,
+            strprintf("%s%d.%08d", sign ? "-" : "", (int64_t)quotient.getdouble(), (int64_t)remainder.getdouble()));
+}
+
 uint256 ParseHashV(const UniValue& v, string strName)
 {
     string strHex;

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -7,6 +7,7 @@
 #define BITCOIN_RPCSERVER_H
 
 #include "amount.h"
+#include "arith_uint256.h"
 #include "rpc/protocol.h"
 #include "uint256.h"
 
@@ -193,6 +194,7 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
+extern UniValue ValueFromAmount(const arith_uint256& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);


### PR DESCRIPTION
changing CAmount (is a int64_t) to arith_uint256 for nTotalAmount in CCoinsStats to prevent overflow
