### PR TITLE
QA: Fix all the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
+    - if [ "$RUN_TESTS" = "true" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq python3-dev; fi
 before_script:
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 os: linux
 language: generic
@@ -20,7 +19,7 @@ env:
     - SDK_URL=https://bitcoincore.org/depends-sources/sdks
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
-  matrix:
+  jobs:
 # ARM
     - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Win32

--- a/qa/pull-tester/install-deps.sh
+++ b/qa/pull-tester/install-deps.sh
@@ -2,7 +2,7 @@
 
 # installs test dependencies
 
-wget https://github.com/langerhans/ltc-scrypt/archive/master.tar.gz
+curl -L https://github.com/langerhans/ltc-scrypt/archive/master.tar.gz --output master.tar.gz
 echo "ade3cdf498927990b6d153d74f0da104114e838584be5a81bef8972accd03341 master.tar.gz" | sha256sum -c
 tar zxf master.tar.gz
 pushd ltc-scrypt-master

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -281,7 +281,7 @@ class RPCTestHandler:
             log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
             self.jobs.append((t,
                               time.time(),
-                              subprocess.Popen(['python3.6']+(RPC_TESTS_DIR + t).split() + self.flags + port_seed,
+                              subprocess.Popen(['python3']+(RPC_TESTS_DIR + t).split() + self.flags + port_seed,
                                                universal_newlines=True,
                                                stdout=log_stdout,
                                                stderr=log_stderr),

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -55,13 +55,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         # ensure that setting changePosition in fundraw with an exact match is handled properly
-        rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():50})
+        rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():500000})
         rawmatch = self.nodes[2].fundrawtransaction(rawmatch, {"changePosition":1, "subtractFeeFromOutputs":[0]})
         assert_equal(rawmatch["changepos"], -1)
 
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.5)
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
-        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 15)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 50)
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -82,7 +82,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # simple test with two coins #
         ##############################
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.2 }
+        outputs = { self.nodes[0].getnewaddress() : 22 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
@@ -95,7 +95,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # simple test with two coins #
         ##############################
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.6 }
+        outputs = { self.nodes[0].getnewaddress() : 26 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
@@ -110,7 +110,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # simple test with two outputs #
         ################################
         inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.6, self.nodes[1].getnewaddress() : 2.5 }
+        outputs = { self.nodes[0].getnewaddress() : 26, self.nodes[1].getnewaddress() : 25 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
@@ -128,10 +128,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################################
         # test a fundrawtransaction with a VIN greater than the required amount #
         #########################################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
-        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : 10 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -149,11 +149,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         #####################################################################
         # test a fundrawtransaction with which will not get a change output #
         #####################################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
         # Dogecoin: Fee is exact, do not use tolerance
-        outputs = { self.nodes[0].getnewaddress() : Decimal(5.0) - fee }
+        outputs = { self.nodes[0].getnewaddress() : Decimal(50) - fee }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -172,10 +172,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         ####################################################
         # test a fundrawtransaction with an invalid option #
         ####################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : Decimal(4.0) }
+        outputs = { self.nodes[0].getnewaddress() : Decimal(40) }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -185,24 +185,24 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # test a fundrawtransaction with an invalid change address #
         ############################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : Decimal(4.0) }
+        outputs = { self.nodes[0].getnewaddress() : Decimal(40) }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
 
-        assert_raises_jsonrpc(-5, "changeAddress must be a valid bitcoin address", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':'foobar'})
+        assert_raises_jsonrpc(-5, "changeAddress must be a valid dogecoin address", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':'foobar'})
 
         ############################################################
         # test a fundrawtransaction with a provided change address #
         ############################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
         # Dogecoin: Reduce this output so the fee doesn't leave us with no change
-        outputs = { self.nodes[0].getnewaddress() : Decimal(2.5) }
+        outputs = { self.nodes[0].getnewaddress() : Decimal(25) }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -218,10 +218,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################################
         # test a fundrawtransaction with a VIN smaller than the required amount #
         #########################################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 1)
+        utx = get_unspent(self.nodes[2].listunspent(), 10)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
-        outputs = { self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : 10 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
 
         # 4-byte version + 1-byte vin count + 36-byte prevout then script_len
@@ -253,11 +253,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###########################################
         # test a fundrawtransaction with two VINs #
         ###########################################
-        utx = get_unspent(self.nodes[2].listunspent(), 1)
-        utx2 = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 10)
+        utx2 = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : 6.0 }
+        outputs = { self.nodes[0].getnewaddress() : 60 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -286,11 +286,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################
         # test a fundrawtransaction with two VINs and two vOUTs #
         #########################################################
-        utx = get_unspent(self.nodes[2].listunspent(), 1)
-        utx2 = get_unspent(self.nodes[2].listunspent(), 5)
+        utx = get_unspent(self.nodes[2].listunspent(), 10)
+        utx2 = get_unspent(self.nodes[2].listunspent(), 50)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']},{'txid' : utx2['txid'], 'vout' : utx2['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : 6.0, self.nodes[0].getnewaddress() : 1.0 }
+        outputs = { self.nodes[0].getnewaddress() : 60, self.nodes[0].getnewaddress() : 10 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -313,7 +313,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ##############################################
         listunspent = self.nodes[2].listunspent()
         inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
-        outputs = { self.nodes[0].getnewaddress() : 1.0}
+        outputs = { self.nodes[0].getnewaddress() : 10}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
@@ -322,12 +322,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         #compare fee of a standard pubkeyhash transaction
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1}
+        outputs = {self.nodes[1].getnewaddress():11}
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
+        txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 11)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
@@ -338,7 +338,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         #compare fee of a standard pubkeyhash transaction with multiple outputs
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1,self.nodes[1].getnewaddress():1.2,self.nodes[1].getnewaddress():0.1,self.nodes[1].getnewaddress():1.3,self.nodes[1].getnewaddress():0.2,self.nodes[1].getnewaddress():0.3}
+        outputs = {self.nodes[1].getnewaddress():110,self.nodes[1].getnewaddress():120,self.nodes[1].getnewaddress():10,self.nodes[1].getnewaddress():130,self.nodes[1].getnewaddress():20,self.nodes[1].getnewaddress():30}
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
         #create same transaction over sendtoaddress
