### PR TITLE
Update test cases at 1000-byte boundaries

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_test)
     int64_t nMinTxFee = COIN;
 
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 250, 0, pool), nMinTxFee);
-    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), 2 * nMinTxFee);
+    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nMinTxFee);
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), 2 * nMinTxFee);
 }
 
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     // Confirm dust penalty fees are added on
 
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 963, 0, pool), 2 * nMinTxFee);
-    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), 3 * nMinTxFee);
+    BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), 2 * nMinTxFee);
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), 3 * nMinTxFee);
 }
 


### PR DESCRIPTION
Update test cases for 1,000 byte TX boundaries; in 1.10 and before the fees for these were rolled up to the next DOGE, however that results in incorrect fees because the UI currently uses 1,000 bytes as a predicted size. This updates the tests to match new behaviour in 1.14.