### PR TITLE
Mention wallet recovery

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,10 @@
 
 This issue tracker is only for technical issues related to Dogecoin Core.
 
-For general questions about Dogecoin or wallet recovery please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
+For general questions about Dogecoin or wallet recovery please use one of the various communities:
+
+* [Dogeducation on reddit](https://www.reddit.com/r/dogeducation/)
+* [Discord](https://discord.com/invite/dogecoin)
 
 ### Describe the issue
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 This issue tracker is only for technical issues related to Dogecoin Core.
 
-For general questions about Dogecoin please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
+For general questions about Dogecoin or wallet recovery please use one of the various communities, e.g. Reddit, IRC, Discord, etc.
 
 ### Describe the issue
 


### PR DESCRIPTION
in the past days a lot of wallet recovery issues popped up.
To prevent those it should be mentioned in the issue template that github issues are not the correct channel for this.