### PR TITLE
Scripts and tools: Bootstrap tool

### DIFF
--- a/build-aux/m4/ax_cxx_check_lib.m4
+++ b/build-aux/m4/ax_cxx_check_lib.m4
@@ -1,0 +1,110 @@
+dnl @synopsis AX_CXX_CHECK_LIB(libname, functioname, action-if, action-if-not)
+dnl
+dnl The standard AC_CHECK_LIB can not test functions in namespaces.
+dnl Therefore AC_CHECK_LIB(cgicc, cgicc::Cgicc::getVersion) will always
+dnl fail. We need to decompose the functionname into a series of namespaces
+dnl where it gets declared so that it can be used for a link test.
+dnl
+dnl In the first version I did allow namespace::functionname to be a
+dnl reference to a void-argument global functionname (just wrapped in a
+dnl namespace) like its C counterparts would be - but in reality such
+dnl thing does not exist. The only global / static functions are always
+dnl made const-functions which is an attribute mangled along into the
+dnl library function export name. 
+dnl
+dnl The normal usage will ask for a test of a class-member function which
+dnl should be presented with a full function spec with arguments given in 
+dnl parentheses following the function name - if the function to test for 
+dnl does expect arguments then you should add default initial values in the 
+dnl prototype (even if they do not exist originally, these are used only 
+dnl locally to build a correct function call in the configure test script).
+dnl
+dnl In the current version if you do omit the parenthesis from the macro
+dnl argument then the macro will assume that you want to check for the
+dnl class name - which is really to check for default constructor being
+dnl exported from the given library name. 
+dnl
+dnl   EXAMPLE:
+dnl AX_CXX_CHECK_LIB(cgicc, [cgicc::HTTPCookie])
+dnl AX_CXX_CHECK_LIB(cgicc, [cgicc::Cgicc::getVersion () const],
+dnl AX_CXX_CHECK_LIB(boost_regex, [boost::RegEx::Position (int i = 0) const])
+dnl
+dnl Result:
+dnl Just as the usual AX_CXX_CHECK_LIB - defines HAVE_LIBCGICC 
+dnl and adds the libraries to the default library path (and
+dnl uses internally the normal ac_check_lib cache symbol
+dnl like ac_cv_lib_cgicc_cgicc__Cgicc)
+dnl
+dnl Footnote: The C++ language is not good at creating stable library
+dnl interfaces at the binary level - a lot of functionality is usually being 
+dnl given as inline functions plus there is hardly a chance to create opaque 
+dnl types. Therefore most C++ library tests will only do compile tests using
+dnl the header files. Doing a check_lib is however good to check the link
+dnl dependency before hitting it as an error in the build later.
+dnl
+dnl @category C++
+dnl @author Guido U. Draheim
+dnl @vesion 2006-12-18
+
+AC_DEFUN([AX_CXX_CHECK_LIB],
+[m4_ifval([$3], , [AH_CHECK_LIB([$1])])dnl
+AS_LITERAL_IF([$1],
+	      [AS_VAR_PUSHDEF([ac_Lib], [ac_cv_lib_$1_$2])],
+	      [AS_VAR_PUSHDEF([ac_Lib], [ac_cv_lib_$1''_$2])])dnl
+AC_CACHE_CHECK([for $2 in -l$1], ac_Lib,
+[ac_check_lib_save_LIBS=$LIBS
+LIBS="-l$1 $5 $LIBS"
+case "$2" 
+in *::*::*\(*)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+ namespace `echo "$2" | sed -e "s/::.*//"` 
+ { class `echo "$2" | sed -e "s/.*::\\(.*\\)::.*/\\1/" -e "s/(.*//"` 
+   { public: int `echo "$2" | sed -e "s/.*:://" -e "/(/!s/..*/&()/"`;
+   };
+ }
+],[`echo "$2" | sed  -e "s/(.*//" -e "s/\\(.*\\)::\\(.*\\)/((\\1*)(0))->\\2/g"`()])],
+	       [AS_VAR_SET(ac_Lib, yes)],
+	       [AS_VAR_SET(ac_Lib, no)])
+;; *::*::*)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+ namespace `echo "$2" | sed -e "s/::.*//"` 
+ { namespace `echo "$2" | sed -e "s/.*::\\(.*\\)::.*/\\1/"` 
+   { class `echo "$2" | sed -e "s/.*:://"` 
+      { public: `echo "$2" | sed -e "s/.*:://"` ();
+      };
+   }
+ }
+],[new $2()])],
+	       [AS_VAR_SET(ac_Lib, yes)],
+	       [AS_VAR_SET(ac_Lib, no)])
+;; *::*\(*)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+ class `echo "$2" | sed -e "s/\\(.*\\)::.*/\\1/" -e "s/(.*//"` 
+   { public: int `echo "$2" | sed -e "s/.*:://" -e "/(/!s/..*/&()/"`;
+   };
+],[`echo "$2" | sed  -e "s/(.*//" -e "s/\\(.*\\)::\\(.*\\)/((\\1*)(0))->\\2/g"`()])],
+	       [AS_VAR_SET(ac_Lib, yes)],
+	       [AS_VAR_SET(ac_Lib, no)])
+;; *::*)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([
+ namespace `echo "$2" | sed -e "s/::.*//"` 
+ { class `echo "$2" | sed -e "s/.*:://"`
+   { public: `echo "$2" | sed -e "s/.*:://"` ();
+   };
+ }
+],[new $2()])],
+	       [AS_VAR_SET(ac_Lib, yes)],
+	       [AS_VAR_SET(ac_Lib, no)])
+;; *)
+AC_LINK_IFELSE([AC_LANG_CALL([], [$2])],
+	       [AS_VAR_SET(ac_Lib, yes)],
+	       [AS_VAR_SET(ac_Lib, no)])
+;; esac
+LIBS=$ac_check_lib_save_LIBS])
+AS_IF([test AS_VAR_GET(ac_Lib) = yes],
+      [m4_default([$3], [AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_LIB$1))
+  LIBS="-l$1 $LIBS"
+])],
+      [$4])dnl
+AS_VAR_POPDEF([ac_Lib])dnl
+])# AC_CHECK_LIB