@@ -369,7 +369,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
+        txId = self.nodes[0].sendtoaddress(mSigObj, 11)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
@@ -402,7 +402,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
 
         #create same transaction over sendtoaddress
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
+        txId = self.nodes[0].sendtoaddress(mSigObj, 11)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
         #compare fee
@@ -425,14 +425,14 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 
         # send 1.2 BTC to msig addr
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
+        txId = self.nodes[0].sendtoaddress(mSigObj, 12)
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
 
         oldBalance = self.nodes[1].getbalance()
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1}
+        outputs = {self.nodes[1].getnewaddress():11}
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[2].fundrawtransaction(rawTx)
 
@@ -443,7 +443,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         # make sure funds are received at node1
-        assert_equal(oldBalance+Decimal('1.10000000'), self.nodes[1].getbalance())
+        assert_equal(oldBalance+Decimal('11.0000000'), self.nodes[1].getbalance())
 
         ############################################################
         # locked wallet test
@@ -469,7 +469,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # drain the keypool
         self.nodes[1].getnewaddress()
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():1.1}
+        outputs = {self.nodes[0].getnewaddress():11}
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         # fund a transaction that requires a new key for the change output
         # creating the key must be impossible because the wallet is locked
@@ -479,12 +479,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].walletpassphrase("test", 100)
         self.nodes[1].walletlock()
 
-        assert_raises_jsonrpc(-13, "walletpassphrase", self.nodes[1].sendtoaddress, self.nodes[0].getnewaddress(), 1.2)
+        assert_raises_jsonrpc(-13, "walletpassphrase", self.nodes[1].sendtoaddress, self.nodes[0].getnewaddress(), 12)
 
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():1.1}
+        outputs = {self.nodes[0].getnewaddress():11}
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawTx)
 
@@ -496,7 +496,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         # make sure funds are received at node1
-        assert_equal(oldBalance+Decimal('500001.10000000'), self.nodes[0].getbalance())
+        assert_equal(oldBalance+Decimal('500011.00000000'), self.nodes[0].getbalance())
 
 
         ###############################################
@@ -510,7 +510,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         for i in range(0,20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 2)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20)
         self.nodes[0].generate(1)
         self.sync_all()
 

--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -25,7 +25,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[0].generate(101)
 
         self.sync_all()
-        
+
         # address
         address1 = self.nodes[0].getnewaddress()
         # pubkey
@@ -58,20 +58,21 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['ismine'], False)
 
         #Send funds to self
-        txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
+        txnid3 = self.nodes[0].sendtoaddress(address3, 2.5)
         self.nodes[0].generate(1)
-        rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
-        proof1 = self.nodes[0].gettxoutproof([txnid1])
+        rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
+        proof3 = self.nodes[0].gettxoutproof([txnid3])
 
-        txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
+        txnid2 = self.nodes[0].sendtoaddress(address2, 5)
         self.nodes[0].generate(1)
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
         proof2 = self.nodes[0].gettxoutproof([txnid2])
 
-        txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
+        txnid1 = self.nodes[0].sendtoaddress(address1, 10)
         self.nodes[0].generate(1)
-        rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
-        proof3 = self.nodes[0].gettxoutproof([txnid3])
+        rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
+        proof1 = self.nodes[0].gettxoutproof([txnid1])
+
 
         self.sync_all()
 
@@ -85,15 +86,15 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[1].importaddress(address2, "add2", False)
         result2 = self.nodes[1].importprunedfunds(rawtxn2, proof2)
         balance2 = self.nodes[1].getbalance("add2", 0, True)
-        assert_equal(balance2, Decimal('0.05'))
+        assert_equal(balance2, Decimal('5'))
 
         #Import with private key with no rescan
         self.nodes[1].importprivkey(address3_privkey, "add3", False)
         result3 = self.nodes[1].importprunedfunds(rawtxn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
-        assert_equal(balance3, Decimal('0.025'))
+        assert_equal(balance3, Decimal('2.5'))
         balance3 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance3, Decimal('0.075'))
