### PR TITLE
Fix CVE-2018-17144

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2902,7 +2902,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
Quoting bitcoincore.org, Security issue CVE-2018-17144: it was discovered that older versions of Bitcoin Core will crash if they try to process a block containing a transaction that attempts to spend the same input twice. Such blocks are invalid, so they can only be created by a miner willing to sacrifice their allowed income for creating a block of at least 12.5 BTC (about $80,000 USD as of this writing).

Since dogecoin core is a fork of bitcoin core, it is liable to the same bug. All dogecoin core versions equivalent to bitcoin core 0.14.0 and above need to upgrade in order to be immune to this vulnerability.

P.S: I don't know which branch to PR to, if this is the wrong branch, please update the branch.