### PR TITLE
Removing GetBlockSubsidy (no use), already replaced by GetDogecoinBlo…

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -280,7 +280,6 @@ std::string GetWarnings(const std::string& strFor);
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
-CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
 double GuessVerificationProgress(const ChainTxData& data, CBlockIndex* pindex);


### PR DESCRIPTION
Removing GetBlockSubsidy (no use), already replaced by GetDogecoinBlockSubsidy

Cleaning Code