### PR TITLE
Fixing indonesian (id_ID) translation

### DIFF
--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -15,11 +15,11 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Salin alamat yang dipilih ke clipboard</translation>
+        <translation>Salin alamat terpilih ke papan klip (clipboard)</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation>&amp;Menyalin</translation>
+        <translation>&amp;Salin</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
@@ -27,11 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>Hapus alamat yang sementara dipilih dari daftar</translation>
+        <translation>Hapus alamat terpilih dari daftar</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>Ekspor data dalam tab sekarang ke sebuah berkas</translation>
+        <translation>Ekspor data dalam tab saat ini ke sebuah berkas</translation>
     </message>
     <message>
         <source>&amp;Export</source>
@@ -43,11 +43,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation>Pilih alamat untuk mengirim koin</translation>
+        <translation>Pilih alamat untuk mengirim koin ke</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation>Piih alamat untuk menerima koin</translation>
+        <translation>Pilih alamat untuk menerima koin dengan</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -58,16 +58,16 @@
         <translation>Alamat-alamat pengirim</translation>
     </message>
     <message>
-        <source>Receiving addresses</source>
+        <source>Much Receiving addresses</source>
         <translation>Alamat-alamat penerima</translation>
     </message>
     <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Ini adalah alamat- alamat Bitcoin Anda untuk mengirimkan pembayaran. Selalu periksa jumlah dan alamat penerima sebelum mengirimkan koin.</translation>
+        <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation>Berikut merupakan alamat - alamat Dogecoinmu yang berguna untuk mengirimkan pembayaran. Selalu periksa jumlah dan alamat penerima sebelum mengirimkan koin.</translation>
     </message>
     <message>
-        <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Ini adalah alamat- alamat Bitcoin Anda untuk menerima pembayaran. Dianjurkan untuk menggunakan alamat penerima yang baru setiap melakukan transaksi.</translation>
+        <source>These are your Dogecoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
+        <translation>Berikut merupakan alamat - alamat Dogecoinmu yang berguna untuk menerima pembayaran. Dianjurkan untuk menggunakan alamat penerima yang baru setiap kali melakukan transaksi.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -75,7 +75,7 @@
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation>Salin&amp; Label</translation>
+        <translation>Salin &amp; Label</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
@@ -87,13 +87,17 @@
     </message>
     <message>
         <source>Comma separated file (*.csv)</source>
-        <translation>File yang berformat(*.csv)</translation>
+        <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation>Mengekspor Gagal</translation>
+        <translation>Gagal Mengekspor</translation>
     </message>
-    </context>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <translation>Terjadi kesalahan saat berusaha untuk menyimpan alamat ke dalam daftar %1. Mohon ulangi kembali.</translation>
+    </message>
+</context>
 <context>
     <name>AddressTableModel</name>
     <message>
@@ -113,23 +117,23 @@
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>Dialog Kata kunci</translation>
+        <translation>Dialog Kata sandi</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>Masukkan kata kunci</translation>
+        <translation>Masukkan kata sandi</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>Kata kunci baru</translation>
+        <translation>Kata sandi baru</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>Ulangi kata kunci baru</translation>
+        <translation>Ulangi kata sandi baru</translation>
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Masukan kata sandi baru ke dompet.&lt;br/&gt;Mohon gunakan kata sandi &lt;b&gt;sepuluh karakter acak atau lebih&lt;/b&gt;, atau &lt;b&gt; delapan atau lebih beberapa kata &lt;/​​b&gt;.</translation>
+        <translation>Masukan kata sandi baru untuk dompet ini.&lt;br/&gt;Mohon gunakan kata sandi &lt;b&gt;sepuluh karakter acak atau lebih&lt;/b&gt;, atau &lt;b&gt; delapan atau lebih beberapa kata &lt;/​​b&gt;.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
@@ -137,7 +141,7 @@
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation>Operasi ini memerlukan kata sandi dompet Anda untuk membuka dompet.</translation>
+        <translation>Operasi ini memerlukan kata sandi dompetmu untuk membuka dompet.</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
@@ -145,7 +149,7 @@
     </message>
     <message>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation>Operasi ini memerlukan kata sandi dompet Anda untuk mendekripsikan dompet.</translation>
+        <translation>Operasi ini memerlukan kata sandi dompetmu untuk mendekripsikan dompet.</translation>
     </message>
     <message>
         <source>Decrypt wallet</source>
@@ -164,24 +168,24 @@
         <translation>Konfirmasi pengenkripsian dompet</translation>
     </message>
     <message>
-        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>Peringatan: Jika Anda enkripsi dompet Anda dan lupa kata sandi anda, Anda akan &lt;b&gt;KEHILANGAN SEMUA BITCOIN ANDA&lt;/b&gt;!</translation>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR DOGECOINS&lt;/b&gt;!</source>
+        <translation>Peringatan: Jika kamu mengenkripsi dompet ini dan melupakan kata sandi anda, Kamu akan &lt;b&gt;KEHILANGAN SEMUA DOGECOIN ANDA&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation>Apakah Anda yakin ingin enkripsi dompet Anda?</translation>
+        <translation>Apakah kamu yakin ingin mengenkripsi dompet ini?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
         <translation>Dompet terenkripsi</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>%1 sekarang akan ditutup untuk menyelesaikan proses enkripsi. Ingatlah bahwa mengenkripsi dompet Anda tidak dapat sepenuhnya melindungi komputer Anda dari pencurian malware yang menginfeksi komputer Anda.</translation>
+        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your dogecoins from being stolen by malware infecting your computer.</source>
+        <translation>%1 sekarang akan tertutup untuk menyelesaikan proses enkripsi. Ingatlah bahwa mengenkripsi dompetmu tidak dapat sepenuhnya melindungi dari pencurian dogecoin oleh malware yang menginfeksi komputer Anda.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>PENTING: Backup sebelumnya yang Anda buat dari file dompet Anda harus diganti dengan file dompet terenkripsi yang baru dibuat. Demi keamanan, backup file dompet sebelumnya yang tidak dienkripsi sebelumnya akan menjadi tidak berguna begitu Anda mulai menggunakan dompet terenkripsi yang baru.</translation>
+        <translation>PENTING: Cadangan data yang pernah kamu buat harus diganti dengan berkas dompet terenkripsi yang baru dibuat. Demi keamanan, cadangan berkas dompet sebelumnya yang tidak dienkripsi itu akan menjadi tidak berguna begitu kamu mulai menggunakan dompet terenkripsi yang baru.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -189,7 +193,7 @@
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation>Pengenkripsian dompet gagal karena kesalahan internal. Dompet Anda tidak dienkripsi.</translation>
+        <translation>Pengenkripsian dompet gagal karena kesalahan internal. Dompetmu tidak dienkripsi.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -197,15 +201,15 @@
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation>Membuka dompet gagal</translation>
+        <translation>Gagal membuka kunci dompet</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation>Kata sandi yang dimasukkan untuk dekripsi dompet salah.</translation>
+        <translation>Kata sandi yang dimasukkan untuk pembukaan enkripsi dompet salah.</translation>
     </message>
     <message>
         <source>Wallet decryption failed</source>
-        <translation>Dekripsi dompet gagal</translation>
+        <translation>Pembukaan enkripsi dompet gagal</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
@@ -224,14 +228,14 @@
     </message>
     <message>
         <source>Banned Until</source>
-        <translation>Di banned sampai</translation>
+        <translation>Diblokir Sampai</translation>
     </message>
 </context>
 <context>
     <name>DogecoinGUI</name>
     <message>
-        <source>Sign &amp;message...</source>
-        <translation>Pesan &amp;penanda...</translation>
+        <source>Wallet</source>
+        <translation>Dompet</translation>
     </message>
     <message>
         <source>Synchronizing with network...</source>
@@ -239,15 +243,27 @@
     </message>
     <message>
         <source>&amp;Wow</source>
-        <translation>&amp;Kilasan</translation>
-    </message>
-    <message>
-        <source>Node</source>
-        <translation>Node</translation>
+        <translation>&amp;Wow</translation>
     </message>
     <message>
         <source>Show general overview of wallet</source>
         <translation>Tampilkan gambaran umum dompet Anda</translation>
+    </message>
+    <message>
+        <source>&amp;Such Send</source>
+        <translation>&amp;Kirim Aja</translation>
+    </message>
+    <message>
+        <source>Send coins to a Dogecoin address</source>
+        <translation>Kirim koin ke alamat Dogecoin</translation>
+    </message>
+    <message>
+        <source>&amp;Much Receive</source>
+        <translation>&amp;Terima Banget</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and dogecoin: URIs)</source>
+        <translation>Minta pembayaran (bikin kode QR dan dogecoin: URI)</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -255,7 +271,7 @@
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation>Lihat riwayat transaksi</translation>
+        <translation>Melihat riwayat transaksi</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -279,7 +295,7 @@
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation>Tampilkan informasi mengenai Qt</translation>
+        <translation>Tampilkan informasi tentang Qt</translation>
     </message>
     <message>
         <source>&amp;Options...</source>
@@ -287,91 +303,7 @@
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation>Pengubahan opsi konfigurasi untuk %1</translation>
-    </message>
-    <message>
-        <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;Enkripsi Dompet...</translation>
-    </message>
-    <message>
-        <source>&amp;Backup Wallet...</source>
-        <translation>&amp;Cadangkan Dompet...</translation>
-    </message>
-    <message>
-        <source>&amp;Change Passphrase...</source>
-        <translation>&amp;Ubah Kata Kunci...</translation>
-    </message>
-    <message>
-        <source>&amp;Such sending addresses...</source>
-        <translation>&amp;Alamat-alamat untuk mengirim...</translation>
-    </message>
-    <message>
-        <source>&amp;Much receiving addresses...</source>
-        <translation>&amp;Alamat-alamat untuk menerima...</translation>
-    </message>
-    <message>
-        <source>Open &amp;URI...</source>
-        <translation>Buka &amp;URI</translation>
-    </message>
-    <message>
-        <source>Click to disable network activity.</source>
-        <translation>Klik untuk menonaktifkan aktivitas jaringan.</translation>
-    </message>
-    <message>
-        <source>Network activity disabled.</source>
-        <translation>Aktivitas jaringan dinonaktifkan.</translation>
-    </message>
-    <message>
-        <source>Click to enable network activity again.</source>
-        <translation>Klik untuk mengaktifkan aktivitas jaringan lagi.</translation>
-    </message>
-    <message>
-        <source>Syncing Headers (%1%)...</source>
-        <translation>Menyinkronkan Header (%1%) ...</translation>
-    </message>
-    <message>
-        <source>Reindexing blocks on disk...</source>
-        <translation>Mengindex ulang blok di dalam disk...</translation>
-    </message>
-    <message>
-        <source>Send coins to a Dogecoin address</source>
-        <translation>Kirim koin ke alamat Dogecoin</translation>
-    </message>
-    <message>
-        <source>Backup wallet to another location</source>
-        <translation>Cadangkan dompet ke lokasi lain</translation>
-    </message>
-    <message>
-        <source>Change the passphrase used for wallet encryption</source>
-        <translation>Ubah kata kunci yang digunakan untuk enkripsi dompet</translation>
-    </message>
-    <message>
-        <source>&amp;Debug window</source>
-        <translation>&amp;Jendela Debug</translation>
-    </message>
-    <message>
-        <source>Open debugging and diagnostic console</source>
-        <translation>Buka konsol debug dan diagnosa</translation>
-    </message>
-    <message>
-        <source>&amp;Verify message...</source>
-        <translation>&amp;Verifikasi pesan...</translation>
-    </message>
-    <message>
-        <source>Dogecoin</source>
-        <translation>Dogecoin</translation>
-    </message>
-    <message>
-        <source>Wallet</source>
-        <translation>Dompet</translation>
-    </message>
-    <message>
-        <source>&amp;Such Send</source>
-        <translation>&amp;Kirim</translation>
-    </message>
-    <message>
-        <source>&amp;Much Receive</source>
-        <translation>&amp;Menerima</translation>
+        <translation>Pengubahan konfigurasi untuk %1</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
@@ -382,16 +314,88 @@
         <translation>Tampilkan atau sembunyikan jendela utama</translation>
     </message>
     <message>
+        <source>&amp;Encrypt Wallet...</source>
+        <translation>&amp;Enkripsi Dompet...</translation>
+    </message>
+    <message>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Enkripsi private key yang dimiliki dompet Anda</translation>
     </message>
     <message>
+        <source>&amp;Backup Wallet...</source>
+        <translation>&amp;Cadangkan Dompet...</translation>
+    </message>
+    <message>
+        <source>Click to disable network activity.</source>
+        <translation>Klik untuk menonaktifkan aktivitas jaringan.</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase...</source>
+        <translation>&amp;Ubah Kata Sandi...</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>Ubah kata kunci yang digunakan untuk enkripsi dompet</translation>
+    </message>
+    <message>
+        <source>Sign &amp;message...</source>
+        <translation>Tandatangani &amp;pesan...</translation>
+    </message>
+    <message>
         <source>Sign messages with your Dogecoin addresses to prove you own them</source>
