### PR TITLE
Fixing travis.yml build errors - replaced trusty with bionic in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 os: linux
 language: generic
 cache:


### PR DESCRIPTION
[![Build Status](https://travis-ci.com/xtemp3r/dogecoin.svg?branch=master)](https://travis-ci.com/xtemp3r/dogecoin)

changing the distribution from trusty to bionic so it fixed 5 out of 7 build errors because of it.