### PR TITLE
Travis: Use minimal trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 os: linux
-language: generic
+language: minimal
 cache:
   directories:
   - depends/built


### PR DESCRIPTION
This removes a ton of unneeded external apt repos out of which at least one (cassandra) is broken right now.