### PR TITLE
Target  OS non-windows use fPIC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -514,8 +514,8 @@ if test x$use_hardening != xno; then
   AX_CHECK_LINK_FLAG([[-Wl,-z,now]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,now"])
 
   if test x$TARGET_OS != xwindows; then
-    AX_CHECK_COMPILE_FLAG([-fPIE],[PIE_FLAGS="-fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
+    AX_CHECK_COMPILE_FLAG([-fPIC],[PIE_FLAGS="-fPIE"])
+    AX_CHECK_LINK_FLAG([[-fno-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
   fi
 
   case $host in


### PR DESCRIPTION
Revisiting this as it was previously a reverted merge because it wasn't done to the dev branch. (see, #1420, #1447)

## Scope of PR:

Resolves an issue where the compiled binaries (in particular dogecoin-qt) cannot be executed using the mouse in non windows environments (i.e. Linux). Forcing users to have to start the client from terminal.

By building with fPIE, the resulting objects are "LSB shared objects".  Thus changing to fPIC builds a LSB executable binary that a user can double-click on to start the program.

This PR changes `-fPIE to fPIC`

### -fPIC
>Generate position-independent code (PIC) suitable for use in a shared library...

### -fPIE
>These options are similar to -fpic and -fPIC, but generated position independent code can be only linked into executables....