+        assert_equal(balance3, Decimal('7.5'))
 
         #Addresses Test - after import
         address_info = self.nodes[1].validateaddress(address1)
@@ -110,11 +111,11 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_raises_jsonrpc(-8, "Transaction does not exist in wallet.", self.nodes[1].removeprunedfunds, txnid1)
 
         balance1 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance1, Decimal('0.075'))
+        assert_equal(balance1, Decimal('7.5'))
 
         self.nodes[1].removeprunedfunds(txnid2)
         balance2 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance2, Decimal('0.025'))
+        assert_equal(balance2, Decimal('2.5'))
 
         self.nodes[1].removeprunedfunds(txnid3)
         balance3 = self.nodes[1].getbalance("*", 0, True)

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -90,12 +90,12 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         multisig = self.nodes[1].createmultisig(1, [self.nodes[1].getnewaddress()])
         self.nodes[0].importaddress(multisig["redeemScript"], "watchonly", False, True)
-        txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
+        txid = self.nodes[1].sendtoaddress(multisig["address"], 1)
         self.nodes[1].generate(1)
         self.sync_all()
         assert(len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
         assert_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
-                           {"category":"receive","amount":Decimal("0.1")},
+                           {"category":"receive","amount":Decimal("1")},
                            {"txid":txid, "account" : "watchonly"} )
 
         self.run_rbf_opt_in_test()
@@ -201,4 +201,3 @@ class ListTransactionsTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     ListTransactionsTest().main()
-

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -26,7 +26,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
     def run_test(self):
         txids = []
-        utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], 91)
+        utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], 181)
 
         #create a mempool tx that will be evicted
         us0 = utxos.pop()
@@ -41,7 +41,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
         base_fee = relayfee*100
-        for i in range (3):
+        for i in range (6):
             txids.append([])
             txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
 

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -26,7 +26,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #Append rpcauth to bitcoin.conf before initialization
         rpcauth = "rpcauth=rt:93648e835a54c573682c2eb19f882535$7681e9c5b74bdd85e78166031d2058e1069b3ed7ed967c93fc63abba06f31144"
         rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
-        with open(os.path.join(self.options.tmpdir+"/node0", "bitcoin.conf"), 'a', encoding='utf8') as f:
+        with open(os.path.join(self.options.tmpdir+"/node0", "dogecoin.conf"), 'a', encoding='utf8') as f:
             f.write(rpcauth+"\n")
             f.write(rpcauth2+"\n")
 
@@ -60,7 +60,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         resp = conn.getresponse()
         assert_equal(resp.status==401, False)
         conn.close()
-        
+
         #Use new authpair to confirm both work
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 

--- a/qa/rpc-tests/test_framework/auxpow.py
+++ b/qa/rpc-tests/test_framework/auxpow.py
@@ -63,7 +63,7 @@ def mineAuxpowBlock (node):
   """
 
   auxblock = node.getauxblock ()
-  target = reverseHex (auxblock['_target'])
+  target = reverseHex (auxblock['target'])
   apow = computeAuxpow (auxblock['hash'], target, True)
   res = node.getauxblock (auxblock['hash'], apow)
   assert res

--- a/qa/rpc-tests/test_framework/auxpow.py
+++ b/qa/rpc-tests/test_framework/auxpow.py
@@ -17,7 +17,7 @@ def computeAuxpow (block, target, ok):
 
   # Start by building the merge-mining coinbase.  The merkle tree
   # consists only of the block hash as root.
-  coinbase = "fabe" + binascii.hexlify ("m" * 2)
+  coinbase = "fabe" + binascii.hexlify("m" * 2)
   coinbase += block
   coinbase += "01000000" + ("00" * 4)
 
@@ -105,7 +105,7 @@ def reverseHex (data):
   Flip byte order in the given data (hex string).
   """
 
-  b = bytearray (bytes.fromhex(data))
+  b = bytearray (binascii.unhexlify(data))
   b.reverse ()
 
-  return b.hex()
+  return binascii.hexlify(b).decode("ascii")

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -36,7 +36,7 @@ from threading import RLock
 from threading import Thread
 import logging
 import copy
-import litecoin_scrypt
+import ltc_scrypt
 from test_framework.siphash import siphash256
 
 BIP0031_VERSION = 60000
@@ -583,7 +583,7 @@ class CBlockHeader(object):
             r += struct.pack("<I", self.nNonce)
             self.sha256 = uint256_from_str(hash256(r))
             self.hash = encode(hash256(r)[::-1], 'hex_codec').decode('ascii')
-            self.scrypt256 = uint256_from_str(litecoin_scrypt.getPoWHash(r))
+            self.scrypt256 = uint256_from_str(ltc_scrypt.getPoWHash(r))
 
     def rehash(self):
         self.sha256 = None

