### PR TITLE
Update block generation constants in wallet_bumpfee

### DIFF
--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -60,7 +60,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.log.info("Mine enough blocks to reach the NODE_NETWORK_LIMITED range.")
         self.connect_nodes(0, 1)
         blocks = self.nodes[1].generatetoaddress(292, self.nodes[1].get_deterministic_priv_key().address)
-        self.sync_blocks([self.nodes[0], self.nodes[1]])
+        self.sync_blocks([self.nodes[0], self.nodes[1]], timeout=5)
 
         self.log.info("Make sure we can max retrieve block at tip-288.")
         node.send_getdata_for_block(blocks[1])  # last block in valid range
@@ -95,7 +95,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.connect_nodes(1, 2)
 
         # sync must be possible
-        self.sync_blocks()
+        self.sync_blocks(timeout=5)
 
         # disconnect all peers
         self.disconnect_all()
@@ -107,7 +107,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
 
         # sync must be possible, node 1 is no longer in IBD and should therefore connect to node 0 (NODE_NETWORK_LIMITED)
-        self.sync_blocks([self.nodes[0], self.nodes[1]])
+        self.sync_blocks([self.nodes[0], self.nodes[1]], timeout=5)
 
 if __name__ == '__main__':
     NodeNetworkLimitedTest().main()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -65,9 +65,7 @@ class BumpFeeTest(BitcoinTestFramework):
 
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
         self.log.info("Mining blocks...")
-        peer_node.generate(110)
-        # Dogecoin: Coinbase maturity is much higher, so we mine to the RBF node for funding
-        rbf_node.generate(140)
+        peer_node.generate(250)
         self.sync_all()
         for _ in range(25):
             peer_node.sendtoaddress(rbf_node_address, 0.001)
@@ -510,7 +508,7 @@ def test_unconfirmed_not_spendable(self, rbf_node, rbf_node_address):
 def test_bumpfee_metadata(self, rbf_node, dest_address):
     self.log.info('Test that bumped txn metadata persists to new txn record')
     assert(rbf_node.getbalance() < 49)
-    rbf_node.generatetoaddress(101, rbf_node.getnewaddress())
+    rbf_node.generatetoaddress(241, rbf_node.getnewaddress())
     rbfid = rbf_node.sendtoaddress(dest_address, 49, "comment value", "to value")
     bumped_tx = rbf_node.bumpfee(rbfid)
     bumped_wtx = rbf_node.gettransaction(bumped_tx["txid"])


### PR DESCRIPTION
* Remove early block generation by RBF node (introduced earlier in 1.21 cycle).
* Increase block generation values from original test, to meet Dogecoin coinbase maturity requirements.