### PR TITLE
fix windows build notes location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Early 2015 (approximately a year and a half after release) there will be approxi
 Each subsequent block will grant 10,000 coins to encourage miners to continue to secure the network and make up for lost wallets on hard drives/phones/lost encryption passwords/etc.
 
 ### How to get doge? – To the moon!
-Dogecoin uses a simplified variant of the scrypt key derivation function as its proof of work with a target time of one minute per block and difficulty readjustment after every block. The block rewards are fixed and halve every 100,000 blocks. Starting with the 600,000th block, a permanent reward of 10,000 Dogecoin per block will be paid. 
+Dogecoin uses a simplified variant of the scrypt key derivation function as its proof of work with a target time of one minute per block and difficulty readjustment after every block. The block rewards are fixed and halve every 100,000 blocks. Starting with the 600,000th block, a permanent reward of 10,000 Dogecoin per block will be paid.
 
 Originally, a different payout scheme was envisioned with block rewards being determined by taking the maximum reward as per the block schedule and applying the result of a Mersenne Twister pseudo-random number generator to arrive at a number between 0 and the maximum reward. This was changed, starting with block 145,000, to prevent large pools from gaming the system and mining only high reward blocks. At the same time, the difficulty retargeting was also changed from four hours to once per block (every minute), implementing an algorithm courtesy of the DigiByte Coin development team, to lessen the impact of sudden increases and decreases of network hashing rate.
 
@@ -96,7 +96,7 @@ The original block reward schedule, with one-minute block targets and four-hour 
 
   - [OSX Build Notes](doc/build-osx.md)
   - [Unix Build Notes](doc/build-unix.md)
-  - [Windows Build Notes](doc/build-msw.md)
+  - [Windows Build Notes](doc/build-windows.md)
 
 ### Such ports
 RPC 22555


### PR DESCRIPTION
This fixes the link to the windows build instructions in the README. Closes https://github.com/dogecoin/dogecoin/issues/1667.