--- a/qa/rpc-tests/test_framework/scrypt_auxpow.py
+++ b/qa/rpc-tests/test_framework/scrypt_auxpow.py
@@ -8,12 +8,12 @@
 # solve an auxpow header and to generate auxpow blocks with scrypt.
 # extends and modifies auxpow module by Daniel Kraft.
 
-# This module requires a built and installed version of the litecoin_scrypt
+# This module requires a built and installed version of the ltc_scrypt
 # package, which can be downloaded from:
 # https://pypi.python.org/packages/source/l/ltc_scrypt/ltc_scrypt-1.0.tar.gz
 
 from .auxpow import *
-import litecoin_scrypt
+import ltc_scrypt
 
 def computeAuxpowWithChainId (block, target, chainid, ok):
   """
@@ -70,7 +70,7 @@ def mineScryptAux (node, chainid, ok):
   """
 
   auxblock = node.getauxblock ()
-  target = reverseHex (auxblock['_target'])
+  target = reverseHex (auxblock['target'])
 
   apow = computeAuxpowWithChainId (auxblock['hash'], target, chainid, ok)
   res = node.getauxblock (auxblock['hash'], apow)
@@ -101,4 +101,4 @@ def getScryptPoW(hexData):
   """
 
   data = bytes.fromhex(hexData)
-  return reverseHex(litecoin_scrypt.getPoWHash(data).hex())
+  return reverseHex(ltc_scrypt.getPoWHash(data).hex())

--- a/qa/rpc-tests/test_framework/scrypt_auxpow.py
+++ b/qa/rpc-tests/test_framework/scrypt_auxpow.py
@@ -14,6 +14,7 @@
 
 from .auxpow import *
 import ltc_scrypt
+import binascii
 
 def computeAuxpowWithChainId (block, target, chainid, ok):
   """
@@ -23,7 +24,7 @@ def computeAuxpowWithChainId (block, target, chainid, ok):
 
   # Start by building the merge-mining coinbase.  The merkle tree
   # consists only of the block hash as root.
-  coinbase = "fabe" + (b"m" * 2).hex()
+  coinbase = "fabe" + binascii.hexlify((b"m" * 2)).decode("ascii")
   coinbase += block
   coinbase += "01000000" + ("00" * 4)
 
@@ -82,11 +83,11 @@ def mineScryptBlock (header, target, ok):
   for the given target.
   """
 
-  data = bytearray (bytes.fromhex(header))
+  data = bytearray (binascii.unhexlify(header))
   while True:
     assert data[79] < 255
     data[79] += 1
-    hexData = data.hex()
+    hexData = binascii.hexlify(data).decode("ascii")
 
     scrypt = getScryptPoW(hexData)
     if (ok and scrypt < target) or ((not ok) and scrypt > target):
@@ -100,5 +101,6 @@ def getScryptPoW(hexData):
   Actual scrypt pow calculation
   """
 
-  data = bytes.fromhex(hexData)
-  return reverseHex(ltc_scrypt.getPoWHash(data).hex())
+  data = binascii.unhexlify(hexData)
+
+  return reverseHex(binascii.hexlify(ltc_scrypt.getPoWHash(data)).decode("ascii"))

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -191,6 +191,8 @@ void PaymentServerTests::paymentServerTests()
     QCOMPARE(PaymentServer::verifySize(tempFile.size()), false);
 
     // Payment request with amount overflow (amount is set to 21000001 BTC):
+    /* PL: This doesn't work for Dogecoin (as there is no actual maximum coins)
+     *     I'm disabling this test for now.
     data = DecodeBase64(paymentrequest5_cert2_BASE64);
     byteArray = QByteArray((const char*)&data[0], data.size());
     r.paymentRequest.parse(byteArray);
@@ -203,6 +205,7 @@ void PaymentServerTests::paymentServerTests()
         if (ExtractDestination(sendingTo.first, dest))
             QCOMPARE(PaymentServer::verifyAmount(sendingTo.second), false);
     }
+    */
 
     delete server;
 }

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -90,7 +90,7 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(result == result2);
 
     RPCConsole::RPCExecuteCommandLine(result, "getblock(getbestblockhash())[tx][0]", &filtered);
-    QVERIFY(result == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    QVERIFY(result == "5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69");
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
     RPCConsole::RPCParseCommandLine(result, "importprivkey", false, &filtered);

--- a/src/test/data/bitcoin-util-test.json
+++ b/src/test/data/bitcoin-util-test.json
@@ -5,7 +5,7 @@
     "description": "Creates a blank v1 transaction"
   },
   { "exec": "./dogecoin-tx",
-    "args": ["-json","-create", "nversion=1"],
+    "args": ["-json", "-create", "nversion=1"],
     "output_cmp": "blanktxv1.json",
     "description": "Creates a blank v1 transaction (output in json)"
   },
@@ -13,15 +13,15 @@
     "args": ["-"],
     "input": "blanktxv2.hex",
     "output_cmp": "blanktxv2.hex",