--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,13 @@ AC_CONFIG_SRCDIR([src/validation.cpp])
 AC_CONFIG_HEADERS([src/config/bitcoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
+dnl Magnet link for the bootstrap.dat file. The torrent file can be downloaded
+dnl here:
+dnl https://dogecoin.gg/bootstrap
+dnl And can be converted to a magnet link here:
+dnl https://nutbread.github.io/t2m/
 AC_DEFINE([BOOTSTRAP_MAGNET],
-  ["magnet:?xt=urn:btih:26TORNYL6UASD3HRDG7IO2CGEDV5GEMY&dn=dogecoin-bootstrap-2021-04-11&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80"],
+  ["magnet:?xt=urn:btih:DCNFN7O2NPUGBDPTYYVRSFNQDANM7BDO&dn=dogecoin-bootstrap-2021-05-09&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80"],
   [Magnet link for the bootstrap torrent file])
 
 BITCOIN_DAEMON_NAME=dogecoind

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,9 @@ AC_CONFIG_SRCDIR([src/validation.cpp])
 AC_CONFIG_HEADERS([src/config/bitcoin-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([build-aux/m4])
+AC_DEFINE([BOOTSTRAP_MAGNET],
+  ["magnet:?xt=urn:btih:26TORNYL6UASD3HRDG7IO2CGEDV5GEMY&dn=dogecoin-bootstrap-2021-04-11&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80"],
+  [Magnet link for the bootstrap torrent file])
 
 BITCOIN_DAEMON_NAME=dogecoind
 BITCOIN_GUI_NAME=dogecoin-qt
@@ -176,6 +179,12 @@ AC_ARG_ENABLE([zmq],
   [disable ZMQ notifications])],
   [use_zmq=$enableval],
   [use_zmq=yes])
+
+AC_ARG_ENABLE([libtorrent],
+  [AS_HELP_STRING([--disable-libtorrent],
+  [disable libtorrent for bootstrap])],
+  [use_libtorrent=$enableval],
+  [use_libtorrent=yes])
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
@@ -859,6 +868,36 @@ else
   fi
 fi
 
+if test "x$use_libtorrent" = "xyes"; then
+   AC_CHECK_HEADER([libtorrent/version.hpp],
+     [AC_DEFINE([ENABLE_LIBTORRENT],[1],[Define to 1 to enable libtorrent functions])],
+     [AC_MSG_WARN([libtorrent/version.hpp not found, disabling libtorrent support])
+      use_libtorrent=no
+      AC_DEFINE([ENABLE_LIBTORRENT],[0],[Define to 1 to enable libtorrent functions])])
+   AC_LANG_PUSH([C++])
+
+   dnl We must check both libtorrent and libtorrent-rasterbar
+   AX_CXX_CHECK_LIB(torrent,[libtorrent::torrent_status],
+     [LIBTORRENT_LIBS=-ltorrent],
+     [AX_CXX_CHECK_LIB(torrent-rasterbar,[libtorrent::torrent_status],
+      [LIBTORRENT_LIBS=-ltorrent-rasterbar],
+      [AC_MSG_WARN([libtorrent not found, disabling libtorrent support])
+       use_libtorrent=no
+       AC_DEFINE([ENABLE_LIBTORRENT],[0],[Define to 1 to enable libtorrent functions])])])
+else
+  AC_DEFINE_UNQUOTED([ENABLE_LIBTORRENT],[0],[Define to 1 to enable libtorrent functions])
+fi
+
+if test "x$use_libtorrent" = "xyes"; then
+  dnl Assume liblibtorrent was built for static linking
+  case $host in
+    *mingw*)
+      LIBTORRENT_CFLAGS="$LIBTORRENT_CFLAGS -DLIBTORRENT_STATIC"
+    ;;
+  esac
+fi
+
+
 save_CXXFLAGS="${CXXFLAGS}"
 CXXFLAGS="${CXXFLAGS} ${CRYPTO_CFLAGS} ${SSL_CFLAGS}"
 AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
@@ -1032,6 +1071,8 @@ fi
 
 AM_CONDITIONAL([ENABLE_ZMQ], [test "x$use_zmq" = "xyes"])
 
+AM_CONDITIONAL([ENABLE_LIBTORRENT], [test "x$use_libtorrent" = "xyes"])
+
 AC_MSG_CHECKING([whether to build test_dogecoin])
 if test x$use_tests = xyes; then
   AC_MSG_RESULT([yes])
@@ -1109,6 +1150,7 @@ AC_SUBST(SSL_LIBS)
 AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
+AC_SUBST(LIBTORRENT_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist src/test/buildenv.py])
@@ -1169,26 +1211,27 @@ esac
 
 echo 
 echo "Options used to compile and link:"
