### PR TITLE
[qt] only allow https explorer links

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -220,8 +220,9 @@ void TransactionView::setModel(WalletModel *_model)
             QStringList listUrls = _model->getOptionsModel()->getThirdPartyTxUrls().split("|", QString::SkipEmptyParts);
             for (int i = 0; i < listUrls.size(); ++i)
             {
-                QString host = QUrl(listUrls[i].trimmed(), QUrl::StrictMode).host();
-                if (!host.isEmpty())
+                QUrl url = QUrl(listUrls[i].trimmed(), QUrl::StrictMode);
+                QString host = url.host();
+                if (!host.isEmpty() && url.scheme() == "https")
                 {
                     QAction *thirdPartyTxUrlAction = new QAction(host, this); // use host as menu item label
                     if (i == 0)


### PR DESCRIPTION
Sanity checks URLs to enforce https scheme. If a different or no scheme is specified, do not enable the menu item, just like when no host is specified.

Originally reported by Fabian Braeunlein of PS Positive Security GmbH