### PR TITLE
Change fPIE to fPIC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -417,8 +417,8 @@ if test x$use_hardening != xno; then
 
   if test x$TARGET_OS != xwindows; then
     # All windows code is PIC, forcing it on just adds useless compile warnings
-    AX_CHECK_COMPILE_FLAG([-fPIE],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
+    AX_CHECK_COMPILE_FLAG([-fPIC],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIC"])
+    AX_CHECK_LINK_FLAG([[-fno-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -fno-pie"])
   fi
 
   case $host in


### PR DESCRIPTION
## -fpic
>Generate position-independent code (PIC) suitable for use in a shared library...

## -fpie
>These options are similar to -fpic and -fPIC, but generated position independent code can be only linked into executables....

By building with fPIE, the resulting binaries are "LSB shared objects" not LSB executables. When trying to run the program (double-click) with mouse it doesn't start. Therefore this change fixes this.