-    "description": "Creates a blank transaction when nothing is piped into dogecoin-tx"
+    "description": "Creates a blank v2 transaction when nothing is piped into dogecoin-tx"
   },
   { "exec": "./dogecoin-tx",
-    "args": ["-json","-create"],
+    "args": ["-json","-create", "nversion=2"],
     "output_cmp": "blanktxv2.json",
-    "description": "Creates a blank transaction (output in json)"
+    "description": "Creates a blank v2 transaction (output in json)"
   },
   { "exec": "./dogecoin-tx",
-    "args": ["-json","-"],
+    "args": ["-json", "-"],
     "input": "blanktxv2.hex",
     "output_cmp": "blanktxv2.json",
     "description": "Creates a blank transaction when nothing is piped into dogecoin-tx (output in json)"
@@ -84,15 +84,15 @@
     "error_txt": "error: TX output missing or too many separators",
     "description": "Malformed outaddr argument (no address specified). Expected to fail."
   },
-  { "exec": "./bitcoin-tx",
+  { "exec": "./dogecoin-tx",
     "args":
     ["-create",
-     "outaddr=1:13tuJJDR2RgArmgfv6JScSdreahzgc4T6o:garbage"],
+     "outaddr=1:DTH54BW9S9Q1EPCCiseQCzEBgf6pTRZv3U:garbage"],
     "return_code": 1,
     "error_txt": "error: TX output missing or too many separators",
     "description": "Malformed outaddr argument (too many separators). Expected to fail."
   },
-  { "exec": "./bitcoin-tx",
+  { "exec": "./dogecoin-tx",
     "args":
     ["-create",
      "outpubkey=0"],
@@ -100,7 +100,7 @@
     "error_txt": "error: TX output missing or too many separators",
     "description": "Malformed outpubkey argument (no pubkey specified). Expected to fail."
   },
-  { "exec": "./bitcoin-tx",
+  { "exec": "./dogecoin-tx",
     "args":
     ["-create",
      "outpubkey=0:02a5613bd857b7048924264d1e70e08fb2a7e6527d32b7ab1bb993ac59964ff397:W:non53nse"],
@@ -108,14 +108,15 @@
     "error_txt": "error: TX output missing or too many separators",
     "description": "Malformed outpubkey argument (too many separators). Expected to fail."
   },
-  { "exec": "./bitcoin-tx",
+  { "exec": "./dogecoin-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd",
-     "outaddr=4:DTH54BW9S9Q1EPCCiseQCzEBgf6pTRZv3U"],
+     "outaddr=4:DTH54BW9S9Q1EPCCiseQCzEBgf6pTRZv3U",
+     "nversion=2"],
     "output_cmp": "txcreate1.hex",
     "description": "Creates a new transaction with three inputs and two outputs"
   },
@@ -127,17 +128,18 @@
      "in=bf829c6bcf84579331337659d31f89dfd138f7f7785802d5501c92333145ca7c:18",
      "in=22a6f904655d53ae2ff70e701a0bbd90aa3975c0f40bfc6cc996a9049e31cdfc:1",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd",
-     "outaddr=4:DTH54BW9S9Q1EPCCiseQCzEBgf6pTRZv3U"],
+     "outaddr=4:DTH54BW9S9Q1EPCCiseQCzEBgf6pTRZv3U",
+     "nversion=2"],
     "output_cmp": "txcreate1.json",
     "description": "Creates a new transaction with three inputs and two outputs (output in json)"
   },
   { "exec": "./dogecoin-tx",
-    "args": ["-create", "outscript=0:"],
+    "args": ["-create", "outscript=0:", "nversion=2"],
     "output_cmp": "txcreate2.hex",
     "description": "Creates a new transaction with a single empty output script"
   },
   { "exec": "./dogecoin-tx",
-    "args": ["-json", "-create", "outscript=0:"],
+    "args": ["-json", "-create", "outscript=0:", "nversion=2"],
     "output_cmp": "txcreate2.json",
     "description": "Creates a new transaction with a single empty output script (output in json)"
   },
