### PR TITLE
Locale independent sorting

### DIFF
--- a/src/leveldb/build_detect_platform
+++ b/src/leveldb/build_detect_platform
@@ -176,7 +176,7 @@ set -f # temporarily disable globbing so that our patterns aren't expanded
 PRUNE_TEST="-name *test*.cc -prune"
 PRUNE_BENCH="-name *_bench.cc -prune"
 PRUNE_TOOL="-name leveldbutil.cc -prune"
-PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o -name '*.cc' -print | sort | sed "s,^$PREFIX/,," | tr "\n" " "`
+PORTABLE_FILES=`find $DIRS $PRUNE_TEST -o $PRUNE_BENCH -o $PRUNE_TOOL -o -name '*.cc' -print | LC_ALL=C sort | sed "s,^$PREFIX/,," | tr "\n" " "`
 
 set +f # re-enable globbing
 


### PR DESCRIPTION
Some locales sort differently, which causes a different order
of files, which leads to an unreproducible build.
Sort the files always with the C locale.

Rebased off #1371 because that is dealing with a tree inconsistency on 1.14-dev.