### PR TITLE
Update or eliminate remaining tests

### DIFF
--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -21,37 +21,37 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     feeRate = CFeeRate(1000);
     // Must always just return the arg
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 121);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 999);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 1e3);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), 9e3);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), 9000);
 
     feeRate = CFeeRate(-1000);
     // Must always just return -1 * arg
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1), -1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), -121);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), -999);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), -1e3);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), -9e3);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1), -1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), -1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), -1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), -1000);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), -9000);
 
     feeRate = CFeeRate(123);
     // Truncates the result, if not integer
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(8), 1); // Special case: returns 1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), 1);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 14);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(122), 15);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 122);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(8), 123); // Special case: returns 1 instead of 0
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9), 123);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), 123);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(122), 123);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), 123);
     BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), 123);
     BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), 1107);
 
     feeRate = CFeeRate(-123);
     // Truncates the result, if not integer
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), 0);
-    BOOST_CHECK_EQUAL(feeRate.GetFee(8), -1); // Special case: returns -1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), -1);
+    BOOST_CHECK_EQUAL(feeRate.GetFee(8), -123); // Special case: returns -1 instead of 0
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9), -123);
 
     // Check full constructor
     // default value

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -489,7 +489,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
     mempool.clear();
 
-    TestPackageSelection(chainparams, scriptPubKey, txFirst);
+    // Dogecoin: Package selection doesn't work that way because our fees are fundamentally
+    //           different. Need to rationalise in a later release.
+    // TestPackageSelection(chainparams, scriptPubKey, txFirst);
 
     fCheckpointsEnabled = true;
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -689,8 +689,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     std::string reason;
     BOOST_CHECK(IsStandardTx(t, reason));
 
+    // Dogecoin: Dust is totally different in Dogecoin, disable these tests
     // Check dust with default relay fee:
-    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000 * 3;
+    /* CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000 * 3;
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
@@ -707,7 +708,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(t, reason));
     // not dust:
     t.vout[0].nValue = 672;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, reason)); */
     dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
 
     t.vout[0].scriptPubKey = CScript() << OP_1;


### PR DESCRIPTION
Update basic fee-based tests to match Doge, eliminate those which do not directly map to the Doge fee schedule (to re-evaluate in a later release).