@@ -216,7 +218,7 @@
   },
   { "exec": "./dogecoin-tx",
     "args":
-    ["-create",
+    ["-create", "nversion=2",
       "in=4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485:0",
       "set=privatekeys:[\"6J8csdv3eDrnJcpSEb4shfjMh2JTiG9MKzC1Yfge4Y4GyUsjdM6\"]",
       "set=prevtxs:[{\"txid\":\"4d49a71ec9da436f71ec4ee231d04f292a29cd316f598bb7068feccabdc59485\",\"vout\":0,\"scriptPubKey\":\"76a91491b24bf9f5288532960ac687abb035127b1d28a588ac\"}]",
@@ -281,7 +283,7 @@
   },
   { "exec": "./dogecoin-tx",
     "args":
-    ["-create",
+    ["-create", "nversion=2",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd",
      "outdata=4:54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
@@ -300,7 +302,7 @@
   },
   { "exec": "./dogecoin-tx",
     "args":
-    ["-create",
+    ["-create", "nversion=2",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd",
      "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
@@ -310,7 +312,7 @@
   { "exec": "./dogecoin-tx",
     "args":
     ["-json",
-     "-create",
+     "-create", "nversion=2",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd",
      "outdata=54686973204f505f52455455524e207472616e73616374696f6e206f7574707574207761732063726561746564206279206d6f646966696564206372656174657261777472616e73616374696f6e2e"],
@@ -319,7 +321,7 @@
   },
   { "exec": "./dogecoin-tx",
     "args":
-    ["-create",
+    ["-create", "nversion=2",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd"],
     "output_cmp": "txcreatedata_seq0.hex",
@@ -328,7 +330,7 @@
   { "exec": "./dogecoin-tx",
     "args":
     ["-json",
-     "-create",
+     "-create", "nversion=2",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:4294967293",
      "outaddr=0.18:D82zqZA4KqaTPmsGegJ1ACoTXiSJ21NcZd"],
     "output_cmp": "txcreatedata_seq0.json",

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vin[0].prevout.n = 1;
     t.vin[0].scriptSig << std::vector<unsigned char>(65, 0);
     t.vout.resize(1);
-    t.vout[0].nValue = 90*CENT;
+    t.vout[0].nValue = COIN;
     CKey key;
     key.MakeNewKey(true);
     t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain240Setup)
         spends[i].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
         spends[i].vin[0].prevout.n = 0;
         spends[i].vout.resize(1);
-        spends[i].vout[0].nValue = 11*CENT;
+        spends[i].vout[0].nValue = COIN;
         spends[i].vout[0].scriptPubKey = scriptPubKey;
 
         // Sign:

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         add_coin( 18*COIN); // now we have 5+6+7+8+18+20+30
 
-        // and now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 cents, the same as the next biggest output, 18
+        // and now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 coins, the same as the next biggest output, 18
         BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * COIN);  // we should get 18 in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest output wins

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -88,115 +88,115 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     {
         empty_wallet();
 
-        // with an empty wallet we can't even pay one cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // with an empty wallet we can't even pay one coin
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        add_coin(1*CENT, 4);        // add a new 1 cent coin
+        add_coin(1*COIN, 4);        // add a new 1 coin output
 
-        // with a new 1 cent coin, we still can't find a mature 1 cent
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * CENT, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // with only a new 1 coin output, we still can't find a mature 1 coin output
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        // but we can find a new 1 cent
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
+        // but we can find a new 1 coin output
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);
 
-        add_coin(2*CENT);           // add a mature 2 cent coin
+        add_coin(2*COIN);           // add a mature 2 coin output
 
-        // we can't make 3 cents of mature coins
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * CENT, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // we can't make 3 coins of mature outputs
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        // we can make 3 cents of new  coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
+        // we can make 3 coin of new outputs
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 3 * COIN);
 
-        add_coin(5*CENT);           // add a mature 5 cent coin,
-        add_coin(10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
-        add_coin(20*CENT);          // and a mature 20 cent coin
+        add_coin(5*COIN);           // add a mature 5 coin output,
+        add_coin(10*COIN, 3, true); // a new 10 coin output sent from one of our own addresses
+        add_coin(20*COIN);          // and a mature 20 coin output
 
         // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
 
-        // we can't make 38 cents only if we disallow new coins:
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
-        // we can't even make 37 cents if we don't allow new coins even if they're from us
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * CENT, 6, 6, 0, vCoins, setCoinsRet, nValueRet));
-        // but we can make 37 cents if we accept new coins from ourself
-        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * CENT, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 37 * CENT);
-        // and we can make 38 cents if we accept all new coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 38 * CENT);
+        // we can't make 38 coins only if we disallow new output:
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // we can't even make 37 coins if we don't allow new output even if they're from us
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * COIN, 6, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // but we can make 37 coins if we accept new output from ourself
+        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 37 * COIN);
+        // and we can make 38 coins if we accept all new output
+        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 38 * COIN);
 
-        // try making 34 cents from 1,2,5,10,20 - we can't do it exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 35 * CENT);       // but 35 cents is closest
+        // try making 34 coins from 1,2,5,10,20 - we can't do it exactly
+        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 35 * COIN);       // but 35 coins is closest
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
 
-        // when we try making 7 cents, the smaller coins (1,2,5) are enough.  We should see just 2+5
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 7 * CENT);
+        // when we try making 7 coins, the smaller outputs (1,2,5) are enough.  We should see just 2+5
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 7 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
-        // when we try making 8 cents, the smaller coins (1,2,5) are exactly enough.
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(nValueRet == 8 * CENT);
+        // when we try making 8 coins, the smaller outputs (1,2,5) are exactly enough.
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(nValueRet == 8 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        // when we try making 9 cents, no subset of smaller coins is enough, and we get the next bigger coin (10)
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 10 * CENT);
+        // when we try making 9 coins, no subset of smaller outputs is enough, and we get the next bigger output (10)
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 10 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
         empty_wallet();
 
-        add_coin( 6*CENT);
-        add_coin( 7*CENT);
-        add_coin( 8*CENT);
-        add_coin(20*CENT);
-        add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
+        add_coin( 6*COIN);
+        add_coin( 7*COIN);
+        add_coin( 8*COIN);
+        add_coin(20*COIN);
+        add_coin(30*COIN); // now we have 6+7+8+20+30 = 71 coins total
 
         // check that we have 71 and not 72
-        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
 
-        // now try making 16 cents.  the best smaller coins can do is 6+7+8 = 21; not as good at the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
+        // now try making 16 coins.  the best smaller outputs can do is 6+7+8 = 21; not as good at the next biggest output, 20
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 20 * COIN); // we should get 20 in one output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
+        add_coin( 5*COIN); // now we have 5+6+7+8+20+30 = 75 coins total
 
-        // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
+        // now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 coins, better than the next biggest output, 20
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 18 * COIN); // we should get 18 in 3 outputs
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
+        add_coin( 18*COIN); // now we have 5+6+7+8+18+20+30
 
