### PR TITLE
Get rid of git merge leftover text

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -447,8 +447,6 @@ Thanks to everyone who directly contributed to this release:
 - Gregory Sanders
 - Jonas Schnelli
 - Matt Corallo
-<<<<<<< HEAD
-=======
 - Matthew King
 - matthias
 - Max Keller


### PR DESCRIPTION
Funny how no one noticed this. Not sure if this PR should be against master, but I guess you can point it whereever you want yourself.