### PR TITLE
Add PureHeader sources to libdogecoinconsensus

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -279,6 +279,8 @@ libbitcoin_consensus_a_SOURCES = \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \
+  primitives/pureheader.cpp \
+  primitives/pureheader.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
   pubkey.cpp \


### PR DESCRIPTION
This fixes a build error I got on Windows builds.