-echo "  with wallet   = $enable_wallet"
-echo "  with gui / qt = $bitcoin_enable_qt"
+echo "  with wallet     = $enable_wallet"
+echo "  with gui / qt   = $bitcoin_enable_qt"
 if test x$bitcoin_enable_qt != xno; then
-    echo "    qt version  = $bitcoin_qt_got_major_vers"
-    echo "    with qr     = $use_qr"
+    echo "    qt version    = $bitcoin_qt_got_major_vers"
+    echo "    with qr       = $use_qr"
 fi
-echo "  with zmq      = $use_zmq"
-echo "  with test     = $use_tests"
-echo "  with bench    = $use_bench"
-echo "  with upnp     = $use_upnp"
-echo "  debug enabled = $enable_debug"
-echo "  werror        = $enable_werror"
+echo "  with zmq        = $use_zmq"
+echo "  with libtorrent = $use_libtorrent"
+echo "  with test       = $use_tests"
+echo "  with bench      = $use_bench"
+echo "  with upnp       = $use_upnp"
+echo "  debug enabled   = $enable_debug"
+echo "  werror          = $enable_werror"
 echo 
-echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  target os       = $TARGET_OS"
+echo "  build os        = $BUILD_OS"
 echo
-echo "  CC            = $CC"
-echo "  CFLAGS        = $CFLAGS"
-echo "  CPPFLAGS      = $CPPFLAGS"
-echo "  CXX           = $CXX"
-echo "  CXXFLAGS      = $CXXFLAGS"
-echo "  LDFLAGS       = $LDFLAGS"
+echo "  CC              = $CC"
+echo "  CFLAGS          = $CFLAGS"
+echo "  CPPFLAGS        = $CPPFLAGS"
+echo "  CXX             = $CXX"
+echo "  CXXFLAGS        = $CXXFLAGS"
+echo "  LDFLAGS         = $LDFLAGS"
 echo 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -533,3 +533,7 @@ endif
 if ENABLE_QT_TESTS
 include Makefile.qttest.include
 endif
