### PR TITLE
fix minimum required space for data directory

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -23,7 +23,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 50;
+static const uint64_t BLOCK_CHAIN_SIZE = 55;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 2;
 /* Total required space (in GB) depending on user choice (prune, not prune) */

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -23,7 +23,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 120;
+static const uint64_t BLOCK_CHAIN_SIZE = 50;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 2;
 /* Total required space (in GB) depending on user choice (prune, not prune) */


### PR DESCRIPTION
The minimum required space for the data directory (shown when first launching the qt wallet) was originally unchanged from Bitcoin. This reduces it to just above the current size of the Dogecoin blockchain.