-        <translation>Tanda tangani sebuah pesan menggunakan alamat Dogecoin Anda untuk membuktikan bahwa Anda adalah pemilik alamat tersebut</translation>
+        <translation>Tanda tangani sebuah pesan menggunakan alamat Dogecoinmu untuk membuktikan bahwa kamu adalah benar-benar pemilik alamat tersebut</translation>
+    </message>
+    <message>
+        <source>Send coins to a Dogecoin address</source>
+        <translation>Kirim koin ke alamat Dogecoin</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Dogecoin addresses</source>
-        <translation>Verifikasi pesan untuk memastikan bahwa pesan tersebut ditanda tangani oleh suatu alamat Dogecoin tertentu</translation>
+        <translation>Verifikasi pesan untuk memastikan bahwa pesan tersebut ditandatangani oleh suatu alamat Dogecoin tertentu</translation>
+    </message>
+    <message>
+        <source>&amp;Print paper wallePrint paper walletsts</source>
+        <translation>&amp;Cetak dompet kertas</translation>
+    </message>
+    <message>
+        <source>Print paper wallets</source>
+        <translation>Cetak dompet kertas</translation>
+    </message>
+    <message>
+        <source>&amp;Debug window</source>
+        <translation>&amp;Jendela Debug</translation>
+    </message>
+    <message>
+        <source>Open debugging and diagnostic console</source>
+        <translation>Buka konsol debug dan diagnosa</translation>
+    </message>
+    <message>
+        <source>Dogecoin</source>
+        <translation>Dogecoin</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation>Dompet</translation>
+    </message>
+    <message>
+        <source>&amp;Much receiving addresses...</source>
+        <translation>&amp;Alamat-alamat untuk menerima...</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation>Tampilkan daftar alamat dan label yang diterima</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI...</source>
+        <translation>Buka &amp;URI</translation>
+    </message>
+    <message>
+        <source>Open a dogecoin: URI or payment request</source>
+        <translation>Buka URI dogecoin: atau permintaan pembayaran</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation>&amp;pilihan Command-line</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -410,24 +414,28 @@
         <translation>Baris tab</translation>
     </message>
     <message>
-        <source>Request payments (generates QR codes and dogecoin: URIs)</source>
-        <translation>Permintaan pembayaran (membuat kode QR dan dogecoin: URIs)</translation>
+        <source>%1 client</source>
+        <translation>%1 klien</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Dogecoin network</source>
+        <translation><numerusform>%n koneksi aktif ke jaringan Dogecoin</numerusform></translation>
     </message>
     <message>
-        <source>Show the list of used sending addresses and labels</source>
-        <translation>Tampilkan daftar alamat dan label yang terkirim</translation>
+        <source>Click to disable network activity.</source>
+        <translation>Klik untuk menonaktifkan aktivitas jaringan.</translation>
     </message>
     <message>
-        <source>Show the list of used receiving addresses and labels</source>
-        <translation>Tampilkan daftar alamat dan label yang diterima</translation>
+        <source>Network activity disabled.</source>
+        <translation>Aktivitas jaringan dinonaktifkan.</translation>
     </message>
     <message>
-        <source>Open a dogecoin: URI or payment request</source>
-        <translation>Buka URI dogecoin: atau permintaan pembayaran</translation>
+        <source>Click to enable network activity again.</source>
+        <translation>Klik untuk mengaktifkan aktivitas jaringan lagi.</translation>
     </message>
     <message>
-        <source>&amp;Command-line options</source>
-        <translation>&amp;pilihan Command-line</translation>
+        <source>Syncing Headers (%1%)...</source>
+        <translation>Menyinkronkan Header (%1%) ...</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Dogecoin network</source>
@@ -441,13 +449,29 @@
         <source>Processing blocks on disk...</source>
         <translation>Memproses blok pada disk ...</translation>
     </message>
+    <message>
+        <source>Reindexing blocks on disk...</source>
+        <translation>Mengindeks ulang blok di dalam disk...</translation>
+    </message>
+    <message>
+        <source>Connecting to peers...</source>
+        <translation>Menghubungkan ke rekan-rekan (peer)...</translation>
+    </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
         <translation><numerusform>%n blok dari riwayat transaksi diproses.</numerusform></translation>
     </message>
     <message>
+        <source>Up to date</source>
+        <translation>Terbaru</translation>
+    </message>
+    <message>
         <source>%1 behind</source>
         <translation>kurang %1</translation>
+    </message>
+    <message>
+        <source>Catching up...</source>
+        <translation>Menangkap...</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -459,7 +483,11 @@
     </message>
     <message>
         <source>Error</source>
-        <translation>Terjadi sebuah kesalahan</translation>
+        <translation>Galat</translation>
+    </message>
+    <message>
+        <source>Dogecoin</source>
+        <translation>Dogecoin</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -474,8 +502,8 @@
         <translation>Terbaru</translation>
     </message>
     <message>
-        <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation>Tampilkan %1 pesan bantuan untuk mendapatkan daftar opsi baris perintah Bitcoin yang memungkinkan</translation>
+        <source>Show the %1 help message to get a list with possible Dogecoin command-line options</source>
+        <translation>Tampilkan %1 pesan bantuan untuk mendapatkan daftar opsi baris perintah Dogecoin yang memungkinkan</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -483,11 +511,11 @@
     </message>
     <message>
         <source>Connecting to peers...</source>
-        <translation>Menghubungkan ke peer...</translation>
+        <translation>Menghubungkan ke rekan-rekan (peer)...</translation>
     </message>
     <message>
         <source>Catching up...</source>
-        <translation>Menyusul...</translation>
+        <translation>Menangkap...</translation>
     </message>
     <message>
         <source>Date: %1
@@ -528,14 +556,26 @@
         <translation>Transaksi diterima</translation>
     </message>
     <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation>Penciptaan kunci HD &lt;b&gt;diaktifkan&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation>Penciptaan kunci HD &lt;b&gt;dinonaktifkan&lt;/b&gt;</translation>
+    </message>
+    <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>Dompet saat ini &lt;b&gt;terenkripsi&lt;/b&gt; dan &lt;b&gt;terbuka&lt;/b&gt;</translation>
+        <translation>Dompet &lt;b&gt;terenkripsi&lt;/b&gt; dan saat ini &lt;b&gt;tidak terkunci&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>Dompet saat ini &lt;b&gt;terenkripsi&lt;/b&gt; dan &lt;b&gt;terkunci&lt;/b&gt;</translation>
+        <translation>Dompet &lt;b&gt;terenkripsi&lt;/b&gt; dan saat ini &lt;b&gt;terkunci&lt;/b&gt;</translation>
     </message>
-    </context>
+    <message>
+        <source>A fatal error occurred. Dogecoin can no longer continue safely and will quit.</source>
+        <translation>Terjadi kesalahan fatal. Dogecoin tidak bisa berlanjut dan akan berhenti.</translation>
+    </message>
+</context>
 <context>
     <name>CoinControlDialog</name>
     <message>
@@ -572,11 +612,11 @@
     </message>
     <message>
         <source>(un)select all</source>
-        <translation>(Tidak)memilih semua</translation>
+        <translation>(Batal)pilih semua</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation>Tree mode</translation>
+        <translation>Mode pohon</translation>
     </message>
     <message>
         <source>List mode</source>
@@ -615,14 +655,78 @@
         <translation>Salin label</translation>
     </message>
     <message>
+        <source>Copy amount</source>
+        <translation>Salin Jumlah</translation>
+    </message>
+    <message>
+        <source>Copy transaction ID</source>
+        <translation>Salin ID transaksi</translation>
+    </message>
+    <message>
+        <source>Lock unspent</source>
+        <translation>Kunci jumlah yang belum terpakai</translation>
+    </message>
+    <message>
+        <source>Unlock unspent</source>
+        <translation>Buka kunci jumlah yang belum terpakai</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation>Salin Kuantitas</translation>
+    </message>
+    <message>
         <source>Copy fee</source>
         <translation>Salin biaya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation>Salin dengan biaya</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation>Salin bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation>Salin dust</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation>Salin kembalian</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation>(%1 terkunci)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation>ya</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation>tidak</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation>Label ini berubah merah jika penerima mendapat jumlah yang lebih sedikit dari batas dust saat ini.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <translation>Nilai bisa bervariasi +/- %1 satoshi per masukan.</translation>
     </message>
     <message>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
-    </context>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation>ubah dari %1 (%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation>(ubah)</translation>
+    </message>
+</context>
 <context>
     <name>EditAddressDialog</name>
     <message>
@@ -645,12 +749,44 @@
         <source>&amp;Address</source>
         <translation>&amp;Alamat</translation>
     </message>
-    </context>
+    <message>
+        <source>New receiving address</source>
+        <translation>Alamat penerimaan baru</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation>Alamat pengiriman baru</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation>Ubah alamat penerimaan</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation>Ubah alamat pengiriman</translation>
+    </message>
+    <message>
+        <source>The entered address &quot;%1&quot; is not a valid Dogecoin address.</source>
+        <translation>Kamu memasukan alamat &quot;%1&quot; yang bukan alamat Dogecoin yang valid.</translation>
+    </message>
+    <message>
+        <source>The entered address &quot;%1&quot; is already in the address book.</source>
+        <translation>Alamat yang kamu masukan &quot;%1&quot; sudah ada di daftar alamat.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation>Tidak bisa membuka kunci dompet.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation>Pembuatan kunci baru gagal.</translation>
+    </message>
+</context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>Sebuah data direktori baru telah dibuat.</translation>
+        <translation>Sebuah data direktori baru akan dibuat.</translation>
     </message>
     <message>
         <source>name</source>
@@ -658,11 +794,11 @@
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>Direktori masih ada. Tambahlah %1 apabila Anda ingin membuat direktori baru disini.</translation>
+        <translation>Direktori sudah ada. Tambahlah %1 apabila kamu menginginkan membuat direktori baru disini.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation>Sudah ada path, dan itu bukan direktori.</translation>
+        <translation>Jalur (path) sudah ada, dan itu bukan direktori.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
@@ -678,6 +814,10 @@
     <message>
         <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>Tentang %1</translation>
     </message>
     <message>
         <source>Command-line options</source>
@@ -705,22 +845,38 @@
     </message>
     <message>
         <source>Start minimized</source>
-        <translation>Start minimized</translation>
+        <translation>Meminimalkan Saat Mulai</translation>
     </message>
     <message>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>Pilih sertifikat root SSL untuk permintaan pembayaran {default: -system-)</translation>
+        <translation>Pilih sertifikat root SSL untuk permintaan pembayaran (default: -system-)</translation>
     </message>
     <message>
         <source>Show splash screen on startup (default: %u)</source>
         <translation>Tampilkan layar kilat saat memulai (default: %u)</translation>
     </message>
-    </context>
+    <message>
+        <source>Reset all settings changed in the GUI</source>
+        <translation>Atur ulang semua pengaturan yang berubah di tampilan GUI</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
         <source>Welcome</source>
         <translation>Selamat Datang</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation>Selamat datang di %1.</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation>Berhubung ini pertama kali program dijalankan, kamu bisa memilih dimana %1 akan menyimpan datanya.</translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Dogecoin block chain. At least %2GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
+        <translation>%1 akan mengunduh dan menyimpan salinan dari rantai blok Dogecoin. Sedikitnya %2GB akan disimpan pada direktori ini, dan akan bertambah secara berkala. Dompet juga akan disimpan dalam direktori ini.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -740,7 +896,7 @@
     </message>
     <message numerus="yes">
         <source>%n GB of free space available</source>
-        <translation><numerusform>%n GB ruang kosong tersedia.</numerusform></translation>
+        <translation><numerusform>Tersedia %n GB ruang kosong</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
@@ -754,10 +910,50 @@
         <translation>Formulir</translation>
     </message>
     <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet&apos;s balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the dogecoin network, as detailed below.</source>
+        <translation>Transaksi terakhir mungkin belum diperlihatkan, karena mungkin saja saldo dompet kamu salah. Informasi ini akan menjadi benar setelah dompetmu tersinkronisasi dengan jaringa dogecoin, seperti tertampil dibawah.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend dogecoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation>Mencoba untuk menggunakan koin-koin yang masuk kedalam kategori &quot;transaksi yang belum ditampilkan&quot; tidak akan diterima oleh jaringan.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation>Jumlah dari blok yang tersisa</translation>
+    </message>
+    <message>
+        <source>Unknown...</source>
+        <translation>Tidak diketahui...</translation>
+    </message>
+    <message>
         <source>Last block time</source>
         <translation>Waktu blok terakhir</translation>
     </message>
-    </context>
+    <message>
+        <source>Progress</source>
+        <translation>Kemajuan</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation>Penambahan kemajuan tiap jam</translation>
+    </message>
+    <message>
+        <source>calculating...</source>
+        <translation>menghitung...</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation>Perkiraan waktu tersisa sampai tersinkronisasi</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>Sembunyi</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1)...</source>
+        <translation>Tidak diketahui. Mensinkronisasi Headers (%1)...</translation>
+    </message>
+</context>
 <context>
     <name>OpenURIDialog</name>
     <message>