+
+if ENABLE_LIBTORRENT
+include Makefile.bootstrap.include
+endif

--- a/src/Makefile.bootstrap.include
+++ b/src/Makefile.bootstrap.include
@@ -1,0 +1,20 @@
+# Copyright (c) 2021-2021 Dogecoin core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+bin_PROGRAMS += bootstrap/dogecoin-bootstrap
+
+bootstrap_dogecoin_bootstrap_CPPFLAGS = $(AM_CPPFLAGS)
+bootstrap_dogecoin_bootstrap_CXXFLAGS = $(AM_CXXFLAGS)
+
+bootstrap_dogecoin_bootstrap_SOURCES = bootstrap/bootstrap.cpp
+bootstrap_dogecoin_bootstrap_LDADD = $(LIBDOGECOIN_COMMON) $(LIBDOGECOIN_UTIL) \
+  $(LIBDOGECOIN_CONSENSUS) $(LIBDOGECOIN_CRYPTO) $(LIBTORRENT_LIBS) \
+  $(BOOST_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS)
+bootstrap_dogecoin_bootstrap_LDFLAGS = $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+bootstrap_dogecoin_bootstrap_LIBTOOLFLAGS = --tag CXX
+
+dogecoin_bootstrap_clean: FORCE
+	rm -f $(CLEAN_QT) $(bootstrap_dogecoin_bootstrap_OBJECTS) bootstrap/dogecoin-bootstrap$(EXEEXT)
+
+dogecoin_bootstrap : bootstrap/dogecoin-bootstrap$(EXEEXT)

