### PR TITLE
Sync nodes before maturing blocks in bumpfee

### DIFF
--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -66,6 +66,7 @@ class BumpFeeTest(BitcoinTestFramework):
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
         self.log.info("Mining blocks...")
         peer_node.generate(110)
+        self.sync_all()
         # Dogecoin: Coinbase maturity is much higher, so we mine to the RBF node for funding
         rbf_node.generate(140)
         self.sync_all()


### PR DESCRIPTION
In Dogecoin we have a much higher coinbase maturity value, so we need a lot more blocks after a block was mined, to be able to spend it. In `wallet_bumpfee` I solved this by having another node mine after the node which receives the blocks, however as the network doesn't sync before changing which node is mining, potentially this is leading to a race condition.

Opening this as a potential solution, but primarily to verify on Travis.
