### PR TITLE
Fix build with qt 5 by including <QPainterPath>

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
This is part 2 of a rebase of PR https://github.com/dogecoin/dogecoin/pull/1655 to fix tests. This only includes the fixes for qt 5, the previous PR for the Boost fixes is here: https://github.com/dogecoin/dogecoin/pull/1694.

Resolves https://github.com/dogecoin/dogecoin/issues/1642