### PR TITLE
Skip auxpow checks when reading blocks from disk

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -777,6 +777,11 @@ void InitParameterInteraction()
         if (SoftSetBoolArg("-whitelistrelay", true))
             LogPrintf("%s: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1\n", __func__);
     }
+
+    // Skip checking auxpow checks when reading from disk
+    if (GetBoolArg("-skipauxpowchecks", DEFAULT_SKIPAUXPOWCHECKS)) {
+        fSkipAuxpowChecks = true;
+    }
 }
 
 static std::string ResolveErrMsg(const char * const optname, const std::string& strBind)
@@ -1549,6 +1554,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         return false;
     }
     LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
+
+    if (fSkipAuxpowChecks)
+        LogPrintf("Skipping auxpow checks on blocks loaded from disk..\n");
 
     boost::filesystem::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fopen(est_path.string().c_str(), "rb"), SER_DISK, CLIENT_VERSION);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -71,6 +71,7 @@ bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
+bool fSkipAuxpowChecks = false;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
@@ -1160,7 +1161,7 @@ static bool ReadBlockOrHeader(T& block, const CDiskBlockPos& pos, const Consensu
     }
 
     // Check the header
-    if (!CheckAuxPowProofOfWork(block, consensusParams))
+    if (!fSkipAuxpowChecks && !CheckAuxPowProofOfWork(block, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -47,6 +47,8 @@ struct ChainTxData;
 struct PrecomputedTransactionData;
 struct LockPoints;
 
+/** Run all standard auxpow checks when reading from disk */
+static const bool DEFAULT_SKIPAUXPOWCHECKS = false;
 /** Default for accepting alerts from the P2P network. */
 static const bool DEFAULT_ALERTS = true;
 /** Default for DEFAULT_WHITELISTRELAY. */
@@ -169,6 +171,7 @@ extern std::atomic_bool fImporting;
 extern bool fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
+extern bool fSkipAuxpowChecks;
 extern bool fIsBareMultisigStd;
 extern bool fRequireStandard;
 extern bool fCheckBlockIndex;


### PR DESCRIPTION
As per discussion in https://github.com/dogecoin/dogecoin/pull/1676