### PR TITLE
[Qt] Disable milli and micro units, introduce kilo and mega units

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -18,8 +18,10 @@ QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits()
 {
     QList<BitcoinUnits::Unit> unitlist;
     unitlist.append(BTC);
-    unitlist.append(mBTC);
-    unitlist.append(uBTC);
+    unitlist.append(kBTC);
+    unitlist.append(MBTC);
+    //unitlist.append(mBTC);
+    //unitlist.append(uBTC);
     return unitlist;
 }
 
@@ -27,10 +29,12 @@ bool BitcoinUnits::valid(int unit)
 {
     switch(unit)
     {
+    case MBTC:
+    case kBTC:
     case BTC:
+        return true;
     case mBTC:
     case uBTC:
-        return true;
     default:
         return false;
     }
@@ -40,6 +44,8 @@ QString BitcoinUnits::name(int unit)
 {
     switch(unit)
     {
+    case MBTC: return QString("MDOGE");
+    case kBTC: return QString("kDOGE");
     case BTC: return QString("DOGE");
     case mBTC: return QString("mDOGE");
     case uBTC: return QString::fromUtf8("μDOGE");
@@ -51,9 +57,11 @@ QString BitcoinUnits::description(int unit)
 {
     switch(unit)
     {
-    case BTC: return QString("Bitcoins");
-    case mBTC: return QString("Milli-Bitcoins (1 / 1" THIN_SP_UTF8 "000)");
-    case uBTC: return QString("Micro-Bitcoins (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
+    case MBTC: return QString("Mega-Dogecoins (1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
+    case kBTC: return QString("Kilo-Dogecoins (1" THIN_SP_UTF8 "000)");
+    case BTC: return QString("Dogecoins");
+    case mBTC: return QString("Milli-Dogecoins (1 / 1" THIN_SP_UTF8 "000)");
+    case uBTC: return QString("Micro-Dogecoins (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     default: return QString("???");
     }
 }
@@ -62,6 +70,8 @@ qint64 BitcoinUnits::factor(int unit)
 {
     switch(unit)
     {
+    case MBTC: return 100000000000000;
+    case kBTC: return 100000000000;
     case BTC:  return 100000000;
     case mBTC: return 100000;
     case uBTC: return 100;
@@ -73,6 +83,8 @@ int BitcoinUnits::decimals(int unit)
 {
     switch(unit)
     {
+    case MBTC: return 14;
+    case kBTC: return 11;
     case BTC: return 8;
     case mBTC: return 5;
     case uBTC: return 2;

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -56,6 +56,8 @@ public:
      */
     enum Unit
     {
+        MBTC,
+        kBTC,
         BTC,
         mBTC,
         uBTC


### PR DESCRIPTION
milli- and micro-Dogecoins are below dust threshold so do not make any sense as display units. Instead, kilo- and mega-dogecoins are probably more useful, as those make common amounts easier to read
instead of harder.