### PR TITLE
Rebase for feature #1991 to branch dev-1.21

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -490,6 +490,7 @@ libbitcoin_common_a_SOURCES = \
   compressor.cpp \
   core_read.cpp \
   core_write.cpp \
+  dogequirks.cpp \
   key.cpp \
   key_io.cpp \
   merkleblock.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -187,7 +187,6 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 BITCOIN_TEST_SUITE = \
   test/main.cpp \
   $(TEST_UTIL_H)
-
 FUZZ_SUITE_LD_COMMON = \
  $(LIBBITCOIN_SERVER) \
  $(LIBBITCOIN_COMMON) \
@@ -234,6 +233,9 @@ BITCOIN_TESTS =\
   test/descriptor_tests.cpp \
   test/flatfile_tests.cpp \
   test/fs_tests.cpp \
+  test/DoS_tests.cpp \
+  test/dogecoin_tests.cpp \
+  test/dogequirks_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/interfaces_tests.cpp \

--- a/src/dogequirks.cpp
+++ b/src/dogequirks.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Dogecoin Core developers
+// Portiosn Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Inspired from Original althorithm posted to voidware.com/moon_phase.htm. 
+#include "dogequirks.h"
+#include<stdio.h>
+
+int CDogeQuirks::moon_phase(int year, int month, int day)
+{
+    /*
+      calculates the moon phase. Returns a number between 0 and 7.
+      where:
+      0 =  new moon.
+      4 = full moon.
+
+      Approximite cycle of each segment about 3 days. 0 and 8 are the same.
+      */
+
+    const double DAYS_IN_YEAR = 365.25;
+    const double MOON_PERIOD=  29.53;
+    const double AVG_DAYS_IN_MONTH=30.6;
+
+    int num_days_year_part;
+    int num_days_month_part;
+    double total_days_elapsed;
+    double total_cycles_elapsed;
+    int total_cycles_elapsed_floor;
+    double total_cycles_remainder;
+    int final_cycle;
+
+    if (month < 3) {
+        year--;
+        month += 12;
+    }
+    month++;
+    num_days_year_part = year * DAYS_IN_YEAR;
+    num_days_month_part = month * AVG_DAYS_IN_MONTH;
+
+    total_days_elapsed = num_days_year_part +num_days_month_part +day-694039.09;  /* sneaky way to factor in sun position */
+    total_cycles_elapsed = total_days_elapsed / MOON_PERIOD; //ie:   (29.53 days) */
+    total_cycles_elapsed_floor = total_cycles_elapsed; /* cast to int to make floor */
+    total_cycles_remainder = total_cycles_elapsed - total_cycles_elapsed_floor;
+    final_cycle = total_cycles_remainder *8 + 0.5; /* count up to nearest int */
+    final_cycle = final_cycle & 7;		   /* 0 and 8 are the same so turn 8 into 0 */
+    return final_cycle;
+}
+
+

--- a/src/dogequirks.h
+++ b/src/dogequirks.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//This file is a little placeholder for 'quirks' that make Dogecoin
+//stand out from other cyprtos
+
+#include<stdio.h>
+
+struct  CDogeQuirks
+{
+static int moon_phase(int y, int m, int d);
+};

