### PR TITLE
Initialise left/right consensus branches to null

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -82,8 +82,8 @@ struct Params {
 
     /** Height-aware consensus parameters */
     uint32_t nHeightEffective; // When these parameters come into use
-    struct Params *pLeft;      // Left hand branch
-    struct Params *pRight;     // Right hand branch
+    struct Params *pLeft = nullptr;      // Left hand branch
+    struct Params *pRight = nullptr;     // Right hand branch
     const Consensus::Params *GetConsensus(uint32_t nTargetHeight) const;
 };
 } // namespace Consensus


### PR DESCRIPTION
Strictly speaking the left/right consensus branches haven't been initialised so contain random values.
Most of the time these happen to be null, but sometimes causes client crashes (at least it does in 1.15, but fixing in earlier versions to be sure).