### PR TITLE
Added additional information to help new developers navigate first builds in Windows

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -96,6 +96,9 @@ results in `Autoconf` configure scripts being able to execute Windows Portable E
 unexpected behaviour during the build, such as Win32 error dialogs for missing libraries. The recommended approach
 is to temporarily disable WSL support for Win32 applications.
 
+Note that if you are are running into the following errors while running `make HOST=x86_64-w64-mingw32`, ensure that your Line endings are set to LF (Linux) and not CLRF (Windows).
+> ./config.sub: 80: Syntax error: word unexpected (expecting "in")
+
 Build using:
 
     PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var


### PR DESCRIPTION
I have added an additional piece of information to the documentation to assist new developers like myself with building for the first time.

Related issue: #2138
