### PR TITLE
Snap Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,9 @@ contrib/devtools/split-debug.sh
 
 .idea/
 .vscode/*
+
+# Snapcraft
+parts/
+prime/
+stage/
+*.snap

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -32,7 +32,7 @@ Notes on getting Gitian builds up and running using KVM.
 PGP keys used for signing Dogecoin Core [Gitian release](/doc/release-process.md) results.
 
 ### [MacDeploy](/contrib/macdeploy) ###
-Scripts and notes for Mac builds. 
+Scripts and notes for Mac builds.
 
 ### [RPM](/contrib/rpm) ###
 RPM spec file for building dogecoin-core on RPM based distributions
@@ -40,7 +40,10 @@ RPM spec file for building dogecoin-core on RPM based distributions
 ### [Gitian-build](/contrib/gitian-build.sh) ###
 Script for running full Gitian builds.
 
-Test and Verify Tools 
+### [Snap](/contrib/snap) ###
+snapcraft.yaml file for building and distributing dogecoin-core with Snapcraft.
+
+Test and Verify Tools
 ---------------------
 
 ### [TestGen](/contrib/testgen) ###

--- a/contrib/snap/README.md
+++ b/contrib/snap/README.md
@@ -1,0 +1,18 @@
+All the commands I used for building and pushing to Snapcraft. I've only tested the amd64 .snap package, but anyone on amd64, arm64, or i686 should be able to build and/or install it for themselves with these instructions.
+
+---
+
+## Building Locally
+
+sudo apt install snapd
+sudo snap install --classic snapcraft
+snapcraft
+
+### To Install Locally
+snap install \*.snap --devmode
+
+### To Push to Snapcraft
+snapcraft login
+snapcraft register dogecoin-core
+snapcraft push \*.snap --release=edge
+sudo snap install dogecoin-core --channel=edge

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -1,0 +1,68 @@
+name: dogecoin-core # you probably want to 'snapcraft register <name>'
+version: '1.14.4'
+summary: Reference client of Dogecoin, a peer-to-peer digital currency like Bitcoin.
+description: |
+  Dogecoin is a cryptocurrency like Bitcoin, although it does not use SHA256 as its proof of work (POW). Taking development cues from Tenebrix and Litecoin, Dogecoin currently employs a simplified variant of scrypt. MIT licenced.
+
+base: core18
+grade: stable
+confinement: strict
+architectures:
+  - build-on: [amd64, i386, arm64]
+
+apps:
+  d:
+    command: dogecoind
+    plugs: [home, removable-media, network, network-bind]
+    environment:
+    # Override HOME so the datadir is located at ~/snap/dogecoin-core/common/.dogecoin/ instead of ~/snap/dogecoin-core/current/.dogecoin/, and each new version of the snap won't have a different data directory: https://docs.snapcraft.io/environment-variables/7983
+      HOME: $SNAP_USER_COMMON
+  qt:
+    command: qt4-launch dogecoin-qt
+    plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
+    environment:
+      HOME: $SNAP_USER_COMMON
+      DISABLE_WAYLAND: 1
+  cli:
+    command: dogecoin-cli
+    plugs: [home, removable-media, network]
+    environment:
+      HOME: $SNAP_USER_COMMON
+
+parts:
+  dogecoin-core:
+    plugin: nil
+    override-build: |
+      echo "Downloading files..."
+      wget https://github.com/dogecoin/dogecoin/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      wget https://github.com/dogecoin/gitian.sigs/archive/refs/heads/master.zip
+      unzip master.zip
+      echo "Verifying signatures..."
+      checksum=$(sha256sum dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz)
+      if ! grep -r $checksum *; then
+        echo "Signature not verified."
+        return
+      fi
+      tar -xvf dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      echo "Running tests..."
+      dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_dogecoin
+      echo "Installing Dogecoin..."
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoind
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-qt
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-cli
+      wget https://raw.githubusercontent.com/dogecoin/dogecoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
+      install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
+    build-packages:
+      - unzip
+      - wget
+    stage-packages:
+      - libfreetype6
+      - libpng16-16
+      - libx11-xcb1
+      - libx11-6
+      - libfontconfig
+  qt4conf:
+    build-packages:
+      - dpkg-dev
+    plugin: make
+    source: https://github.com/kyrofa/qt4conf.git


### PR DESCRIPTION
Hello,

I've re-implemented #1360 to make the snap build process download the latest official binaries and verify the gitian signatures instead of build from source, and it seems to work better. Similar to the other pull request, this would also let a wide variety of users install Dogecoin Core with a single command. This has dogecoind, dogecoin-qt, and dogecoin-cli all packed in under the commands `dogecoin-core.d`, `dogecoin-core.qt`, and `dogecoin-core.cli`.

I've tested it under Ubuntu 20.04 and Ubuntu 18.04 so far, and it works perfectly on both.
![image](https://user-images.githubusercontent.com/31290848/117610233-60c47880-b12f-11eb-9348-e26baac5de6c.png)
![image](https://user-images.githubusercontent.com/31290848/117610256-6ae67700-b12f-11eb-9e8b-80431ac3dd3b.png)

Finally, anyone reading this can also test it with `sudo snap install dogecoin-unofficial --channel=edge`. The commands are `dogecoin-unofficial.d`, `dogecoin-unofficial.qt`, and `dogecoin-unofficial.cli` to respectively start the daemon, the qt gui, and the cli. Please only do this in a virtual machine in case of any unforeseen bugs. 