-        // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * CENT);  // we should get 18 in 1 coin
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest coin wins
+        // and now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 cents, the same as the next biggest output, 18
+        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 18 * COIN);  // we should get 18 in 1 output
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest output wins
 
-        // now try making 11 cents.  we should get 5+6
-        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 11 * CENT);
+        // now try making 11 coins.  we should get 5+6
+        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 11 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
-        // check that the smallest bigger coin is used
-        add_coin( 1*COIN);
-        add_coin( 2*COIN);
-        add_coin( 3*COIN);
-        add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
-        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
+        // check that the smallest bigger output is used
+        add_coin( 100*COIN);
+        add_coin( 200*COIN);
+        add_coin( 300*COIN);
+        add_coin( 400*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 100 * COIN);  // we should get 100 coins in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);  // we should get 2 BTC in 1 coin
+        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 200 * COIN);  // we should get 200 coins in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        // empty the wallet and start again, now with fractions of a cent, to test small change avoidance
+        // empty the wallet and start again, now with fractions of a coin, to test small change avoidance
 
         empty_wallet();
         add_coin(MIN_CHANGE * 1 / 10);
@@ -210,14 +210,14 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);
 
-        // but if we add a bigger coin, small change is avoided
+        // but if we add a bigger output, small change is avoided
         add_coin(1111*MIN_CHANGE);
 
         // try making 1 from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
 
-        // if we add more small coins:
+        // if we add more small output:
         add_coin(MIN_CHANGE * 6 / 10);
         add_coin(MIN_CHANGE * 7 / 10);
 
@@ -226,26 +226,26 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
 
         // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
-        // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
+        // they tried to consolidate 10 50k outputs into one 500k output, and ended up with 50k in change
         empty_wallet();
         for (int j = 0; j < 20; j++)
             add_coin(50000 * COIN);
 
         BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 10U); // in ten coins
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 10U); // in ten outputs
 
         // if there's not enough in the smaller coins to make at least 1 * MIN_CHANGE change (0.5+0.6+0.7 < 1.0+1.0),
         // we need to try finding an exact subset anyway
 
-        // sometimes it will fail, and so we use the next biggest coin:
+        // sometimes it will fail, and so we use the next biggest output:
         empty_wallet();
         add_coin(MIN_CHANGE * 5 / 10);
         add_coin(MIN_CHANGE * 6 / 10);
         add_coin(MIN_CHANGE * 7 / 10);
         add_coin(1111 * MIN_CHANGE);
         BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1111 * MIN_CHANGE); // we get the bigger coin
+        BOOST_CHECK_EQUAL(nValueRet, 1111 * MIN_CHANGE); // we get the bigger output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(1111 * MIN_CHANGE);
         BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);   // we should get the exact amount
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two coins 0.4+0.6
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two outputs 0.4+0.6
 
         // test avoiding small change
         empty_wallet();
@@ -264,26 +264,26 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         add_coin(MIN_CHANGE * 1);
         add_coin(MIN_CHANGE * 100);
 
