### PR TITLE
Create v1 transactions for compatibility with 1.10

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -303,7 +303,8 @@ class CTransaction
 {
 public:
     // Default transaction version.
-    static const int32_t CURRENT_VERSION=2;
+    // Dogecoin: Temporarily restricted to v1 for compatibility with 1.10
+    static const int32_t CURRENT_VERSION=1;
 
     // Changing the default transaction version requires a two step process: first
     // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date


### PR DESCRIPTION
Create v1 transactions for compatibility with 1.10. See https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki for context.

This should NOT be merged into 1.16.