@@ -774,9 +970,13 @@
     </message>
     <message>
         <source>Select payment request file</source>
-        <translation>Pilih data permintaan pembayaran</translation>
+        <translation>Pilih berkas permintaan pembayaran</translation>
     </message>
-    </context>
+    <message>
+        <source>Select payment request file to open</source>
+        <translation>Pilih berkas permintaan pembayaran untuk membuka</translation>
+    </message>
+</context>
 <context>
     <name>OptionsDialog</name>
     <message>
@@ -788,6 +988,14 @@
         <translation>&amp;Utama</translation>
     </message>
     <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation>Otomatis memulai %1 setelah dicatat dalam sistem.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation>&amp;Memulai %1 saat masuk ke dalam sistem</translation>
+    </message>
+    <message>
         <source>Size of &amp;database cache</source>
         <translation>Ukuran cache &amp;database</translation>
     </message>
@@ -797,7 +1005,7 @@
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation>Jumlah script &amp;verification threads</translation>
+        <translation>Banyaknya script &amp;jumlah verifikasi</translation>
     </message>
     <message>
         <source>Accept connections from outside</source>
@@ -809,15 +1017,15 @@
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation>Alamat IP proxy (cth. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation>Alamat IP dari proxy (cth. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation>Minimalisasi aplikasi ketika jendela ditutup. Ketika pilihan ini dipilih, aplikasi akan menutup seluruhnya jika anda memilih Keluar di menu yang tersedia.</translation>
+        <translation>Minimalisasi aplikasi ketika jendela ditutup. Ketika pilihan ini dipilih, aplikasi akan menutup seluruhnya jika kamu memilih Keluar di menu yang tersedia.</translation>
     </message>
     <message>
         <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation>URL pihak ketika (misalnya sebuah block explorer) yang mumcul dalam tab transaksi sebagai konteks menu. %s dalam URL diganti dengan kode transaksi. URL dipisahkan dengan tanda vertikal |.</translation>
+        <translation>URL pihak ketiga (misalnya sebuah block explorer) yang muncul dalam tab transaksi sebagai konteks menu. %s dalam URL diganti dengan kode transaksi. URL dipisahkan dengan tanda vertikal |.</translation>
     </message>
     <message>
         <source>Third party transaction URLs</source>
@@ -841,7 +1049,7 @@
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation>(0 = auto, &lt;0 = leave that many cores free)</translation>
+        <translation>(0 = otomatis, &lt;0 = leave that many cores free)</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
@@ -857,7 +1065,7 @@
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation>Jika Anda menonaktifkan perubahan saldo untuk transaksi yang belum dikonfirmasi, perubahan dari transaksi tidak dapat dilakukan sampai transaksi memiliki setidaknya satu konfirmasi. Hal ini juga mempengaruhi bagaimana saldo Anda dihitung.</translation>
+        <translation>Jika kamu menonaktifkan pengeluaran dari transaksi yang belum dikonfirmasi, perubahan dari transaksi tidak dapat dilakukan sampai transaksi memiliki setidaknya satu konfirmasi. Hal ini juga mempengaruhi bagaimana saldomu dihitung.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -865,7 +1073,7 @@
     </message>
     <message>
         <source>Automatically open the Dogecoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Otomatis membuka port client Dogecoin di router. Hanya berjalan apabila router anda mendukung UPnP dan di-enable.</translation>
+        <translation>Otomatis membuka port klien Dogecoin di router. Hanya berjalan apabila router kami mendukung UPnP dan sudah diaktifkan.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -873,7 +1081,11 @@
     </message>
     <message>
         <source>Connect to the Dogecoin network through a SOCKS5 proxy.</source>
-        <translation>Hubungkan ke jaringan Dogecoin melalui SOCKS5 proxy.</translation>
+        <translation>Hubungkan ke jaringan Dogecoin melalui proxy SOCKS5.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation>&amp;Hubungkan melalui proxy SOCKS5 (default proxy):</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
@@ -888,6 +1100,14 @@
         <translation>Port proxy (cth. 9050)</translation>
     </message>
     <message>
+        <source>Used for reaching peers via:</source>
+        <translation>Digunakan untuk menggapai para rekan (peers) melalui:</translation>
+    </message>
+    <message>
+        <source>Shows, if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation>Tampilkan, jika proxy SOCKS5 digunakan untuk menggapai para rekan (peers) melalui jenis jaringan ini.</translation>
+    </message>
+    <message>
         <source>IPv4</source>
         <translation>IPv4</translation>
     </message>
@@ -900,20 +1120,36 @@
         <translation>Tor</translation>
     </message>
     <message>
+        <source>Connect to the Dogecoin network through a separate SOCKS5 proxy for Tor hidden services.</source>
+        <translation>Terhubung ke jaringan Dogecoin melalui proxy SOCKS5 yang terpisah untuk layanan tersembunyi Tor.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
+        <translation>Gunakan proxy SOCKS5 yang terpisah untuk terhubung ke para rekan (peers) melalui layanan tersembunyi Tor:</translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation>&amp;Jendela</translation>
     </message>
     <message>
+        <source>&amp;Hide the icon from the system tray.</source>
+        <translation>&amp;Sembunyikan ikon dari baki sistem (system tray).</translation>
+    </message>
+    <message>
+        <source>Hide tray icon</source>
+        <translation>Sembunyikan ikon pada baki</translation>
+    </message>
+    <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Hanya tampilkan ikon tray setelah meminilisasi jendela</translation>
+        <translation>Tampilkan ikon saja pada baki (tray) setelah meminimalisasi jendela.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;Meminilisasi ke tray daripada taskbar</translation>
+        <translation>&amp;Meminimalisasi ke dalam baki (tray) daripada ke dalam taskbar</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation>M&amp;eminilisasi saat tutup</translation>
+        <translation>M&amp;eminimalisasi saat menutup</translation>
     </message>
     <message>
         <source>&amp;Display</source>
@@ -922,6 +1158,10 @@
     <message>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Bahasa Antarmuka Pengguna:</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation>Bahasa yang digunakan dalam bisa diatur disini. Efek pengaturan terjadi setelah melakukan muat ulang %1.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -949,23 +1189,23 @@
     </message>
     <message>
         <source>none</source>
-        <translation>tidak satupun</translation>
+        <translation>tidak satu pun</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
-        <translation>Memastikan reset pilihan</translation>
+        <translation>Pastikan atur ulang opsi</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
-        <translation>Restart klien diperlukan untuk mengaktifkan perubahan.</translation>
+        <translation>Muat ulang diperlukan untuk mengaktifkan perubahan.</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
-        <translation>Klien akan dimatikan, apakah anda hendak melanjutkan?</translation>
+        <translation>Aplikasi klien akan dimatikan, apakah kamu mau melanjutkan?</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation>Perubahan ini akan memerlukan restart klien</translation>
+        <translation>Perubahan ini akan memerlukan muat ulang</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
@@ -980,7 +1220,11 @@
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Informasi terlampir mungkin sudah kedaluwarsa. Dompet Anda secara otomatis mensinkronisasi dengan jaringan Dogecoin ketika sebuah hubungan terbentuk, namun proses ini belum selesai.</translation>
+        <translation>Informasi terlampir mungkin sudah kedaluwarsa. Dompetmu secara otomatis mensinkronisasi dengan jaringan Dogecoin ketika sebuah hubungan terbentuk, namun proses ini belum selesai.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation>Hanya menonton saja:</translation>
     </message>
     <message>
         <source>Available:</source>
@@ -988,27 +1232,27 @@
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation>Jumlah yang Anda bisa keluarkan sekarang</translation>
+        <translation>Jumlah saldo yang bisa kamu pakai saat ini</translation>
     </message>
     <message>
         <source>Pending:</source>
-        <translation>Ditunda</translation>
+        <translation>Ditunda:</translation>
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Jumlah keseluruhan transaksi yang belum dikonfirmasi, dan belum saatnya dihitung sebagai pengeluaran saldo yang telah dibelanjakan.</translation>
+        <translation>Jumlah keseluruhan transaksi yang belum juga dikonfirmasi, dan belum terhitung sebagai saldo yang bisa dibelanjakan.</translation>
     </message>
     <message>
         <source>Immature:</source>
-        <translation>Terlalu Muda:</translation>
+        <translation>Belum Dewasa:</translation>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation>Saldo ditambang yang masih terlalu muda</translation>
+        <translation>Jumlah saldo yang tertambang yang belum cukup dewasa</translation>
     </message>
     <message>
         <source>Balances</source>
-        <translation>Saldo:</translation>
+        <translation>Saldo</translation>
     </message>
     <message>
         <source>Total:</source>
@@ -1016,19 +1260,304 @@
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation>Jumlah saldo Anda sekarang</translation>
+        <translation>Jumlah saldo saat ini</translation>
     </message>
-    </context>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation>Jumlah saldo kamu di alamat &quot;hanya-menonton&quot;</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation>Bisa digunakan:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation>Transaksi terkini</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation>Transaksi belum terkonfirmasi dari alamat &quot;hanya-menonton&quot;</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation>Jumlah saldo tertambang dari alamat &quot;hanya-menonton&quot; yang belum dewasa</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation>Jumlah saldo keseluruhan dari alamat &quot;hanya-menonton&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>PaperWalletDialog</name>
+    <message>
+        <source>Print Your Paper Wallets</source>
+        <translation>Cetak Dompet Kertasmu</translation>
+    </message>
+    <message>
+        <source>Very New Address</source>
+        <translation>Alamat Baru Banget</translation>
+    </message>
+    <message>
+        <source>So Print</source>
+        <translation>Cetak Sekali</translation>
+    </message>
+    <message>
+        <source>Many Wallets?</source>
+        <translation>Banyak Dompet?</translation>
+    </message>
+    <message>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <source>3</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <source>4</source>
+        <translation>4</translation>
+    </message>
+    <message>
+        <source>5</source>
+        <translation>5</translation>
+    </message>
+    <message>
+        <source>6</source>
+        <translation>6</translation>
+    </message>
+    <message>
+        <source>7</source>
+        <translation>7</translation>
+    </message>
+    <message>
+        <source>8</source>
+        <translation>8</translation>
+    </message>
+    <message>
+        <source>9</source>
+        <translation>9</translation>
+    </message>
+    <message>
+        <source>10</source>
+        <translation>10</translation>
+    </message>
+    <message>
+        <source>11</source>
+        <translation>11</translation>
+    </message>
+    <message>
+        <source>12</source>
+        <translation>12</translation>
+    </message>
+    <message>
+        <source>Public Key:</source>
+        <translation>Kunci Publik:</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Tutup</translation>
+    </message>
+    <message>
+        <source>It is recommended to disconnect from the internet before printing paper wallets. Even though paper wallets are generated on your local computer, it is still possible to unknowingly have malware that transmits your screen to a remote location. It is also recommended to print to a local printer vs a network printer since that network traffic can be monitored. Some advanced printers also store copies of each printed document. Proceed with caution relative to the amount of value you plan to store on each address.</source>
+        <translation>Dianjurkan untuk memutuskan koneksi dari internet sebelum mencetak dompet kertas. Meskipun dompet kertas dibuat di komputer lokal, masih ada kemungkinan malware menyadap layarmu. Juga disarankan untuk mencetak melalui printer lokal karena transmisi pada printer jaringan dapat dipantau. Beberapa printer canggih  juga menyimpan salinan dari setiap dokumen yang dicetak. Lanjutkan tahap ini dengan hati-hati, terutama terkait jumlah nilai koin yang akan disimpan disetiap alamat.</translation>
+    </message>
+    <message>
+        <source>Error encoding Address into QR Code.</source>
+        <translation>Gagal saat proses penyandian Alamat kedalam Kode QR.</translation>
+    </message>
+    <message>
+        <source>Error encoding private key into QR Code.</source>
+        <translation>Gagal saat proses penyandian Kunci Privat kedalam Kode QR.</translation>
+    </message>
+    <message>
+        <source>failed to open file, is it writable?</source>
+        <translation>Gagal membuka berkas, apakah berkas dapat ditulis?</translation>
+    </message>
+    <message>
+        <source>Load Paper Wallets</source>
+        <translation>Muat Dompet Kertas</translation>
+    </message>
+    <message>
+        <source>The paper wallet printing process has begun.&lt;br/&gt;Please wait for the wallets to print completely and verify that everything printed correctly.&lt;br/&gt;Check for misalignments, ink bleeding, smears, or anything else that could make the private keys unreadable.&lt;br/&gt;Now, enter the number of DOGE you wish to send to each wallet:</source>
+        <translation>Proses pencetakan dompet kertas telah dimulai.&lt;br/&gt;Harap tunggu sampai dompet sepenuhnya telah dicetak dan pastikan semua bagian sudah tercetak dengan benar.&lt;br/&gt;Periksa juga barangkali ada ketidak sejajaran, tinta bercampur, bercak, atau apapun yang membuat kunci privat tidak terbaca.&lt;br/&gt;Sekarang, masukan berapa banyak DOGE yang mau dikirim kesetiap dompet:</translation>
+    </message>
+    <message>
+        <source>Paper wallet %1</source>
+        <translation>Dompet kertas %1</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; to Paper Wallet &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt; ke Dompet Kertas &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</translation>
+    </message>
+    <message>
+        <source>Send Coins</source>
+        <translation>Kirim Koin</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid, please recheck.</source>
+        <translation>Alamat penerima tidak valid, periksa lagi.</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0</source>
+        <translation>Jumlah yang mau dikirim harus lebih besar dari 0</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation>Jumlah melebihi saldomu.</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the transaction fee is included</source>
+        <translation>Total jumlah melebihi saldo kamu kalau biaya transaksi ikut dihitung</translation>
+    </message>
+    <message>
+        <source>Duplicate address found, can only send to each address once per send operation.</source>
+        <translation>Ditemukan alamat yang sama, kamu cuma bisa mengirim ke satu alamat disetiap operasi pengiriman.</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation>Gagal membuat transaksi!</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to send?</source>
+        <translation>Apakah kamu yakin mau mengirim?</translation>
+    </message>
+    <message>
+        <source>added as transaction fee</source>
+        <translation>menambahkan sebagai biaya transaksi</translation>
+    </message>
+    <message>
+        <source>Total Amount %1 (= %2)</source>
+        <translation>Total Jumlah %1 (= %2)</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation>atau</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation>Konfirmasi pengiriman koin</translation>
+    </message>
+    <message>
+        <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
+        <translation>Aduh! Transaksi ditolak! Mungkin in terjadi kalau beberapa koin di dompetmu sudah dibelanjakan, seperti kalau kamu menggunakan salinan dari wallet.dat dan koin didalamnya tidak ditandai kalau digunakan disini.</translation>
+    </message>
+</context>
 <context>
     <name>PaymentServer</name>
-    </context>
+    <message>
+        <source>Payment request error</source>
+        <translation>Permintaan pembayaran gagal</translation>
+    </message>
+    <message>
+        <source>Cannot start dogecoin: click-to-pay handler</source>
+        <translation>Tidak bisa memulai dogecoin: penanganan ketuk-untuk-bayar</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation>Penanganan URI</translation>
+    </message>
+    <message>
+        <source>Payment request fetch URL is invalid: %1</source>
+        <translation>URL permintaan pembayaran tidak valid: %1</translation>
+    </message>
+    <message>
+        <source>Invalid payment address %1</source>
+        <translation>Alamat pembayaran tidak valid %1</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation>URI tidak bisa diterjemahkan! Bisa disebabkan karena alamat Bitcoin yang salah atau parameter URI yang tidak benar.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation>Penanganan berkas permintaan pembayaran</translation>
+    </message>
+    <message>
+        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
+        <translation>Berkas permintaan pembayaran tidak bisa dibaca! Bisa disebabkan karena berkas permintaan pembayaran yang tidak valid.</translation>
+    </message>
+    <message>
+        <source>Payment request rejected</source>
+        <translation>Permintaan pembayaran ditolak</translation>
+    </message>
+    <message>
+        <source>Payment request network doesn&apos;t match client network.</source>
+        <translation>Permintaan pembayaran tidak cocok dengan jaringan klien.</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation>Permintaan pembayaran kedaluwarsa.</translation>
+    </message>
+    <message>
+        <source>Payment request is not initialized.</source>
+        <translation>Permintaan pembayaran belum diinisiasi.</translation>
+    </message>
+    <message>
+        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
+        <translation>Permintaan pembayaran yang belum diverifikasi ke pembayaran custom tidak didukung.</translation>
+    </message>
+    <message>
+        <source>Invalid payment request.</source>
+        <translation>Permintaan pembayaran tidak valid.</translation>
+    </message>
+    <message>
+        <source>Requested payment amount of %1 is too small (considered dust).</source>
+        <translation>Jumlah permintaan pembayaran dari %1 terlalu kecil (disarakan dust).</translation>
+    </message>
+    <message>
+        <source>Refund from %1</source>
+        <translation>Refund dari %1</translation>
+    </message>
+    <message>
+        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
+        <translation>Permintaan pembayaran %1 terlalu besar (%2 bytes, diizinkan %3 bytes)</translation>
+    </message>
+    <message>
+        <source>Error communicating with %1: %2</source>
+        <translation>Gagal saat mengkomunikasikan dengan %1: %2</translation>
+    </message>
+    <message>
+        <source>Payment request cannot be parsed!</source>
+        <translation>Permintaan pembayaran tidak dapat diterjemahkan!</translation>
+    </message>
+    <message>
+        <location line="+13"/>
+        <source>Bad response from server %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+22"/>
+        <source>Network request error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Payment acknowledged</source>
+        <translation>Pembayaran diakui</translation>
+    </message>
+</context>
 <context>
     <name>PeerTableModel</name>
     <message>
         <source>User Agent</source>
-        <translation>Agen Pengguna</translation>
+        <translation>User Agent</translation>
     </message>
-    </context>
+    <message>
+        <source>Node/Service</source>
+        <translation>Node/Layanan</translation>
+    </message>
+    <message>
+        <source>NodeId</source>
+        <translation>IdNode</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <translation>Ping</translation>
+    </message>
+</context>
 <context>
     <name>QObject</name>
     <message>
@@ -1037,40 +1566,112 @@
     </message>
     <message>
         <source>Enter a Dogecoin address (e.g. %1)</source>
-        <translation>Masukkan alamat Dogecoin (contoh %1)</translation>
+        <translation>Masukkan alamat Dogecoin (contoh. %1)</translation>
+    </message>
+    <message>
+        <source>%1 d</source>
+        <translation>%1 hari</translation>
     </message>
     <message>
         <source>%1 h</source>
-        <translation>%1 Jam</translation>
+        <translation>%1 jam</translation>
     </message>
     <message>
         <source>%1 m</source>
         <translation>%1 menit</translation>
     </message>
     <message>
+        <source>%1 s</source>
+        <translation>%1 detik</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Tidak Ada</translation>
+    </message>
+    <message>
         <source>N/A</source>
-        <translation>T/S</translation>
+        <translation>N/A</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation>%1 ms</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation><numerusform>%n detik</numerusform><numerusform>%n detik</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation><numerusform>%n menit</numerusform><numerusform>%n menit</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation><numerusform>%n jam</numerusform><numerusform>%n jam</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation><numerusform>%n hari</numerusform><numerusform>%n hari</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation><numerusform>%n minggu</numerusform><numerusform>%n minggu</numerusform></translation>
     </message>
     <message>
         <source>%1 and %2</source>
         <translation>%1 dan %2</translation>
     </message>
-    </context>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation><numerusform>%n tahun</numerusform><numerusform>%n tahun</numerusform></translation>
+    </message>
+    <message>
+        <source>%1 didn&apos;t yet exit safely...</source>
+        <translation>%1 belum juga keluar dengan aman...</translation>
+    </message>
+</context>
 <context>
     <name>QObject::QObject</name>
-    </context>
+    <message>
+        <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <translation>Galat: Direktori yang ditentukan &quot;%1&quot; tidak ada.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Galat: Tidak berhasil menerjemahkan berkas konfigurasi: %1. Hanya menggunakan sintaks kunci=nilai.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>Galat: %1</translation>
+    </message>
+</context>
 <context>
     <name>QRImageWidget</name>
-    </context>
+    <message>
+        <source>&amp;Save Image...</source>
+        <translation>&amp;Simpan Gambar...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation>&amp;Salin Gambar</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation>Salin Kode QR</translation>
+    </message>
+    <message>
+        <source>PNG Image (*.png)</source>
+        <translation>Gambar PNG (*.png)</translation>
+    </message>
+</context>
 <context>
     <name>RPCConsole</name>
     <message>
         <source>N/A</source>
-        <translation>T/S</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Client version</source>
-        <translation>Versi Klien</translation>
+        <translation>Versi Aplikasi Klien</translation>
     </message>
     <message>
         <source>&amp;Information</source>
@@ -1083,6 +1684,14 @@
     <message>
         <source>General</source>
         <translation>Umum</translation>
+    </message>
+    <message>
+        <source>Using BerkeleyDB version</source>
+        <translation>Menggunakan BerkeleyDB versi</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation>Datadir</translation>
     </message>
     <message>
         <source>Startup time</source>
@@ -1098,7 +1707,7 @@
     </message>
     <message>
         <source>Number of connections</source>
-        <translation>Jumlah hubungan</translation>
+        <translation>Jumlah koneksi jaringan</translation>
     </message>
     <message>
         <source>Block chain</source>
@@ -1106,25 +1715,115 @@
     </message>
     <message>
         <source>Current number of blocks</source>
-        <translation>Jumlah blok terkini</translation>
+        <translation>Jumlah blok saat ini</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation>Memory Pool</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation>Jumlah transaksi saat ini</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation>Penggunaan Memori</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation>Diterima</translation>
     </message>
     <message>
         <source>Sent</source>
         <translation>Terkirim</translation>
     </message>
     <message>
+        <source>&amp;Peers</source>
+        <translation>&amp;Para Rekan (peers)</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation>Rekan yang diblokir</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation>Pilih salah satu rekan untuk melihat informasi lebih lengkap.</translation>
+    </message>
+    <message>
+        <source>Whitelisted</source>
+        <translation>Daftar Putih</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Direktori</translation>
+    </message>
+    <message>
         <source>Version</source>
         <translation>Versi</translation>
     </message>
     <message>
+        <source>Starting Block</source>
+        <translation>Blok Pertama</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation>Header Tersinkron</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation>Blok Tersinkron</translation>
+    </message>
+    <message>
         <source>User Agent</source>
-        <translation>Agen Pengguna
-
-</translation>
+        <translation>User Agent</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation>Buka dengan %1 berkas catatan debug dari direktori saat ini. Mungkin memakan beberapa detik untuk ukuran berkas catatan yang besar.</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation>Kurangi ukuran huruf</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation>Tingkatkan ukuran huruf</translation>
     </message>
     <message>
         <source>Services</source>
         <translation>Layanan</translation>
+    </message>
+    <message>
+        <source>Ban Score</source>
+        <translation>Skor Blokir</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation>Waktu Koneksi</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation>Terakhir Kirim</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation>Terakhir Diterima</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation>Waktu Ping</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation>Durasi dari ping luar biasa.</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation>Waktu Tunggu Ping</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation>Selisih Waktu</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -1183,12 +1882,36 @@
         <translation>1 &amp;tahun</translation>
     </message>
     <message>
+        <source>&amp;Disconnect</source>
+        <translation>&amp;Putuskan Hubungan</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation>Blokir untuk</translation>
+    </message>
+    <message>
+        <source>&amp;Unban</source>
+        <translation>Batal Blokir</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.</source>
+        <translation>Selamat datang di konsol RPC %1.</translation>
+    </message>
+    <message>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
-        <translation>Gunakan panah keatas dan kebawah untuk menampilkan sejarah, dan &lt;b&gt;Ctrl-L&lt;/b&gt; untuk bersihkan layar.</translation>
+        <translation>Gunakan panah keatas dan kebawah untuk menampilkan riwayat, dan &lt;b&gt;Ctrl-L&lt;/b&gt; untuk membersihkan layar.</translation>
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Ketik &lt;b&gt;help&lt;/b&gt; untuk menampilkan perintah tersedia.</translation>
+        <translation>Ketik &lt;b&gt;help&lt;/b&gt; untuk menampilkan perintah yang tersedia.</translation>
+    </message>
+    <message>
+        <source>WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramification of a command.</source>
+        <translation>PERINGATAN: Scammer sedang marak, dengan modus menyuruh orang untuk mengetikan perintah disini, untuk mencuri isi dompet. Jangan gunakan konsol ini tanpa pengetahuan yang cukup.</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation>Aktifitas jaringan dinonaktifkan</translation>
     </message>
     <message>
         <source>%1 B</source>
@@ -1207,6 +1930,26 @@
         <translation>%1 GB</translation>
     </message>
     <message>
+        <source>(node id: %1)</source>
+        <translation>(id node: %1)</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation>melalui %1</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>tidak pernah</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>Masuk</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>Keluar</translation>
+    </message>
+    <message>
         <source>Yes</source>
         <translation>Ya</translation>
     </message>
@@ -1223,7 +1966,7 @@
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation>&amp;Nilai:</translation>
+        <translation>&amp;Banyaknya:</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
@@ -1234,8 +1977,16 @@
         <translation>&amp;Pesan:</translation>
     </message>
     <message>
+        <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
+        <translation>Gunakan alamat penerimaan yang sebelumnya pernah dipakai. Menggunakan kembali alamat punya potensi isu keamanan dan privasi. Jangan gunakan lagi kecuali sebelumnya sudah membuat ulang permintaan pembayaran.</translation>
+    </message>
+    <message>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>Gunakan lagi alamat penerima yang ada (tidak disarankan)</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dogecoin network.</source>
+        <translation>Pesan tidak wajib yang dilampirkan dalam permintaan pembayaran, yang akan ditampilkan ketika permintaan telah dibuka. Catatan: Pesan ini tidak akan dikirim bersama dengan pembayaran melalui jaringan Dogecoin.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
@@ -1243,7 +1994,7 @@
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>Gunakan form ini untuk meminta pembayaran. Semua bidang adalah &lt;b&gt;opsional&lt;/b&gt;.</translation>
+        <translation>Gunakan formulir ini untuk meminta pembayaran. Semua bidang adalah &lt;b&gt;opsional&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
@@ -1251,7 +2002,7 @@
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation>Hapus informasi dari form.</translation>
+        <translation>Hapus informasi dari formulir.</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -1259,7 +2010,7 @@
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation>Riwayat pembayaran yang diminta Anda</translation>
+        <translation>Riwayat permintaan pembayaranmu</translation>
     </message>
     <message>
         <source>&amp;Request payment</source>
@@ -1282,10 +2033,22 @@
         <translation>Menghapus</translation>
     </message>
     <message>
+        <source>Copy URI</source>
+        <translation>Salin URI</translation>
+    </message>
+    <message>
         <source>Copy label</source>
         <translation>Salin label</translation>
     </message>
-    </context>
+    <message>
+        <source>Copy message</source>
+        <translation>Salin pesan</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>Salin Jumlah</translation>
+    </message>
+</context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
@@ -1302,7 +2065,19 @@
     </message>
     <message>
         <source>&amp;Save Image...</source>
-        <translation>&amp;Simpan Gambaran...</translation>
+        <translation>&amp;Simpan Gambar...</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation>Minta pembayaran ke %1</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation>Informasi pembayaran</translation>
+    </message>
+    <message>
+        <source>URI</source>
+        <translation>URI</translation>
     </message>
     <message>
         <source>Address</source>
@@ -1316,18 +2091,50 @@
         <source>Label</source>
         <translation>Label</translation>
     </message>
-    </context>
+    <message>
+        <source>Message</source>
+        <translation>Pesan</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation>URI yang dihasilkan terlalu panjang, coba kurangi teks untuk label / pesan.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation>Terjadi kesalahan saat melakukan penyandian URI ke dalam Kode QR.</translation>
+    </message>
+</context>
 <context>
     <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
+        <source>Message</source>
+        <translation>Pesan</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
-    </context>
+    <message>
+        <source>(no message)</source>
+        <translation>(tidak ada pesan)</translation>
+    </message>
+    <message>
+        <source>(no amount requested)</source>
+        <translation>(tidak ada jumlah yang diminta)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation>Diminta</translation>
+    </message>
+</context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
@@ -1344,11 +2151,11 @@
     </message>
     <message>
         <source>automatically selected</source>
-        <translation>Pemilihan otomatis</translation>
+        <translation>dipilih otomatis</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation>Saldo tidak mencukupi!</translation>
+        <translation>Saldo tidak cukup!</translation>
     </message>
     <message>
         <source>Quantity:</source>
@@ -1360,7 +2167,7 @@
     </message>
     <message>
         <source>Amount:</source>
-        <translation>Nilai:</translation>
+        <translation>Jumlah:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -1387,8 +2194,48 @@
         <translation>Biaya Transaksi:</translation>
     </message>
     <message>
+        <source>Choose...</source>
+        <translation>Pilih...</translation>
+    </message>
+    <message>
+        <source>collapse fee-settings</source>
+        <translation>tutup pengaturan biaya</translation>
+    </message>
+    <message>
+        <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 satoshis in fee, while &quot;total at least&quot; pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
+        <translation>Jika biaya khusus diatur menjadi 1000 koinu dan transaksi hanya 250 bytes, maka &quot;per kilobyte&quot; nya hanya bayar 250 koinu, dimana &quot;total sedikitnya&quot; membayar 1000 koinu. Untuk transaksi yang lebih besar dari satu kilobyte dihitung membayar per kilobyte.</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation>per kilobyte</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>Sembunyikan</translation>
+    </message>
+    <message>
+        <source>total at least</source>
+        <translation>jumlah paling sedikit</translation>
+    </message>
+    <message>
+        <source>(read the tooltip)</source>
+        <translation>(baca tooltip)</translation>
+    </message>
+    <message>
+        <source>(read the tooltip)</source>
+        <translation>(baca tooltip)</translation>
+    </message>
+    <message>
         <source>Recommended:</source>
-        <translation>Disarankan</translation>
+        <translation>Disarankan:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation>Khusus:</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
+        <translation>(Biaya cerdas belum diatur. Biasanya membutuhkan beberapa blok...)</translation>
     </message>
     <message>
         <source>normal</source>
@@ -1404,15 +2251,23 @@
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation>Tambahlah &amp;Penerima</translation>
+        <translation>Tambah &amp;Penerima</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation>Hapus informasi dari form.</translation>
+        <translation>Hapus informasi dari formulir.</translation>
     </message>
     <message>
         <source>Dust:</source>
         <translation>Dust:</translation>
+    </message>
+    <message>
+        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for dogecoin transactions than the network can process.</source>
+        <translation>Boleh saja membayar hanya biaya minimum selama volume transaksi lebih sedikit daripada ruang di blok yang tersedia. Tetapi ketahuilah bahwa ini bisa menyebabkan transaksimu tidak pernah terkonfirmasi kalau permintaan untuk transaksi terus meningkat melebihi kapasitas jaringan dogecoin.</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation>Target waktu konfirmasi:</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -1431,8 +2286,120 @@
         <translation>K&amp;irim</translation>
     </message>
     <message>
+        <source>Copy quantity</source>
+        <translation>Salin kuantitas</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>Salin jumlah</translation>
+    </message>
+    <message>
         <source>Copy fee</source>
         <translation>Salin biaya</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation>Salin biaya setelahnya</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation>Salin bytes</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation>Salin dust</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation>Salin kembalian</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation>%1 sampai %2</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to send?</source>
+        <translation>Kamu yakin jadi mengirim?</translation>
+    </message>
+    <message>
+        <source>added as transaction fee</source>
+        <translation>ditambahkan sebagai biaya transaksi</translation>
+    </message>
+    <message>
+        <source>Total Amount %1</source>
+        <translation>Total Jumlah %1</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation>atau</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation>Konfirmasi mengirim koin</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation>Alamat penerima tidak valid. Mohon periksa lagi.</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation>Jumlah yang mau dibayarkan harus lebih besar dari 0.</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation>Jumlah melebihi saldomu.</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
+        <translation>Jumlah total melebihi saldo jika biaya transaksi %1 ikut dihitung.</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation>Alamat ditemukan duplikat: alamat seharusnya hanya digunakan sekali sepanjang operasi.</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation>Gagal membuat transaksi!</translation>
+    </message>
+    <message>
+        <source>The transaction was rejected with the following reason: %1</source>
+        <translation>Transaksi ditolak dengan alasan: %1</translation>
+    </message>
+    <message>
+        <source>A fee higher than %1 is considered an absurdly high fee.</source>
+        <translation>Biaya yang lebih tinggi dari %1 termasuk biaya yang sangat tinggi.</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation>Permintaan pembayaran kedaluwarsa.</translation>
+    </message>
+    <message>
+        <source>%n block(s)</source>
+        <translation>%n blok</translation>
+    </message>
+    <message>
+        <source>Pay only the required fee of %1</source>
+        <translation>Cuma membayar biaya yang dibutuhkan dari %1</translation>
+    </message>
+    <message>
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation>Kira-kira akan memulai konfirmasi dalam %n blok</translation>
+    </message>
+    <message>
+        <source>Warning: Invalid Dogecoin address</source>
+        <translation>Peringatan: Alamat Dogecoin tidak valid</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation>Peringatan: Alamat pengembalian tidak diketahui</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation>Konfirmasi alamat pengembalian khusus</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation>Alamat yang kamu pilih untuk kembalian bukan bagian dari dompet ini. Beberapa atau semua dana yang ada di dompetmu akan dikirim ke alamat ini. Apakah kamu yakin?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1455,11 +2422,15 @@
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation>Pilih alamat yang telah digunakan sebelumnya</translation>
+        <translation>Pilih alamat yang sebelumnya digunakan</translation>
     </message>
     <message>
         <source>This is a normal payment.</source>
-        <translation>Ini adalah pembayaran normal</translation>
+        <translation>Ini adalah pembayaran normal.</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address to send the payment to</source>
+        <translation>Alamat Dogecoin yang akan dikirimkan bayaran</translation>
     </message>
     <message>
         <source>Alt+A</source>
@@ -1467,7 +2438,7 @@
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>Tempel alamat dari salinan</translation>
+        <translation>Tempel alamat dari papan klip (clipboard)</translation>
     </message>
     <message>
         <source>Alt+P</source>
@@ -1478,12 +2449,32 @@
         <translation>Hapus masukan ini</translation>
     </message>
     <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less dogecoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation>Biaya tersebut akan dipotong dari jumlah yang dikirimkan. Penerima akan menerima dogecoin lebih sedikit daripada yang kamu masukkan diisian jumlah. Jika beberapa penerima dipilih sekaligus, biayanya akan dibagi rata.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation>Kurangkan biaya dari jumlah</translation>
+    </message>
+    <message>
         <source>Message:</source>
         <translation>Pesan:</translation>
     </message>
     <message>
+        <source>This is an unauthenticated payment request.</source>
+        <translation>Ini adalah permintaan pembayaran yang tidak terauntentikasi.</translation>
+    </message>
+    <message>
+        <source>This is an authenticated payment request.</source>
+        <translation>Ini adalah permintaan pembayaran yang terauntentikasi.</translation>
+    </message>
+    <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>Masukkan label untuk alamat ini untuk dimasukan dalam daftar alamat yang pernah digunakan</translation>
+        <translation>Masukkan label untuk alamat ini agar dimasukan ke dalam daftar alamat yang pernah digunakan</translation>
+    </message>
+    <message>
+        <source>A message that was attached to the dogecoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Dogecoin network.</source>
+        <translation>Pesan yang dilampirkan ke dogecoin: URI yang akan disimpan dengan transaksi sebagai referensi kamu. Catatan: Pesan ini tidak akan dikirim bersama dengan pembayaran melalui jaringan Dogecoin.</translation>
     </message>
     <message>
         <source>Pay To:</source>
@@ -1491,17 +2482,29 @@
     </message>
     <message>
         <source>Memo:</source>
-        <translation>Catatan Peringatan:</translation>
+        <translation>Catatan:</translation>
     </message>
-    </context>
+    <message>
+        <source>Enter a label for this address to add it to your address book</source>
+        <translation>Masukkan label untuk alamat ini untuk ditambahkan ke buku alamatmu</translation>
+    </message>
+</context>
 <context>
     <name>SendConfirmationDialog</name>
-    </context>
+    <message>
+        <source>Yes</source>
+        <translation>Ya</translation>
+    </message>
+</context>
 <context>
     <name>ShutdownWindow</name>
     <message>
+        <source>%1 is shutting down...</source>
+        <translation>%1 sedang dimatikan...</translation>
+    </message>
+    <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation>Kamu tidak dapat mematikan komputer sebelum jendela ini tertutup sendiri.</translation>
+        <translation>Jangan mematikan komputer sebelum jendela ini tertutup.</translation>
     </message>
 </context>
 <context>
@@ -1515,8 +2518,20 @@
         <translation>&amp;Tandakan Pesan</translation>
     </message>
     <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive dogecoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation>Kamu bisa menandatangani pesan / perjanjian dengan alamat tujuan untuk membuktikan bahwa kamu dapat menerima dogecoin. Berhati-hatilah untuk tidak menandatangani apa pun yang samar atau acak, karena serangan phishing mungkin mencoba menipumy agar menyerahkan identitas. Tetap wasapada dan hanya tanda tangani pernyataan yang detail dan kamu pahami. </translation>
+    </message>
+    <message>
         <source>Choose previously used address</source>
-        <translation>Pilih alamat yang telah digunakan sebelumnya</translation>
+        <translation>Pilih alamat yang digunakan sebelumnya</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address to sign the message with</source>
+        <translation>Alamat Dogecoin untuk menanda tangani pesan dengan</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation>Gunakan alamat yang pernah digunakan</translation>
     </message>
     <message>
         <source>Alt+A</source>
@@ -1524,7 +2539,7 @@
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>Tempel alamat dari salinan</translation>
+        <translation>Tempel alamat dari papan klip</translation>
     </message>
     <message>
         <source>Alt+P</source>
@@ -1544,7 +2559,7 @@
     </message>
     <message>
         <source>Sign the message to prove you own this Dogecoin address</source>
-        <translation>Tandai pesan untuk menyetujui kamu pemiliki alamat Dogecoin ini</translation>
+        <translation>Tandai pesan untuk menyetujui kamu pemilik alamat Dogecoin ini</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -1563,6 +2578,18 @@
         <translation>&amp;Verifikasi Pesan</translation>
     </message>
     <message>
+        <source>Enter the receiver&apos;s address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation>Masukkan alamat penerima, pesan (pastikan menyalin jeda baris, spasi, tab, dll dengan tepat) dan tanda tangan di bawah ini untuk memverifikasi pesan. Berhati-hatilah untuk tidak membaca lebih banyak ke dalam tanda tangan daripada apa yang ada di pesan yang ditandatangani itu sendiri, untuk menghindari tertipu oleh serangan man-in-the-middle. Perhatikan bahwa ini hanya membuktikan bahwa pihak yang menandatangani menerima dengan alamat tersebut, tidak dapat membuktikan pengiriman transaksi apa pun!</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address the message was signed with</source>
+        <translation>Alamat Dogecoin yang digunakan telah ditandatangani dengan</translation>
+    </message>
+    <message>
+        <source>Verify the message to ensure it was signed with the specified Dogecoin address</source>
+        <translation>Verifikasi pesan untuk memastikan telah ditandatangani dengan alamat Dogecoin</translation>
+    </message>
+    <message>
         <source>Verify &amp;Message</source>
         <translation>Verifikasi &amp;Pesan</translation>
     </message>
@@ -1570,7 +2597,59 @@
         <source>Reset all verify message fields</source>
         <translation>Hapus semua bidang verifikasi pesan</translation>
     </message>
-    </context>
+    <message>
+        <source>Click &quot;Sign Message&quot; to generate signature</source>
+        <translation>Klik &quot; Tanda Tangani Pesan &quot; untuk menghasilkan tanda tangan</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation>Alamat yang dimasukan tidak valid.</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation>Mohon periksa dan ulangi lagi</translation>
+    </message>
+    <message>
+        <source>The entered address does not refer to a key.</source>
+        <translation>Alamat yang dimasukan tidak merujuk ke sebuah kunci.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation>Pembukaan kunci dompet dibatalkan.</translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation>Kunci Privat untuk alamat yang dimasukan tidak tersedia.</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation>Gagal menandatangani pesan.</translation>
+    </message>
+    <message>
+        <source>Message signed.</source>
+        <translation>Pesan berhasil ditandatangani.</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation>Tanda tangan tidak bisa diartikan.</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation>Periksa lagi tandatangan dan coba lagi.</translation>
+    </message>
+    <message>
+        <source>The signature did not match the message digest.</source>
+        <translation>Tanda tangan tidak cocok dengan isi pesan.</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation>Verifikasi pesan gagal.</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation>Pesan terverifikasi.</translation>
+    </message>
+</context>
 <context>
     <name>SplashScreen</name>
     <message>
@@ -1588,30 +2667,365 @@
 <context>
     <name>TransactionDesc</name>
     <message>
+        <source>Open for %n more block(s)</source>
+        <translation>Buka untuk %n blok lagi</translation>
+    </message>
+    <message>
+        <source>Open until %1</source>
+        <translation>Buka sampai %1</translation>
+    </message>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <translation>bentrok dengan sebuah transaksi dengan %1 konfirmasi</translation>
+    </message>
+    <message>
+        <source>%1/offline</source>
+        <translation>%1/offline</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, %1</source>
+        <translation>0/belum terkonfirmasi, %1</translation>
+    </message>
+    <message>
+        <source>in memory pool</source>
+        <translation>dalam memory pool</translation>
+    </message>
+    <message>
+        <source>abandoned</source>
+        <translation>ditinggalkan</translation>
+    </message>
+    <message>
+        <source>%1/unconfirmed</source>
+        <translation>%1/belum terkonfirmasi</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <translation>%1 konfirmasi</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <source>, has not been successfully broadcast yet</source>
+        <translation>, saat ini belum berhasil disiarkan</translation>
+    </message>
+    <message>
+        <source>, broadcast through %n node(s)</source>
+        <translation>, disiarkan melalui %n node</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation>Sumber</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation>Tercipta</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation>Dari</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation>tidak diketahui</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation>Ke</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation>memiliki alamat</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation>hanya-menonton</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation>label</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation>Kredit</translation>
+    </message>
+    <message>
+        <source>matures in %n more block(s)</source>
+        <translation>dewasa dalam %n blok lagi</translation>
+    </message>
+    <message>
+        <source>not accepted</source>
+        <translation>tidak diterima</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation>Debit</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation>Total debit</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation>Total kredit</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation>Biaya Transaksi</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation>Net amount</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation>Pesan</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation>Komentar</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation>ID Transaksi</translation>
+    </message>
+    <message>
+        <source>Transaction total size</source>
+        <translation>Total ukuran transaksi</translation>
+    </message>
+    <message>
+        <source>Output index</source>
+        <translation>Indeks Luaran</translation>
+    </message>
+    <message>
+        <source>Merchant</source>
+        <translation>Merchant</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation>Koin yang dihasilkan harus menjadi dewasa %1 blok sebelum dapat digunakan. Saat Anda membuat blok ini, blok disiarkan ke jaringan untuk ditambahkan ke rantai blok (blockchain). Jika gagal masuk ke rantai, statusnya akan berubah menjadi &quot; tidak diterima &quot; dan itu tidak akan bisa dibelanjakan. Terkadang dapat terjadi jika node lain menghasilkan blok beberapa detik lebih cepat darimu.</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation>Informasi Debug</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation>Transaksi</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation>Input</translation>
+    </message>
+    <message>
         <source>Amount</source>
         <translation>Jumlah</translation>
     </message>
-    </context>
+    <message>
+        <source>true</source>
+        <translation>benar</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation>salah</translation>
+    </message>
+</context>
 <context>
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation>Jendela ini menampilkan deskripsi rinci dari transaksi tersebut</translation>
+        <translation>Jendela ini menampilkan deskripsi rinci transaksi tersebut</translation>
     </message>
-    </context>
+    <message>
+        <source>Details for %1</source>
+        <translation>Detail untuk %1</translation>
+    </message>
+</context>
 <context>
     <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Tipe</translation>
+    </message>
     <message>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
+        <source>Open for %n more block(s)</source>
+        <translation>Buka untuk %n blok lagi</translation>
+    </message>
+    <message>
+        <source>Open until %1</source>
+        <translation>Buka sampai %1</translation>
+    </message>
+    <message>
+        <source>Offline</source>
+        <translation>Luring</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation>Belum Terkonfirmasi</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation>Ditinggalkan</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation>Mengkonfirmasi (%1 dari %2 konfirmasi yang disarankan)</translation>
+    </message>
+    <message>
+        <source>Confirmed (%1 confirmations)</source>
+        <translation>Terkonfirmasi (%1 konfirmasi)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation>Bentrok</translation>
+    </message>
+    <message>
+        <source>Immature (%1 confirmations, will be available after %2)</source>
+        <translation>Belum dewasa (%1 konfirmasi, akan tersedia setelah %2)</translation>
+    </message>
+    <message>
+        <source>This block was not received by any other nodes and will probably not be accepted!</source>
+        <translation>Blok ini tidak diterima oleh node manapun dan mungkin tidak akan diterima!</translation>
+    </message>
+    <message>
+        <source>Generated but not accepted</source>
+        <translation>Diciptakan tapi tidak disetujui</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation>Diterima dengan</translation>
+    </message>
+    <message>
+        <source>Received from</source>
+        <translation>Diterima dari</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation>Dikirim ke</translation>
+    </message>
+    <message>
+        <source>Payment to yourself</source>
+        <translation>Pembayaran ke diri sendiri</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation>Ditambang</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation>hanya-menonton</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation>(n/a)</translation>
+    </message>
+        <source>(n/a)</source>
+        <translation>(n/a)</translation>
+    </message>
+    <message>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
-    </context>
+    <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation>Status transaksi. Arahkan kursor ke bidang ini untuk menunjukkan jumlah konfirmasi.</translation>
+    </message>
+    <message>
+        <source>Date and time that the transaction was received.</source>
+        <translation>Tanggal dan waktu saat transaksi diterima.</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation>Tipe transaksi.</translation>
+    </message>
+    <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation>Apakah sebuah alamat &quot; hanya-menonton &quot; terlibat dalam transaksi ini.</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation>Maksud / tujuan transaksi yang ditentukan pengguna.</translation>
+    </message>
+    <message>
+        <source>Amount removed from or added to balance.</source>
+        <translation>Jumlah saldo yang dihilangkan atau ditambahkan.</translation>
+    </message>
+</context>
 <context>
     <name>TransactionView</name>
+    <message>
+        <source>All</source>
+        <translation>Semua</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation>Hari ini</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation>Minggu ini</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation>Bulan ini</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation>Bulan lalu</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation>Tahun ini</translation>
+    </message>
+    <message>
+        <source>Range...</source>
+        <translation>Rentang...</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation>Diterima dengan</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation>Terkirim ke</translation>
+    </message>
+    <message>
+        <source>To yourself</source>
+        <translation>Kepada diri sendiri</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation>Ditambang</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>Lainnya</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation>Masukan alamat atau label untuk mencari</translation>
+    </message>
+    <message>
+        <source>Min amount</source>
+        <translation>Jumlah Minimal</translation>
+    </message>
+    <message>
+        <source>Abandon transaction</source>
+        <translation>Tinggalkan Transaksi</translation>
+    </message>
     <message>
         <source>Copy address</source>
         <translation>Salin alamat</translation>
@@ -1621,8 +3035,52 @@
         <translation>Salin label</translation>
     </message>
     <message>
+        <source>Copy amount</source>
+        <translation>Salin jumlah</translation>
+    </message>
+    <message>
+        <source>Copy transaction ID</source>
+        <translation>Salin ID transaksi</translation>
+    </message>
+    <message>
+        <source>Copy raw transaction</source>
+        <translation>Salin transaksi mentah</translation>
+    </message>
+    <message>
+        <source>Copy full transaction details</source>
+        <translation>Salin tdetail lengkap transaksi</translation>
+    </message>
+    <message>
+        <source>Edit label</source>
+        <translation>Ubah Label</translation>
+    </message>
+    <message>
+        <source>Show transaction details</source>
+        <translation>Tampilkan detail transaksi</translation>
+    </message>
+    <message>
+        <source>Export Transaction History</source>
+        <translation>Ekspor Riwayat Transaksi</translation>
+    </message>
+    <message>
         <source>Comma separated file (*.csv)</source>
-        <translation>Berkas yang berformat(*.csv)</translation>
+        <translation>Comma separated file (*.csv)</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation>Terkonfirmasi</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation>Hanya-menonton</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>Tanggal</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Tipe</translation>
     </message>
     <message>
         <source>Label</source>
@@ -1633,24 +3091,212 @@
         <translation>Alamat</translation>
     </message>
     <message>
-        <source>Exporting Failed</source>
-        <translation>Mengekspor Gagal</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
-    </context>
+    <message>
+        <source>Exporting Failed</source>
+        <translation>Gagal Mengekspor</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the transaction history to %1.</source>
+        <translation>Terjadi kesalahan saat mencoba untuk menyimpan riwayat transaksi ke %1.</translation>
+    </message>
+    <message>
+        <source>Exporting Successful</source>
+        <translation>Eskspor Berhasil</translation>
+    </message>
+    <message>
+        <source>The transaction history was successfully saved to %1.</source>
+        <translation>Riwayat transaksi telah berhasil disimpan ke %1</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>Rentang:</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>ke</translation>
+    </message>
+</context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
-    </context>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation>Unit untuk menampilkan jumlah. Klik untuk memilih unit lain.</translation>
+    </message>
+</context>
 <context>
     <name>WalletFrame</name>
-    </context>
+    <message>
+        <source>No wallet has been loaded.</source>
+        <translation>Tidak ada dompet termuat.</translation>
+    </message>
+</context>
 <context>
     <name>WalletModel</name>
-    </context>
+    <message>
+        <source>Send Coins</source>
+        <translation>Kirim Koin</translation>
+    </message>
+</context>
 <context>
     <name>WalletView</name>
-    </context>
+    <message>
+        <source>&amp;Export</source>
+        <translation>&amp;Ekspor</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>Ekspor data di tab ini ke sebuah berkas</translation>
+    </message>
+    <message>
+        <source>Backup Wallet</source>
+        <translation>Cadangkan Dompet</translation>
+    </message>
+    <message>
+        <source>Wallet Data (*.dat)</source>
+        <translation>Data Dompet (*.dat)</translation>
+    </message>
+    <message>
+        <source>Backup Failed</source>
+        <translation>Gagal Mencadangkan Dompet</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the wallet data to %1.</source>
+        <translation>Terjadi kesalahan saat mencoba untuk menyimpan data dompet ke %1.</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation>Pencadangan Berhasil</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation>Dompet terlah berhasil tersimpan di %1.</translation>
+    </message>
+</context>
 <context>
     <name>dogecoin-core</name>
+    <message>
+        <source>Dogecoin Core</source>
+        <translation>Dogecoin Core</translation>
+    </message>
+    <message>
+        <source>The %s developers</source>
+        <translation>%s pengembang</translation>
+    </message>
+    <message>
+        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
+        <translation>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</translation>
+    </message>
+    <message>
+        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation>-maxtxfee diatur sangat tinggi! Biaya yang besar ini bisa dibayar dalam satu kali transaksi.</translation>
+    </message>
+    <message>
+        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
+        <translation>Sebuah biaya rate (di %s/kB) yang akan digunakan ketika estimasi biaya memilik data yang kurang (default: %s)</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
+        <translation>Terima koneksi dari luar (default: 1 jika tidak -proxy atau -connect/-noconnect)</translation>
+    </message>
+    <message>
+        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
+        <translation>Setujui transaksi terusan yang diterima dari rekan yang masuk daftar putih meskipun tidak menyampaikan transaksi (default: %d)</translation>
+    </message>
+    <message>
+        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
+        <translation>Izinkan koneksi JSON-RPC dari sumber tertentu. Valid untuk &lt;ip&gt; tunggal (e.g. 1.2.3.4), network/netmask (e.g. 1.2.3.4/255.255.255.0) atau network/CIDR (e.g. 1.2.3.4/24). Opsi ini bisa dispesifikan beberapa kali</translation>
+    </message>
+    <message>
+        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
+        <translation>Bind to given address and always listen on it. Use [host]:port notation for IPv6</translation>
+    </message>
+    <message>
+        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6/source>
+        <translation>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</translation>
+    </message>
+    <message>
+        <source>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
+        <translation>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</translation>
+    </message>
+    <message>
+        <source>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
+        <translation>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</translation>
+    </message>
+    <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation>Cannot obtain a lock on data directory %s. %s is probably already running.</translation>
+    </message>
+    <message>
+        <source>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
+        <translation>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</translation>
+    </message>
+    <message>
+        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
+        <translation>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</translation>
+    </message>
+    <message>
+        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
+        <translation>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</translation>
+    </message>
+    <message>
+        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
+        <translation>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</translation>
+    </message>
+    <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation>Distributed under the MIT software license, see the accompanying file %s or %s</translation>
+    </message>
+    <message>
+        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
+        <translation>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</translation>
+    </message>
+    <message>
+        <source>Equivalent bytes per sigop in transactions for relay and mining (default: %u)</source>
+        <translation>Equivalent bytes per sigop in transactions for relay and mining (default: %u)</translation>
+    </message>
+    <message>
+        <source>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</source>
+        <translation>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <translation>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</translation>
+    </message>
+    <message>
+        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
+        <translation>Error: Listening for incoming connections failed (listen returned error %s)</translation>
+    </message>
+    <message>
+        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
+        <translation>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</translation>
+    </message>
+    <message>
+        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
+        <translation>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</translation>
+    </message>
+    <message>
+        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
+        <translation>Execute command when the best block changes (%s in cmd is replaced by block hash)</translation>
+    </message>
+    <message>
+        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
+        <translation>Extra transactions to keep in memory for compact block reconstructions (default: %u)</translation>
+    </message>
+    <message>
+        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
+        <translation>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</translation>
+    </message>
+    <message>
+        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
+        <translation>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</translation>
+    </message>
+    <message>
+        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
+        <translation>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</translation>
+    </message>
     <message>
         <source>Options:</source>
         <translation>Pilihan:</translation>
@@ -1661,19 +3307,19 @@
     </message>
     <message>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>Hubungkan ke node untuk menerima alamat peer, dan putuskan</translation>
+        <translation>Hubungkan ke node untuk menerima alamat rekan (peer), dan putuskan</translation>
     </message>
     <message>
         <source>Specify your own public address</source>
-        <translation>Tentukan alamat publik Anda sendiri</translation>
+        <translation>Tentukan alamat publik kamu sendiri</translation>
     </message>
     <message>
         <source>Accept command line and JSON-RPC commands</source>
-        <translation>Menerima perintah baris perintah dan JSON-RPC</translation>
+        <translation>Menerima baris perintah dan JSON-RPC</translation>
     </message>
     <message>
         <source>Run in the background as a daemon and accept commands</source>
-        <translation>Berjalan dibelakang sebagai daemin dan menerima perintah</translation>
+        <translation>Berjalan dibelakang sebagai daemon dan menerima perintah</translation>
     </message>
     <message>
         <source>Dogecoin Core</source>
@@ -1681,7 +3327,7 @@
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Jalankan perintah ketika perubahan transaksi dompet (%s di cmd digantikan oleh TxID)</translation>
+        <translation>Jalankan perintah ketika terjadi perubahan transaksi dompet (%s di cmd digantikan oleh TxID)</translation>
     </message>
     <message>
         <source>Block creation options:</source>
@@ -1693,43 +3339,43 @@
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation>Menemukan database blok yang rusak </translation>
+        <translation>Menemukan basis data blok yang rusak</translation>
     </message>
     <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>Jangan memuat dompet dan menonaktifkan panggilan dompet RPC</translation>
+        <translation>Jangan muat dompet dan nonaktifkan panggilan dompet RPC</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation>Apakah Anda ingin coba membangun kembali database blok sekarang?</translation>
+        <translation>Apakah kamu ingin membangun kembali basis data blok sekarang?</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation>Kesalahan menginisialisasi database blok</translation>
+        <translation>Kesalahan menginisialisasi basis data blok</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation>Kesalahan menginisialisasi dompet pada database%s!</translation>
+        <translation>Kesalahan saat menginisialisasi basis data lingkungan dompet %s!</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation>Gagal memuat database blok</translation>
+        <translation>Gagal memuat basis data blok</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation>Menemukan masalah membukakan database blok</translation>
+        <translation>Gagal saat membukakan basis data blok</translation>
     </message>
     <message>
         <source>Error: Disk space is low!</source>
-        <translation>Gagal: Hard disk hampir terisi!</translation>
+        <translation>Gagal: Ruang penyimpan hampir penuh!</translation>
     </message>
     <message>
         <source>Importing...</source>
-        <translation>mengimpor...</translation>
+        <translation>Mengimpor...</translation>
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation>Tidak bisa cari blok pertama, atau blok pertama salah. Salah direktori untuk jaringan?</translation>
+        <translation>Tidak bisa menemukan atau ada kesalahan pada blok penciptaan. Mungkin saja kesalahan mengatur lokasi direktori data untuk jaringan?</translation>
     </message>
     <message>
         <source>Invalid -onion address: '%s'</source>
@@ -1737,15 +3383,15 @@
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
-        <translation>Deskripsi berkas tidak tersedia dengan cukup.</translation>
+        <translation>Tidak tersedia berkas deskripsi yang cukup.</translation>
     </message>
     <message>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Atur ukuran maksimal untuk blok dalam byte (biasanya: %d)</translation>
+        <translation>Atur ukuran maksimal untuk blok dalam byte (default: %d)</translation>
     </message>
     <message>
         <source>Specify wallet file (within data directory)</source>
-        <translation>Tentukan arsip dompet (dalam direktori data)</translation>
+        <translation>Tentukan berkas dompet (di dalam direktori data)</translation>
     </message>
     <message>
         <source>Verifying blocks...</source>
@@ -1757,7 +3403,7 @@
     </message>
     <message>
         <source>Wallet %s resides outside data directory %s</source>
-        <translation>Dompet %s ada diluar direktori data %s</translation>
+        <translation>Dompet %s ada di luar direktori data %s</translation>
     </message>
     <message>
         <source>Wallet options:</source>
@@ -1776,16 +3422,32 @@
         <translation>Opsi server RPC:</translation>
     </message>
     <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation>Mengurangi -maxconnections dari %d ke %d dikarenakan keterbatasan sistem.</translation>
+    </message>
+    <message>
+        <source>Rescan the block chain for missing wallet transactions on startup</source>
+        <translation>Pindai ulang block chain saat memulai, untuk menemukan transaksi yang hilang</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
-        <translation>Kirim info jejak/debug ke konsol bukan berkas debug.log</translation>
+        <translation>Kirim info jejak/debug ke konsol bukan ke berkas debug.log</translation>
+    </message>
+    <message>
+        <source>Send transactions as zero-fee transactions if possible (default: %u)</source>
+        <translation>Jika memungkinkan, kirim transaksi sebagai transaksi bebas biaya (default: %u)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Tampilkan semua opsi debug (penggunaan: --help -help-debug)</translation>
     </message>
     <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Mengecilkan berkas debug.log saat klien berjalan  (Standar: 1 jika tidak -debug)</translation>
+        <translation>Kecilkan berkas debug.log saat klien memulai (default: 1 jika tidak -debug)</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation>Tandatangani transaksi tergagal</translation>
+        <translation>Tanda tangani transaksi gagal</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
@@ -1797,7 +3459,7 @@
     </message>
     <message>
         <source>Username for JSON-RPC connections</source>
-        <translation>Nama pengguna untuk hubungan JSON-RPC</translation>
+        <translation>Nama pengguna untuk koneksi JSON-RPC</translation>
     </message>
     <message>
         <source>Warning</source>
@@ -1805,15 +3467,15 @@
     </message>
     <message>
         <source>Zapping all transactions from wallet...</source>
-        <translation>Setiap transaksi dalam dompet sedang di-'Zap'...</translation>
+        <translation>Melakukan proses "Zapping" ke semua transaksi dalam dompet...</translation>
     </message>
     <message>
         <source>Password for JSON-RPC connections</source>
-        <translation>Kata sandi untuk hubungan JSON-RPC</translation>
+        <translation>Kata sandi untuk koneksi JSON-RPC</translation>
     </message>
     <message>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Menjalankan perintah ketika perubahan blok terbaik (%s dalam cmd digantikan oleh hash blok)</translation>
+        <translation>Menjalankan perintah ketika perubahan terjadi pada blok terbaik (%s dalam cmd digantikan oleh hash blok)</translation>
     </message>
     <message>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
@@ -1829,7 +3491,7 @@
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation>Jaringan tidak diketahui yang ditentukan dalam -onlynet: '%s'</translation>
+        <translation>Jaringan tidak diketahui dalam -onlynet: '%s'</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -1841,7 +3503,7 @@
     </message>
     <message>
         <source>Add a node to connect to and attempt to keep the connection open</source>
-        <translation>Tambahkan node untuk dihubungkan dan upaya untuk menjaga hubungan tetap terbuka</translation>
+        <translation>Tambahkan koneksi node untuk menjaga koneksi tetap terbuka</translation>
     </message>
     <message>
         <source>Loading wallet...</source>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -2932,6 +2932,7 @@
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
+    <message>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
@@ -3214,7 +3215,7 @@
         <translation>Bind to given address and always listen on it. Use [host]:port notation for IPv6</translation>
     </message>
     <message>
-        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6/source>
+        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
         <translation>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -3131,7 +3131,7 @@
     <name>WalletFrame</name>
     <message>
         <source>No wallet has been loaded.</source>
-        <translation>Tidak ada dompet termuat.</translation>
+        <translation>Belum ada dompet termuat.</translation>
     </message>
 </context>
 <context>
@@ -3149,7 +3149,7 @@
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>Ekspor data di tab ini ke sebuah berkas</translation>
+        <translation>Ekspor data dari tab ini ke dalam sebuah berkas</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
@@ -3173,7 +3173,7 @@
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation>Dompet terlah berhasil tersimpan di %1.</translation>
+        <translation>Dompet terlah berhasil tersimpan pada %1.</translation>
     </message>
 </context>
 <context>
@@ -3188,115 +3188,111 @@
     </message>
     <message>
         <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
-        <translation>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</translation>
+        <translation>(1 = pertahankan meta data pengiriman (tx) contohnya akun pemilik dan informasi permintaan pembayaran, 2 = hapus meta data pengiriman (tx))</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation>-maxtxfee diatur sangat tinggi! Biaya yang besar ini bisa dibayar dalam satu kali transaksi.</translation>
+        <translation>-maxtxfee diatur sangat tinggi! Biaya besar ini seharusnya bisa dibayar dalam satu kali transaksi.</translation>
     </message>
     <message>
         <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
-        <translation>Sebuah biaya rate (di %s/kB) yang akan digunakan ketika estimasi biaya memilik data yang kurang (default: %s)</translation>
+        <translation>Kurs biaya (di %s/kB) yang akan digunakan ketika estimasi biaya kekurangan data (bawaan: %s)</translation>
     </message>
     <message>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
-        <translation>Terima koneksi dari luar (default: 1 jika tidak -proxy atau -connect/-noconnect)</translation>
+        <translation>Terima koneksi dari luar (bawaan: 1 jika tanpa -proxy atau -connect/-noconnect)</translation>
     </message>
     <message>
         <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
-        <translation>Setujui transaksi terusan yang diterima dari rekan yang masuk daftar putih meskipun tidak menyampaikan transaksi (default: %d)</translation>
+        <translation>Terima transaksi tersiar dari rekan yang masuk dalam daftar putih meskipun ketika sedang tidak menyiarkan transaksi (bawaan: %d)</translation>
     </message>
     <message>
         <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
-        <translation>Izinkan koneksi JSON-RPC dari sumber tertentu. Valid untuk &lt;ip&gt; tunggal (e.g. 1.2.3.4), network/netmask (e.g. 1.2.3.4/255.255.255.0) atau network/CIDR (e.g. 1.2.3.4/24). Opsi ini bisa dispesifikan beberapa kali</translation>
+        <translation>Terima koneksi JSON-RPC dari sumber tertentu. Sah untuk &lt;ip&gt; tunggal (contoh. 1.2.3.4), network/netmask (e.g. 1.2.3.4/255.255.255.0) atau network/CIDR (e.g. 1.2.3.4/24). Opsi ini bisa dikhususkan beberapa kali</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Bind to given address and always listen on it. Use [host]:port notation for IPv6</translation>
+        <translation>Kaitkan pada alamat yang diberika ndan selalu mendegarkannya. Gunakan anotasi [host]:port untuk IPv6</translation>
     </message>
     <message>
         <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
-        <translation>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</translation>
+        <translation>Kaitkan pada alamat yang diberikan dan rekan (peers) dapat terhubung dengannya. Guanakan notasi [host]:port untuk IPv6</translation>
     </message>
     <message>
         <source>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
-        <translation>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</translation>
-    </message>
-    <message>
-        <source>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
-        <translation>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</translation>
+        <translation>Kaitkan pada alamat yang diberikan untuk mendengar koneksi JSON-RPC. Gunakan anotasi [host]:port untuk IPv6. Opsi ini dapat dikhususkan beberapa kali (bawaan: kaitkan dengan semua antarmuka)</translation>
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation>Cannot obtain a lock on data directory %s. %s is probably already running.</translation>
+        <translation>Tidak dapat memperoleh kunci dari direktori data %s. %s is kemungkinan karena sudah berjalan.</translation>
     </message>
     <message>
         <source>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
-        <translation>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</translation>
+        <translation>Hubungkan pada node(s) tertentu; -noconnect atau -connect=0 sendiri untuk mematikan koneksi otomatis</translation>
     </message>
     <message>
         <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</translation>
+        <translation>Buat berkas baru dengan hak akses bawaan, dibandingkan dengan mengatur 077 (efektif hanya untuk fungsi dompet yang dimatikan)</translation>
     </message>
     <message>
         <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</translation>
+        <translation>Hapus semua transaksi dompet dan hanya memulihkan bagian rantaiblok melalui -rescan saat aplikasi dimulai</translation>
     </message>
     <message>
         <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
-        <translation>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</translation>
+        <translation>Temukan alamat IP milik sendiri (bawaan: 1 ketika mendengarkan dan -externalip atau -proxy)</translation>
     </message>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation>Distributed under the MIT software license, see the accompanying file %s or %s</translation>
+        <translation>Distribusikan dibawah lisensi perangkat lunak MIT, lihat berkas %s atau %s</translation>
     </message>
     <message>
         <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
-        <translation>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</translation>
+        <translation>Jangan biarkan transaksi dalam mempool bertahan lebih dari &lt;n&gt; jam (bawaan: %u)</translation>
     </message>
     <message>
         <source>Equivalent bytes per sigop in transactions for relay and mining (default: %u)</source>
-        <translation>Equivalent bytes per sigop in transactions for relay and mining (default: %u)</translation>
+        <translation>Kesetaraan bytes per sigop dalam transaksi penyiaran dan menambangan (bawaan: %u)</translation>
     </message>
     <message>
         <source>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</source>
-        <translation>Error loading %s: You can&apos;t enable HD on a already existing non-HD wallet</translation>
+        <translation>Gagal memuat %s: Kamu bisa mengaktifkan HD dalam dompet non-HD</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</translation>
+        <translation>Gagal membaca %s! Semua kunci terbaca dengan benar, namun data transaksi atau isi alamat buku mungkin hilang atau salah.</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation>Error: Listening for incoming connections failed (listen returned error %s)</translation>
+        <translation>Kesalahan: Gagal mendengarkan koneksi yang masuk (menghasilkan kesalahan %s)</translation>
     </message>
     <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</translation>
+        <translation>Jalankan perintah ketika peringatan yang relevan diterima atau ketika fork yang sangat penjang ditemukan (%s dalam cmd akan digantikan dengan sebuah pesan)</translation>
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</translation>
+        <translation>Jalankan perintah ketika sebuah transaksi berubah pada dompet (%s dalam cmd akan digantikan dengan TxID)</translation>
     </message>
     <message>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Execute command when the best block changes (%s in cmd is replaced by block hash)</translation>
+        <translation>Jalankan perintah ketika blok terbaik berubah (%s dalam cmd akan digantikan dengan hash blok)</translation>
     </message>
     <message>
         <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation>Extra transactions to keep in memory for compact block reconstructions (default: %u)</translation>
+        <translation>Transaksi ekstra agar tetap terjaga di memori untuk rekonstruksi blok yang padat (bawaan: %u)</translation>
     </message>
     <message>
         <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</translation>
+        <translation>Biaya (dalam %s/kB) lebih kecil dari nilai ini, dianggap bebas biaya untuk penyiaran, penambangan dan pembuatan transaksi (bawaan: %s)</translation>
     </message>
     <message>
         <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
-        <translation>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</translation>
+        <translation>Biaya (dalam %s/kB) yang lebih kecil dari nilai ini, dianggap bebas biaya untuk pembuatan transaksi (bawaan: %s)</translation>
     </message>
     <message>
         <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</translation>
+        <translation>Pasa penyiaran transaksi dari rekan (peers) yang masuk daftar putih, meskipun mereka melanggar aturan kepenyiaran lokal (bawaan: %d)</translation>
     </message>
     <message>
         <source>Options:</source>
@@ -3308,19 +3304,19 @@
     </message>
     <message>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>Hubungkan ke node untuk menerima alamat rekan (peer), dan putuskan</translation>
+        <translation>Hubungkan ke node untuk menerima alamat rekan (peer), dan kemudian putuskan hubungan</translation>
     </message>
     <message>
         <source>Specify your own public address</source>
-        <translation>Tentukan alamat publik kamu sendiri</translation>
+        <translation>Tentukan alamat publik-mu sendiri</translation>
     </message>
     <message>
         <source>Accept command line and JSON-RPC commands</source>
-        <translation>Menerima baris perintah dan JSON-RPC</translation>
+        <translation>Terima command line dan perintah JSON-RPC</translation>
     </message>
     <message>
         <source>Run in the background as a daemon and accept commands</source>
-        <translation>Berjalan dibelakang sebagai daemon dan menerima perintah</translation>
+        <translation>Berjalan pada latar belakang sebagai daemon dan menerima perintah</translation>
     </message>
     <message>
         <source>Dogecoin Core</source>
@@ -3336,11 +3332,11 @@
     </message>
     <message>
         <source>Connection options:</source>
-        <translation>Pilih koneksi:</translation>
+        <translation>Pilihan koneksi:</translation>
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation>Menemukan basis data blok yang rusak</translation>
+        <translation>Terdeteksi basis data blok yang rusak</translation>
     </message>
     <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
@@ -3348,27 +3344,27 @@
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
-        <translation>Apakah kamu ingin membangun kembali basis data blok sekarang?</translation>
+        <translation>Apakah kamu ingin membangun kembali blokbasis data sekarang?</translation>
     </message>
     <message>
         <source>Error initializing block database</source>
-        <translation>Kesalahan menginisialisasi basis data blok</translation>
+        <translation>Kesalahan menginisialisasi blok basis data</translation>
     </message>
     <message>
         <source>Error initializing wallet database environment %s!</source>
-        <translation>Kesalahan saat menginisialisasi basis data lingkungan dompet %s!</translation>
+        <translation>Kesalahan saat menginisialisasi basis data pada lingkungan dompet %s!</translation>
     </message>
     <message>
         <source>Error loading block database</source>
-        <translation>Gagal memuat basis data blok</translation>
+        <translation>Gagal memuat blok basis data</translation>
     </message>
     <message>
         <source>Error opening block database</source>
-        <translation>Gagal saat membukakan basis data blok</translation>
+        <translation>Gagal saat membukakan blok basis data</translation>
     </message>
     <message>
         <source>Error: Disk space is low!</source>
-        <translation>Gagal: Ruang penyimpan hampir penuh!</translation>
+        <translation>Gagal: Kekurangan ruang penyimpan!</translation>
     </message>
     <message>
         <source>Importing...</source>
@@ -3376,7 +3372,7 @@
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation>Tidak bisa menemukan atau ada kesalahan pada blok penciptaan. Mungkin saja kesalahan mengatur lokasi direktori data untuk jaringan?</translation>
+        <translation>Ada kesalahan atau blok penciptaan tidak ditemukan. Mungkin saja salah mengatur lokasi direktori data jaringan?</translation>
     </message>
     <message>
         <source>Invalid -onion address: '%s'</source>
@@ -3384,11 +3380,11 @@
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
-        <translation>Tidak tersedia berkas deskripsi yang cukup.</translation>
+        <translation>Tidak tersedia berkas descriptor yang cukup.</translation>
     </message>
     <message>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Atur ukuran maksimal untuk blok dalam byte (default: %d)</translation>
+        <translation>Atur ukuran maksimal blok dalam byte (bawaan: %d)</translation>
     </message>
     <message>
         <source>Specify wallet file (within data directory)</source>
@@ -3396,7 +3392,7 @@
     </message>
     <message>
         <source>Verifying blocks...</source>
-        <translation>Blok-blok sedang diverifikasi...</translation>
+        <translation>Memverifikasi beberapa blok...</translation>
     </message>
     <message>
         <source>Verifying wallet...</source>
@@ -3404,7 +3400,7 @@
     </message>
     <message>
         <source>Wallet %s resides outside data directory %s</source>
-        <translation>Dompet %s ada di luar direktori data %s</translation>
+        <translation>Dompet %s berada di luar direktori data %s</translation>
     </message>
     <message>
         <source>Wallet options:</source>
@@ -3428,27 +3424,27 @@
     </message>
     <message>
         <source>Rescan the block chain for missing wallet transactions on startup</source>
-        <translation>Pindai ulang block chain saat memulai, untuk menemukan transaksi yang hilang</translation>
+        <translation>Pindai ulang rantai blok saat memulai, untuk menemukan transaksi yang hilang</translation>
     </message>
     <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
-        <translation>Kirim info jejak/debug ke konsol bukan ke berkas debug.log</translation>
+        <translation>Kirimkan informasi jejak/informasi debug ke konsol bukan ke berkas debug.log</translation>
     </message>
     <message>
         <source>Send transactions as zero-fee transactions if possible (default: %u)</source>
-        <translation>Jika memungkinkan, kirim transaksi sebagai transaksi bebas biaya (default: %u)</translation>
+        <translation>Jika memungkinkan, kirim transaksi sebagai transaksi bebas biaya (bawaan: %u)</translation>
     </message>
     <message>
         <source>Show all debugging options (usage: --help -help-debug)</source>
-        <translation>Tampilkan semua opsi debug (penggunaan: --help -help-debug)</translation>
+        <translation>Tampilkan semua opsi debug (cara penggunaan: --help -help-debug)</translation>
     </message>
     <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Kecilkan berkas debug.log saat klien memulai (default: 1 jika tidak -debug)</translation>
+        <translation>Kecilkan berkas debug.log saat aplikasi klien dimulai (bawaan: 1 jika tanpa -debug)</translation>
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation>Tanda tangani transaksi gagal</translation>
+        <translation>Penandatanganan transaksi gagal</translation>
     </message>
     <message>
         <source>Transaction amount too small</source>
@@ -3476,7 +3472,7 @@
     </message>
     <message>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Menjalankan perintah ketika perubahan terjadi pada blok terbaik (%s dalam cmd digantikan oleh hash blok)</translation>
+        <translation>Menjalankan perintah ketika perubahan terjadi pada blok terbaik (%s dalam cmd akan digantikan oleh blok hash)</translation>
     </message>
     <message>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
@@ -3484,7 +3480,7 @@
     </message>
     <message>
         <source>Loading addresses...</source>
-        <translation>Memuat alamat...</translation>
+        <translation>Memuat daftar alamat...</translation>
     </message>
     <message>
         <source>Invalid -proxy address: '%s'</source>
@@ -3492,7 +3488,7 @@
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation>Jaringan tidak diketahui dalam -onlynet: '%s'</translation>
+        <translation>Sebuah jaringan tak dikenal dalam -onlynet: '%s'</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
@@ -3516,7 +3512,7 @@
     </message>
     <message>
         <source>Cannot write default address</source>
-        <translation>Tidak dapat menyimpan alamat standar</translation>
+        <translation>Tidak dapat menyimpan alamat bawaan</translation>
     </message>
     <message>
         <source>Rescanning...</source>
@@ -3524,7 +3520,7 @@
     </message>
     <message>
         <source>Done loading</source>
-        <translation>Memuat selesai</translation>
+        <translation>Selesai memuat</translation>
     </message>
     <message>
         <source>Error</source>


### PR DESCRIPTION
Fixing some translation. Really need your help to review the code. Thanks.

Changes in this PR:
- [x] Syncing with `bitcoin_en.ts`
- [x] Replacing `Anda` with `Kamu` for more casual translation 
- [x] Reordering follows `bitcoin_en.ts` order 
- [x] Fixing some typos 
- [x] Finishing `<name>dogecoin-core</name>` section.