### PR TITLE
Added Github Actions automatic build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        name:
+          - Ubuntu 18.04 GCC
+        include:
+          - name: Ubuntu 18.04 GCC
+            os: ubuntu-18.04
+            compiler: gcc
+            cpp-compiler: g++
+            build-dir: build
+            build-src-dir: ..
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Install packages (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libdb++-dev libboost-all-dev ${{ matrix.packages }}
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate project files
+        run: |
+          ./autogen.sh
+          ./configure  --disable-wallet
+
+      - name: Compile source code
+        run: |
+          make -j2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install libdb++-dev libboost-all-dev ${{ matrix.packages }}
+          sudo apt-get install libdb++-dev libboost-all-dev libevent-dev ${{ matrix.packages }}
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
I added an automatic build for Linux. I can also try to add automatic builds and releases for MacOS and Windows. It can help to quickly know if new warnings and incompatibilities between platforms are made on each PR. What do you guys think? Has this been discussed before? Also is there an IRC or Discord where the devs hang out so I can have a better understating of your workflow so I'm able to figure out how I can help?

such actions