--- a/src/test/dogequirks_tests.cpp
+++ b/src/test/dogequirks_tests.cpp
@@ -1,0 +1,36 @@
+#include "test/test_bitcoin.h"
+#include "dogequirks.h"
+#include <boost/test/unit_test.hpp>
+BOOST_FIXTURE_TEST_SUITE(dogequirks_tests, BasicTestingSetup)
+
+inline int date_test(const char *date)
+{
+int year;
+int month;
+int day;
+sscanf(date, "%2d/%2d/%4d", &month,&day,&year);
+int phase=CDogeQuirks::moon_phase(year,month,day);
+return phase;
+}
+
+
+BOOST_AUTO_TEST_CASE(data_access_test)
+{
+//Test some "random" moon dates to see everything is working
+
+//Date of creating this test case
+
+BOOST_CHECK(date_test("5/23/2021") == 3); // not quite the full moon yet
+BOOST_CHECK(date_test("5/25/2008") == 6); // #GeekPower
+BOOST_CHECK(date_test("5/26/2021") == 4); // Actual full moon (and full lunar eclipse too!)
+BOOST_CHECK(date_test("5/28/2021") == 5); // Just after the full moon
+BOOST_CHECK(date_test("5/16/1976") == 5); // somebodys birthday maybe?
+BOOST_CHECK(date_test("2/29/1980") == 4); // birth of an awesome leap year baby
+BOOST_CHECK(date_test("6/22/2002") == 3); // wedding day
+BOOST_CHECK(date_test("5/4/2011") == 1);  // RD2D/C3PO
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -9,6 +9,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <optional.h>
+#include "dogequirks.h"
 #include <validation.h>
 #include <policy/policy.h>
 #include <policy/fees.h>
@@ -999,12 +1000,24 @@ void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
 
 CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
     LOCK(cs);
+
+
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 
     int64_t time = GetTime();
+    int year;
+    int month;
+    int day;
+    const char *nowdt = FormatISO8601DateTime(time).c_str();
+    sscanf(nowdt, "%4d-%2d-%2d", &year,&month,&day);
+    int moon_phase=CDogeQuirks::moon_phase(year,month,day);
+
+
     if (time > lastRollingFeeUpdate + 10) {
         double halflife = ROLLING_FEE_HALFLIFE;
+	if (moon_phase == 4 && PROPOSED_TX_FEE == 0 ) rollingMinimumFeeRate = rollingMinimumFeeRate /2;
+	else if (moon_phase == 4) rollingMinimumFeeRate = PROPOSED_TX_FEE;
         if (DynamicMemoryUsage() < sizelimit / 4)
             halflife /= 4;
         else if (DynamicMemoryUsage() < sizelimit / 2)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -34,6 +34,22 @@ extern RecursiveMutex cs_main;
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
+// Set to non-zero to use this instead of halving at full moon (see 1991)
+static const unsigned int PROPOSED_TX_FEE = 0;
+
+inline double AllowFreeThreshold()
+{
+    return COIN * 144 / 250;
+}
+
+inline bool AllowFree(double dPriority)
+{
+    // Large (in bytes) low-priority (new, small-coin) transactions
+    // need a fee.
+    return dPriority > AllowFreeThreshold();
+}
+
+
 struct LockPoints
 {
     // Will be set to the blockchain height and median time past


### PR DESCRIPTION
This is the rebase for #1991 in branch dev-1.2.1

==
This is the pull request for #1991. It implements a new 'dogequirks' class that can be extended to specific doge coin items without (hopefully) to much disturbance to keeping aligned upstream.

I am not 100% sure I got the GetMinFee procedure correct. If I understand it correctly it halves on each call, so I may not have put the moon_phase code in exactly the 'right' spot, it's a little hard to test.

Perhaps it should also be (or only be) in miner.cpp

```
if (IsArgSet("-blockmintxfee")) {
        CAmount n = 0;
        ParseMoney(GetArg("-blockmintxfee", ""), n);
        blockMinFeeRate = CFeeRate(n);
    } else {
        blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
        **// Add moon check code here??**
         
    }


```
Appropriate unit test class has been added as well, the specific unit test works but I re-ran all (now 254) unit tests and many failed which seem to have nothing to do with my change, some unit test clean up maybe required?

Required Testing: / Test Plan

a) Verify the calculation of the transaction fee calculated on one of the '3' days of 'full moon' show at approx. half the rate as the other days of the month

b) Try changing the constant "PROPOSED_TX_FEE" to a non-zero, in mem-pool.h. Does the tx fee then become the proposed fee when preforming a calculation

c) What happens if the minrate is really low, and then gets halved, will the function still work correctly with very small 0.000000001 fees?