### PR TITLE
Travis: switch back to trusty and remove useless repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 os: linux
 language: minimal
 cache:
@@ -41,6 +41,7 @@ before_install:
 install:
     - if [ -n "$PPA" ]; then travis_retry sudo add-apt-repository "$PPA" -y; fi
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
+    - if [ -n "$PACKAGES" ]; then sudo rm -rf /etc/apt/sources.list.d/*; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
     - if [ "$RUN_TESTS" = "true" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq python3-dev; fi


### PR DESCRIPTION
The mingw compiler in bionic seems to be having the same issues that xenial had. Given the actual reason our builds failed with trusty was just a 404 in pgsql's apt repo the simple fix is just not querying these repos. As a precaution cause other vendors might be removing their trusty repos, all 3rd party sources are removed before apt is called.

This has the added advantage that travis stays in line with gitian for this branch.