### PR TITLE
Make Travis slightly happier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
     - mkdir build && cd build
     - ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make distdir VERSION=$HOST
-    - cd bitcoin-$HOST
+    - cd dogecoin-$HOST
     - ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib


### PR DESCRIPTION
Tiny oversight there. Sample build: https://travis-ci.org/langerhans/dogecoin/builds/439762565

The failing tests actually passed before. Most of them fail cause `dogecoin-tx` will by default create nversion=1 transactions (which is correct), but the tests seem to expect nversion=2 a lot, which we do not use yet. I was updating them when I realized that they have already been updated. @rnicoll any idea about that? You can run them locally with `./test/bitcoin-util-test.py --srcdir=. --verbose`