### PR TITLE
Load AuxPoW blocks from index correctly

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -14,6 +14,8 @@ CBlockHeader CBlockIndex::GetBlockHeader(const Consensus::Params& consensusParam
 {
     CBlockHeader block;
 
+    block.nVersion       = nVersion;
+
     /* The CBlockIndex object's block header is missing the auxpow.
        So if this is an auxpow block, read it from disk instead.  We only
        have to read the actual *header*, not the full block.  */
@@ -23,7 +25,6 @@ CBlockHeader CBlockIndex::GetBlockHeader(const Consensus::Params& consensusParam
         return block;
     }
 
-    block.nVersion       = nVersion;
     if (pprev)
         block.hashPrevBlock = pprev->GetBlockHash();
     block.hashMerkleRoot = hashMerkleRoot;


### PR DESCRIPTION
Load AuxPoW blocks from index correctly, by setting the version on the block before trying to check if it's AuxPoW. Previously the AuxPoW part of the block was never loaded because the check always failed.