### PR TITLE
Remove deprecated encoding key in dogecoin-qt.desktop

### DIFF
--- a/contrib/debian/dogecoin-qt.desktop
+++ b/contrib/debian/dogecoin-qt.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Dogecoin Core
 Comment=Connect to the Dogecoin P2P Network
 Comment[de]=Verbinde mit dem Dogecoin peer-to-peer Netzwerk


### PR DESCRIPTION
I came across that installing the dogecoin-qt.desktop file that it is using an encoding key which is deprecated and UTF-8 is a requirement. It can be safely removed per https://lintian.debian.org/tags/desktop-entry-contains-encoding-key.html
https://github.com/dogecoin/dogecoin/blob/038ccec3e44dbfa458e00aff99a8a27fac7fb8d7/contrib/debian/dogecoin-qt.desktop#L2

I validated this by running the command:

`desktop-file-validate /usr/share/applications/dogecoin-qt.desktop`

Its output states:
```bash
/usr/share/applications/dogecoin-qt.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
```