### PR TITLE
Fix dogecoin payment links

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -47,7 +47,7 @@
 #endif
 
 const int BITCOIN_IPC_CONNECT_TIMEOUT = 1000; // milliseconds
-const QString BITCOIN_IPC_PREFIX("bitcoin:");
+const QString BITCOIN_IPC_PREFIX("dogecoin:");
 // BIP70 payment protocol messages
 const char* BIP70_MESSAGE_PAYMENTACK = "PaymentACK";
 const char* BIP70_MESSAGE_PAYMENTREQUEST = "PaymentRequest";


### PR DESCRIPTION
Given that GUIUtil::parseBitcoinURI is expecting it to start with dogecoin, it seems like this was overlooked, and this results in dogecoin: links not being processed as expected in handleURIOrFile, ipcParseCommandLine.

Instead of processing the link as a payment request and opening the such send page, it simply opens the core wallet (or attempts to open another).

This commit makes dogecoin-qt properly handle dogecoin links so that the such send page is opened with the desired information obtained from the link.

Fixes #1628