-        // trying to make 100.01 from these three coins
+        // trying to make 100.01 from these three outputs
         BOOST_CHECK(wallet.SelectCoinsMinConf(MIN_CHANGE * 10001 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE * 10105 / 100); // we should get all coins
+        BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE * 10105 / 100); // we should get all outputs
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        // but if we try to make 99.9, we should take the bigger of the two small coins to avoid small change
+        // but if we try to make 99.9, we should take the bigger of the two small outputs to avoid small change
         BOOST_CHECK(wallet.SelectCoinsMinConf(MIN_CHANGE * 9990 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 101 * MIN_CHANGE);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // test with many inputs
-        for (CAmount amt=1500; amt < COIN; amt*=10) {
+        for (CAmount amt=15*CENT; amt < 10000 * COIN; amt*=10) {
              empty_wallet();
              // Create 676 inputs (=  (old MAX_STANDARD_TX_SIZE == 100000)  / 148 bytes per input)
              for (uint16_t j = 0; j < 676; j++)
                  add_coin(amt);
-             BOOST_CHECK(wallet.SelectCoinsMinConf(2000, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-             if (amt - 2000 < MIN_CHANGE) {
+             BOOST_CHECK(wallet.SelectCoinsMinConf(20*CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+             if (amt - 20*CENT < MIN_CHANGE) {
                  // needs more than one input:
-                 uint16_t returnSize = std::ceil((2000.0 + MIN_CHANGE)/amt);
+                 uint16_t returnSize = std::ceil((20.0 * CENT + MIN_CHANGE)/amt);
                  CAmount returnValue = amt * returnSize;
                  BOOST_CHECK_EQUAL(nValueRet, returnValue);
                  BOOST_CHECK_EQUAL(setCoinsRet.size(), returnSize);
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             for (int i2 = 0; i2 < 100; i2++)
                 add_coin(COIN);
 
-            // picking 50 from 100 coins doesn't depend on the shuffle,
+            // picking 50 from 100 outputs doesn't depend on the shuffle,
             // but does depend on randomness in the stochastic approximation code
             BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, 0, vCoins, setCoinsRet , nValueRet));
             BOOST_CHECK(wallet.SelectCoinsMinConf(50 * COIN, 1, 6, 0, vCoins, setCoinsRet2, nValueRet));
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             int fails = 0;
             for (int j = 0; j < RANDOM_REPEATS; j++)
             {
-                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
+                // selecting 1 from 100 identical outputs depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail
                 BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, 0, vCoins, setCoinsRet , nValueRet));
                 BOOST_CHECK(wallet.SelectCoinsMinConf(COIN, 1, 6, 0, vCoins, setCoinsRet2, nValueRet));
@@ -318,22 +318,22 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             }
             BOOST_CHECK_NE(fails, RANDOM_REPEATS);
 
-            // add 75 cents in small change.  not enough to make 90 cents,
-            // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
+            // add 75 coins in small change.  not enough to make 90 coins,
+            // then try making 90 coins.  there are multiple competing "smallest bigger" outputs,
             // one of which should be picked at random
-            add_coin(5 * CENT);
-            add_coin(10 * CENT);
-            add_coin(15 * CENT);
-            add_coin(20 * CENT);
-            add_coin(25 * CENT);
+            add_coin(5 * COIN);
+            add_coin(10 * COIN);
+            add_coin(15 * COIN);
+            add_coin(20 * COIN);
+            add_coin(25 * COIN);
 
             fails = 0;
             for (int j = 0; j < RANDOM_REPEATS; j++)
             {
-                // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
+                // selecting 1 from 100 identical outputs depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, 0, vCoins, setCoinsRet , nValueRet));
-                BOOST_CHECK(wallet.SelectCoinsMinConf(90*CENT, 1, 6, 0, vCoins, setCoinsRet2, nValueRet));
+                BOOST_CHECK(wallet.SelectCoinsMinConf(90*COIN, 1, 6, 0, vCoins, setCoinsRet , nValueRet));
+                BOOST_CHECK(wallet.SelectCoinsMinConf(90*COIN, 1, 6, 0, vCoins, setCoinsRet2, nValueRet));
                 if (equal_sets(setCoinsRet, setCoinsRet2))
                     fails++;
             }


### PR DESCRIPTION
### VERY QUALITY

**Core tests:**
- _transactiontests_, _txvalidationcachetests_ and _wallettests_ were spending dust
  - changed test amounts
- _dogecoin-tx_ tests were failing due to a difference in tx version with upstream caused by 140cc1d 
  - made versions explicit
- _dogecoin-tx_ tests had some statements that were referring to the `bitcoin-tx` executable 
  - changed to `dogecoin-tx`

**QT tests:**
- _rpcnestedtests_ was testing for a bitcoin block hash
  - changed to the dogecoin block hash
- _paymentservertests_ was testing to spend the maximum amount of bitcoin, which works differently on DOGE.
  - commented the test out

**RPC test framework:**
- Core test framework was calling `python3.6` hardcoded, which doesn't work on trusty (and thus our travis setup)
  - hardcoded to `python3` like everything else
- Pull tester dependencies were using `wget`, where everything else uses `curl`
  - changed to use `curl`
- Auxpow framework libraries were using `litecoin_scrypt` but deps were installing `ltc_scrypt`
  - reverted libraries to use `ltc_scrypt`
- Auxpow framework libraries were calling `_target` attribute which was supposed to be just `target`
  - changed to use `target`
- Auxpow framework libraries were using python 3.5+ `binary.hex()` calls which don't work on trusty
  - changed to use `binascii` calls consistently for `binary.hex()` and `binary.fromhex()`

**RPC tests**
- _importprunedfunds_, _fundrawtransaction_ and _listtransaction_ were spending dust
  - changed test amounts
- _importprunedfunds_ was re-spending target outputs used in later tests
  - changed tx creation order to ascending value
- _multi_rpc_ was writing credentials to `bitcoin.conf`
  - fixed that to write to `dogecoin.conf`

**Travis:**
- remove `sudo` flag because its depreciated - removes warning
- rename `env/matrix` to `env/jobs` - removes warning
- `RUN_TESTS` directive requires python3-dev for compiling `ltc_scrypt`
