### PR TITLE
Formatting in "Development Tips and Tricks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ P2P 22556
 **compiling for debugging**
 
 Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
-`CXXFLAGS="-g -ggdb -O0`" or whatever debug flags you need.
+`CXXFLAGS="-g -ggdb -O0"` or whatever debug flags you need.
 
 **debug.log**
 

--- a/README.md
+++ b/README.md
@@ -108,32 +108,32 @@ P2P 22556
 
 **compiling for debugging**
 
-Run configure with the --enable-debug option, then make. Or run configure with
-CXXFLAGS="-g -ggdb -O0" or whatever debug flags you need.
+Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
+`CXXFLAGS="-g -ggdb -O0`" or whatever debug flags you need.
 
 **debug.log**
 
 If the code is behaving strangely, take a look in the debug.log file in the data directory;
 error and debugging messages are written there.
 
-The -debug=... command-line option controls debugging; running with just -debug will turn
+The `-debug=...` command-line option controls debugging; running with just `-debug` will turn
 on all categories (and give you a very large debug.log file).
 
-The Qt code routes qDebug() output to debug.log under category "qt": run with -debug=qt
+The Qt code routes `qDebug()` output to debug.log under category "qt": run with `-debug=qt`
 to see it.
 
 **testnet and regtest modes**
 
-Run with the -testnet option to run with "play dogecoins" on the test network, if you
+Run with the `-testnet` option to run with "play dogecoins" on the test network, if you
 are testing multi-machine code that needs to operate across the internet.
 
-If you are testing something that can run on one machine, run with the -regtest option.
+If you are testing something that can run on one machine, run with the `-regtest` option.
 In regression test mode, blocks can be created on-demand; see qa/rpc-tests/ for tests
-that run in -regtest mode.
+that run in `-regtest` mode.
 
 **DEBUG_LOCKORDER**
 
 Dogecoin Core is a multithreaded application, and deadlocks or other multithreading bugs
-can be very difficult to track down. Compiling with -DDEBUG_LOCKORDER (configure
-CXXFLAGS="-DDEBUG_LOCKORDER -g") inserts run-time checks to keep track of which locks
+can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
+CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
 are held, and adds warnings to the debug.log file if inconsistencies are detected.


### PR DESCRIPTION
Formatting the `commands` within this section