### PR TITLE
Removing GetBlockSubsidy (no use), already replaced by GetDogecoinBlo…

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1197,19 +1197,6 @@ bool ReadBlockHeaderFromDisk(CBlockHeader& block, const CBlockIndex* pindex, con
     return ReadBlockOrHeader(block, pindex, consensusParams, fCheckPOW);
 }
 
-CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
-{
-    int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
-    // Force block reward to zero when right shift is undefined.
-    if (halvings >= 64)
-        return 0;
-
-    CAmount nSubsidy = 50 * COIN;
-    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
-    nSubsidy >>= halvings;
-    return nSubsidy;
-}
-
 bool IsInitialBlockDownload()
 {
     const CChainParams& chainParams = Params();


### PR DESCRIPTION
Removing GetBlockSubsidy (no use), already replaced by GetDogecoinBlockSubsidy

Cleaning the code