### PR TITLE
[rpc] Add initialblockdownload to getblockchaininfo

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -513,6 +513,7 @@ Value getblockchaininfo(const Array& params, bool fHelp)
             "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
             "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
+            "  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial Block Download mode.\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "}\n"
             "\nExamples:\n"
@@ -529,6 +530,7 @@ Value getblockchaininfo(const Array& params, bool fHelp)
     obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
     obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
     obj.push_back(Pair("verificationprogress",  Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip())));
+    obj.push_back(Pair("initialblockdownload",  IsInitialBlockDownload()));
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
     obj.push_back(Pair("pruned",                fPruneMode));
     if (fPruneMode)


### PR DESCRIPTION
Mirroring the PR that bitcoin made here: https://github.com/bitcoin/bitcoin/pull/11258

For operators of dogecoin nodes that cannot have downtime, the debug info is very useful. It allows automated health-checking of the nodes (don't serve traffic if the node doesn't have a fully synced chain)