### PR TITLE
Removal of Denarius (D) DNS Peer Seeder Nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -163,9 +163,6 @@ public:
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.push_back(CDNSSeedData("multidoge.org", "seed.multidoge.org", true));
         vSeeds.push_back(CDNSSeedData("multidoge.org", "seed2.multidoge.org"));
-        vSeeds.push_back(CDNSSeedData("veryseed.denarius.pro", "veryseed.denarius.pro"));
-        vSeeds.push_back(CDNSSeedData("muchseed.denarius.pro", "muchseed.denarius.pro"));
-        vSeeds.push_back(CDNSSeedData("suchseed.denarius.pro", "suchseed.denarius.pro"));
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,22);


### PR DESCRIPTION
We are removing our Dogecoin DNS Peer Seeder nodes from DOGE. We provided DNS peer seeders for Dogecoin in hopes that we would at least be given some basic credit that the Denarius community was providing these nodes and helping everyone sync. That is not the case.

Dogecoin is a joke and should be treated as such. Join a real project like Denarius (D).

veryseed.denarius.pro
muchseed.denarius.pro
suchseed.denarius.pro

Are now removed. @buzzkillb will be providing statistics in this PR of how many requests we handled with absolutely zero credit. It is really a shame, something so simple, could not be given...