--- a/src/bootstrap/bootstrap.cpp
+++ b/src/bootstrap/bootstrap.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2021-2021 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif
+
+#include "util.h"
+
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <fstream>
+
+#include <libtorrent/session.hpp>
+#include <libtorrent/add_torrent_params.hpp>
+#include <libtorrent/torrent_handle.hpp>
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/alert_types.hpp>
+#include <libtorrent/bencode.hpp>
+#include <libtorrent/torrent_status.hpp>
+#include <libtorrent/read_resume_data.hpp>
+#include <libtorrent/write_resume_data.hpp>
+#include <libtorrent/error_code.hpp>
+#include <libtorrent/magnet_uri.hpp>
+
+namespace {
+
+using clk = std::chrono::steady_clock;
+
+// return the name of a torrent status enum
+char const* state(lt::torrent_status::state_t s)
+{
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+  switch(s) {
+    case lt::torrent_status::checking_files: return "checking";
+    case lt::torrent_status::downloading_metadata: return "dl metadata";
+    case lt::torrent_status::downloading: return "downloading";
+    case lt::torrent_status::finished: return "finished";
+    case lt::torrent_status::seeding: return "seeding";
+    case lt::torrent_status::checking_resume_data: return "checking resume";
+    default: return "<>";
+  }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+}
+
+bool ends_with(std::string const &str, std::string const &suffix) {
+    if (str.length() >= suffix.length()) {
+        return (0 == str.compare(str.length() - suffix.length(),
+                                 suffix.length(),
+                                 suffix));
+    } else {
+        return false;
+    }
+}
+
+} // anonymous namespace
+
+int main(int argc, char const* argv[]) try
+{
+  lt::settings_pack pack;
+  pack.set_int(lt::settings_pack::alert_mask
+    , lt::alert_category::error
+    | lt::alert_category::storage
+    | lt::alert_category::status);
+
+  lt::session ses(pack);
+  clk::time_point last_save_resume = clk::now();
+
+  // load resume data from disk and pass it in as we add the magnet link
+  std::string resume_file = (
+      GetDefaultDataDir() / ".bootstrap_resume_file").string();
+  std::ifstream ifs(resume_file, std::ios_base::binary);
+  ifs.unsetf(std::ios_base::skipws);
+  std::vector<char> buf{std::istream_iterator<char>(ifs)
+    , std::istream_iterator<char>()};
+
+  lt::add_torrent_params magnet = lt::parse_magnet_uri(BOOTSTRAP_MAGNET);
+  if (buf.size()) {
+    lt::add_torrent_params atp = lt::read_resume_data(buf);
+    if (atp.info_hash == magnet.info_hash)
+      magnet = std::move(atp);
+  }
+  magnet.save_path = GetDefaultDataDir().string();
+  ses.async_add_torrent(std::move(magnet));
+
+  // this is the handle we'll set once we get the notification of it being
+  // added
+  lt::torrent_handle h;
+
+  // set when we're exiting
+  bool done = false;
+  bool renamed = false;
+  for (;;) {
+    std::vector<lt::alert*> alerts;
+    ses.pop_alerts(&alerts);
+
+    for (lt::alert const* a : alerts) {
+      if (auto at = lt::alert_cast<lt::add_torrent_alert>(a)) {
+        h = at->handle;
+      }
+      // if we receive the finished alert or an error, we're done
+      if (lt::alert_cast<lt::torrent_finished_alert>(a)) {
+        h.save_resume_data(lt::torrent_handle::save_info_dict);
+        done = true;
+      }
+      if (lt::alert_cast<lt::torrent_error_alert>(a)) {
+        std::cout << a->message() << std::endl;
+        done = true;
+        h.save_resume_data(lt::torrent_handle::save_info_dict);
+      }
+
+      // when we already have the metadata, check the files
+      if (!renamed && h.is_valid() && h.has_metadata()) {
+        const int n_files = h.get_torrent_info().files().num_files();
+        for (int i = 0; i < n_files; i++) {
+          std::string path = h.get_torrent_info().files().file_path(i);
+          if (ends_with(path, "/bootstrap.dat")) {
+            h.rename_file(i, "bootstrap.dat");
+          }
+          renamed = true;
+        }
+      }
+
+      // when resume data is ready, save it
+      if (auto rd = lt::alert_cast<lt::save_resume_data_alert>(a)) {
+        std::ofstream of(resume_file, std::ios_base::binary);
+        of.unsetf(std::ios_base::skipws);
+        auto const b = write_resume_data_buf(rd->params);
+        of.write(b.data(), int(b.size()));
+        if (done) goto done;
+      }
+
+      if (lt::alert_cast<lt::save_resume_data_failed_alert>(a)) {
+        if (done) goto done;
+      }
+
+      if (auto st = lt::alert_cast<lt::state_update_alert>(a)) {
+        if (st->status.empty()) continue;
+
+        // we only have a single torrent, so we know which one
+        // the status is for
+        lt::torrent_status const& s = st->status[0];
+        std::cout << '\r' << state(s.state) << ' '
+          << (s.download_payload_rate / 1000) << " kB/s "
+          << (s.total_done / 1000) << " / "
+          << (s.total_wanted / 1000) << " kB ("
+          << (s.progress_ppm / 10000) << "%) downloaded ("
+          << s.num_peers << " peers)\x1b[K";
+        std::cout.flush();
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // ask the session to post a state_update_alert, to update our
+    // state output for the torrent
+    ses.post_torrent_updates();
+
+    // save resume data once every 30 seconds
+    if (clk::now() - last_save_resume > std::chrono::seconds(30)) {
+      h.save_resume_data(lt::torrent_handle::save_info_dict);
+      last_save_resume = clk::now();
+    }
+  }
+
+done:
+  std::cout << "\ndone, shutting down" << std::endl;
+}
+catch (std::exception& e)
+{
+  std::cerr << "Error: " << e.what() << std::endl;
+}


### PR DESCRIPTION
A tiny tool which uses libtorrent to download the bootstrap.dat file (related with #1673), for the time being straight to the `GetDefaultDataDir()` folder.

The magnet link can be modified in configure.ac:16

```
AC_DEFINE([BOOTSTRAP_MAGNET],
  ["magnet:?xt=urn:btih:26TORNYL6UASD3HRDG7IO2CGEDV5GEMY&dn=dogecoin-bootstrap-2021-04-11&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80"],
  [Magnet link for the bootstrap torrent file])
```

That is the magnet of the torrent file provided in the discord channel (up to 11-04-2021).

Some changes would be probably welcome to the bootstrap tool:

* Choose the data dir
* Create the data dir if it does not exists (maybe libtorrent is doing that automagically, I did not tested it)
* Integration in the QT client
* dogecoin core must discard the already processed bootstrap.dat (~41GB wasted), instead of renaming it as bootstrap.dat.old

But first I want to submit this proof of concept, so we can discuss if you really want to get something like this inside dogecoin.