### PR TITLE
Update package links for OSX cross compilation

### DIFF
--- a/depends/packages/native_ds_store.mk
+++ b/depends/packages/native_ds_store.mk
@@ -1,9 +1,8 @@
 package=native_ds_store
 $(package)_version=1.1.0
-$(package)_download_path=https://bitbucket.org/al45tair/ds_store/get
-$(package)_download_file=v$($(package)_version).tar.bz2
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=921596764d71d1bbd3297a90ef6d286f718794d667e4f81d91d14053525d64c1
+$(package)_download_path=https://github.com/al45tair/ds_store/archive/
+$(package)_file_name=v$($(package)_version).tar.gz
+$(package)_sha256_hash=a9f4c0755c6be7224ff7029e188dd262e830bb81e801424841db9eb0780ec8ed
 $(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
 $(package)_dependencies=native_biplist
 

--- a/depends/packages/native_mac_alias.mk
+++ b/depends/packages/native_mac_alias.mk
@@ -1,9 +1,9 @@
 package=native_mac_alias
 $(package)_version=1.1.0
-$(package)_download_path=https://bitbucket.org/al45tair/mac_alias/get
-$(package)_download_file=v$($(package)_version).tar.bz2
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=87ad827e66790028361e43fc754f68ed041a9bdb214cca03c853f079b04fb120
+$(package)_download_path=https://github.com/al45tair/mac_alias/archive/
+$(package)_download_file=v$($(package)_version).tar.gz
+$(package)_file_name=mac_alias-$($(package)_version).tar.gz
+$(package)_sha256_hash=b10cb44ecb64fc25283fae7a9cf365d2829377d84e37b9c21100aca8757509be
 $(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
 $(package)_patches=python3.patch
 


### PR DESCRIPTION
Update broken package links while cross compiling for OSX.

Also, something Dogecoin developers might find useful:
https://github.com/Vertian/DockerDOGE/