### PR TITLE
fix broken dependency package links (openssl & qt)

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,7 +1,8 @@
 package=openssl
-$(package)_version=1.0.1l
-$(package)_download_path=https://www.openssl.org/source
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_version=1.0.1
+$(package)_version_suffix=l
+$(package)_download_path=https://www.openssl.org/source/old/$($(package)_version)
+$(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
 $(package)_sha256_hash=b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4
 
 define $(package)_set_vars

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.7/$($(package)_version)/submodules
+$(package)_download_path=http://download.qt.io/new_archive/qt/5.7/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410


### PR DESCRIPTION
This little change updates the dependency package urls to ones that correctly resolve as of the date of this PR.