### PR TITLE
Fix errors of bitcoin_ko_KR.ts file

### DIFF
--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -1,0 +1,3905 @@
+<TS language="ko_KR" version="2.1">
+<context>
+    <name>AddressBookPage</name>
+    <message>
+        <source>Right-click to edit address or label</source>
+        <translation>지갑 주소나 라벨을 수정하려면 우클릭하세요.</translation>
+    </message>
+    <message>
+        <source>Create a new address</source>
+        <translation>새 주소 만들기</translation>
+    </message>
+    <message>
+        <source>&amp;New</source>
+        <translation>새 항목(&amp;N)</translation>
+    </message>
+    <message>
+        <source>Copy the currently selected address to the system clipboard</source>
+        <translation>현재 선택한 주소를 시스템 클립보드로 복사하기</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation>복사(&amp;C)</translation>
+    </message>
+    <message>
+        <source>C&amp;lose</source>
+        <translation>닫기(&amp;L)</translation>
+    </message>
+    <message>
+        <source>Delete the currently selected address from the list</source>
+        <translation>현재 목록에서 선택한 주소 삭제</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>현재 탭에 있는 데이터를 파일로 내보내기</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>내보내기(&amp;E)</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>삭제(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Choose the address to send coins to</source>
+        <translation>코인을 보낼 주소를 선택하세요</translation>
+    </message>
+    <message>
+        <source>Choose the address to receive coins with</source>
+        <translation>코인을 받을 주소를 선택하세요</translation>
+    </message>
+    <message>
+        <source>C&amp;hoose</source>
+        <translation>선택(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Such sending addresses</source>
+        <translation>보내는 주소들</translation>
+    </message>
+    <message>
+        <source>Much receiving addresses</source>
+        <translation>받는 주소들</translation>
+    </message>
+    <message>
+        <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation>도지코인을 보내는 계좌 주소입니다. 코인을 보내기 전에 잔고와 받는 주소를 항상 확인하세요.</translation>
+    </message>
+    <message>
+        <source>These are your Dogecoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
+        <translation>지불액을 받기 위한 도지코인 주소들이 있습니다. 각 거래마다 새로운 주소 사용을 권장합니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Address</source>
+        <translation>계좌 복사(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Label</source>
+        <translation>라벨 복사(&amp;L)</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>편집(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Export Address List</source>
+        <translation>주소 목록 내보내기</translation>
+    </message>
+    <message>
+        <source>Comma separated file (*.csv)</source>
+        <translation>쉼표로 구분된 파일(*.csv)</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation>내보내기 실패</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the address list to %1. Please try again.</source>
+        <translation>%1 에 주소 리스트를 저장하는 동안 오류가 발생했습니다. 다시 시도해주세요.</translation>
+    </message>
+</context>
+<context>
+    <name>AddressTableModel</name>
+    <message>
+        <source>Label</source>
+        <translation>라벨</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation>주소</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation>(라벨 없음)</translation>
+    </message>
+</context>
+<context>
+    <name>AskPassphraseDialog</name>
+    <message>
+        <source>Passphrase Dialog</source>
+        <translation>비밀번호 대화상자</translation>
+    </message>
+    <message>
+        <source>Enter passphrase</source>
+        <translation>비밀번호 입력하기</translation>
+    </message>
+    <message>
+        <source>New passphrase</source>
+        <translation>새로운 비밀번호</translation>
+    </message>
+    <message>
+        <source>Repeat new passphrase</source>
+        <translation>새로운 비밀번호 재확인</translation>
+    </message>
+    <message>
+        <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
+        <translation>지갑에 새로운 비밀번호를 입력하세요.&lt;br/&gt;비밀번호를 &lt;b&gt;열 개 이상의 무작위 글자&lt;/b&gt; 혹은 &lt;b&gt;여덟개 이상의 단어로&lt;b&gt; 정하세요.</translation>
+    </message>
+    <message>
+        <source>Encrypt wallet</source>
+        <translation>지갑 암호화</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to unlock the wallet.</source>
+        <translation>이 작업을 실행하려면 사용자 지갑의 비밀번호가 필요합니다.</translation>
+    </message>
+    <message>
+        <source>Unlock wallet</source>
+        <translation>지갑 잠금 해제</translation>
+    </message>
+    <message>
+        <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
+        <translation>이 작업은 지갑을 복호화하기 위해 사용자 지갑의 비밀번호가 필요합니다.</translation>
+    </message>
+    <message>
+        <source>Decrypt wallet</source>
+        <translation>지갑 복호화</translation>
+    </message>
+    <message>
+        <source>Change passphrase</source>
+        <translation>비밀번호 변경</translation>
+    </message>
+    <message>
+        <source>Enter the old passphrase and new passphrase to the wallet.</source>
+        <translation>지갑의 기존 비밀번호와 새로운 비밀번호를 입력해주세요.</translation>
+    </message>
+    <message>
+        <source>Confirm wallet encryption</source>
+        <translation>지갑 암호화 확인</translation>
+    </message>
+    <message>
+        <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR DOGECOINS&lt;/b&gt;!</source>
+        <translation>경고: 만약 암호화된 지갑의 비밀번호를 잃어버릴 경우, &lt;b&gt;모든 도지코인을 잃어버릴 수 있습니다&lt;/b&gt;!</translation>
+    </message>
+    <message>
+        <source>Are you sure you wish to encrypt your wallet?</source>
+        <translation>지갑 암호화를 진행하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Wallet encrypted</source>
+        <translation>지갑 암호화 완료</translation>
+    </message>
+    <message>
+        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your dogecoins from being stolen by malware infecting your computer.</source>
+        <translation>암호화 처리 과정을 끝내기 위해 %1 을/를 종료합니다. 지갑 암호화는 컴퓨터를 감염시키는 악성 코드로 인해 도지코인 도난당하는 것을 온전히 보호할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
+        <translation>중요: 본인 지갑 파일에서 만든 예전 백업들은 새로 생성한 암호화된 지갑 파일로 교체됩니다. 보안상 이유로 이전에 암호화하지 않은 지갑 파일 백업은 사용할 수 없게 되니 이른 시일 내로 새로 암호화된 지갑을 사용하시기 바랍니다.</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed</source>
+        <translation>지갑 암호화 실패</translation>
+    </message>
+    <message>
+        <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
+        <translation>지갑 암호화는 내부 오류로 인해 실패했습니다. 당신의 지갑은 암호화되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>The supplied passphrases do not match.</source>
+        <translation>입력한 비밀번호가 일치하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock failed</source>
+        <translation>지갑 잠금 해제 실패</translation>
+    </message>
+    <message>
+        <source>The passphrase entered for the wallet decryption was incorrect.</source>
+        <translation>지갑 복호화를 위한 비밀번호가 틀렸습니다.</translation>
+    </message>
+    <message>
+        <source>Wallet decryption failed</source>
+        <translation>지갑 복호화 실패</translation>
+    </message>
+    <message>
+        <source>Wallet passphrase was successfully changed.</source>
+        <translation>지갑 비밀번호가 성공적으로 변경되었습니다.</translation>
+    </message>
+    <message>
+        <source>Warning: The Caps Lock key is on!</source>
+        <translation>경고: Caps Lock 키가 켜져 있습니다!</translation>
+    </message>
+</context>
+<context>
+    <name>BanTableModel</name>
+    <message>
+        <source>IP/Netmask</source>
+        <translation>IP 주소/넷마스크</translation>
+    </message>
+    <message>
+        <source>Banned Until</source>
+        <translation>다음과 같은 상황이 될 때까지 계정이 정지됩니다.</translation>
+    </message>
+</context>
+<context>
+    <name>DogecoinGUI</name>
+    <message>
+        <source>Sign &amp;message...</source>
+        <translation>메시지 서명(&amp;M)...</translation>
+    </message>
+    <message>
+        <source>Synchronizing with network...</source>
+        <translation>네트워크와 동기화 중...</translation>
+    </message>
+    <message>
+        <source>&amp;Wow</source>
+        <translation>개요(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Node</source>
+        <translation>노드</translation>
+    </message>
+    <message>
+        <source>Show general overview of wallet</source>
+        <translation>지갑의 일반적인 개요를 보여줍니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Transactions</source>
+        <translation>거래(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Browse transaction history</source>
+        <translation>거래 내역을 검색합니다.</translation>
+    </message>
+    <message>
+        <source>E&amp;xit</source>
+        <translation>나가기(&amp;X)</translation>
+    </message>
+    <message>
+        <source>Quit application</source>
+        <translation>애플리케이션 종료</translation>
+    </message>
+    <message>
+        <source>&amp;About %1</source>
+        <translation>%1 정보(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Show information about %1</source>
+        <translation>%1 정보를 표시합니다</translation>
+    </message>
+    <message>
+        <source>About &amp;Qt</source>
+        <translation>&amp;Qt 정보</translation>
+    </message>
+    <message>
+        <source>Show information about Qt</source>
+        <translation>Qt 정보를 표시합니다</translation>
+    </message>
+    <message>
+        <source>&amp;Options...</source>
+        <translation>옵션(&amp;O)</translation>
+    </message>
+    <message>
+        <source>Modify configuration options for %1</source>
+        <translation>%1 설정 옵션 수정</translation>
+    </message>
+    <message>
+        <source>&amp;Encrypt Wallet...</source>
+        <translation>지갑 암호화(&amp;E)...</translation>
+    </message>
+    <message>
+        <source>&amp;Backup Wallet...</source>
+        <translation>지갑 백업(&amp;B)...</translation>
+    </message>
+    <message>
+        <source>&amp;Change Passphrase...</source>
+        <translation>비밀번호 변경(&amp;C)...</translation>
+    </message>
+    <message>
+        <source>&amp;Such sending addresses...</source>
+        <translation>보내는 주소(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Much receiving addresses...</source>
+        <translation>받는 주소(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Open &amp;URI...</source>
+        <translation>&amp;URI 열기...</translation>
+    </message>
+    <message>
+        <source>Click to disable network activity.</source>
+        <translation>네트워크 활동을 중지하려면 클릭하세요.</translation>
+    </message>
+    <message>
+        <source>Network activity disabled.</source>
+        <translation>네트워크 활동이 중지되었습니다.</translation>
+    </message>
+    <message>
+        <source>Click to enable network activity again.</source>
+        <translation>네트워크 활동을 다시 시작하려면 클릭하세요.</translation>
+    </message>
+    <message>
+        <source>Syncing Headers (%1%)...</source>
+        <translation>헤더 동기화 중(%1%)...</translation>
+    </message>
+    <message>
+        <source>Reindexing blocks on disk...</source>
+        <translation>디스크에서 블록 다시 색인 중...</translation>
+    </message>
+    <message>
+        <source>Send coins to a Dogecoin address</source>
+        <translation>도지코인 주소로 코인 보내기</translation>
+    </message>
+    <message>
+        <source>Backup wallet to another location</source>
+        <translation>지갑을 다른 장소에 백업</translation>
+    </message>
+    <message>
+        <source>Change the passphrase used for wallet encryption</source>
+        <translation>지갑 암호화에 사용되는 비밀번호 변경</translation>
+    </message>
+    <message>
+        <source>&amp;Debug window</source>
+        <translation>디버그 창(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Open debugging and diagnostic console</source>
+        <translation>디버깅 및 진단 콘솔 열기</translation>
+    </message>
+    <message>
+        <source>&amp;Verify message...</source>
+        <translation>메시지 확인(&amp;V)...</translation>
+    </message>
+    <message>
+        <source>Dogecoin</source>
+        <translation>도지코인</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation>지갑</translation>
+    </message>
+    <message>
+        <source>&amp;Such Send</source>
+        <translation>보내기(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Much Receive</source>
+        <translation>받기(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Show / Hide</source>
+        <translation>보이기 / 숨기기(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Show or hide the main Window</source>
+        <translation>메인 창 보이기 또는 숨기기</translation>
+    </message>
+    <message>
+        <source>Encrypt the private keys that belong to your wallet</source>
+        <translation>지갑에 포함된 개인 키 암호화하기</translation>
+    </message>
+    <message>
+        <source>Sign messages with your Dogecoin addresses to prove you own them</source>
+        <translation>도지코인 주소로 메시지에 서명하여 소유함을 증명하기</translation>
+    </message>
+    <message>
+        <source>Verify messages to ensure they were signed with specified Dogecoin addresses</source>
+        <translation>지정된 도지코인 주소로 메시지가 서명되었는지 확인하기</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>파일(&amp;F)</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>설정(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>도움말(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Tabs toolbar</source>
+        <translation>툴바 색인표</translation>
+    </message>
+    <message>
+        <source>Request payments (generates QR codes and dogecoin: URIs)</source>
+        <translation>지불 요청하기(QR 코드와 dogecoin: URI 생성)</translation>
+    </message>
+    <message>
+        <source>Show the list of used sending addresses and labels</source>
+        <translation>한 번 이상 사용된 보내는 주소와 라벨의 목록 보기</translation>
+    </message>
+    <message>
+        <source>Show the list of used receiving addresses and labels</source>
+        <translation>한 번 이상 사용된 받는 주소와 라벨의 목록 보기</translation>
+    </message>
+    <message>
+        <source>Open a dogecoin: URI or payment request</source>
+        <translation>dogecoin: URI 또는 지불 요청 열기</translation>
+    </message>
+    <message>
+        <source>&amp;Command-line options</source>
+        <translation>커맨드라인 옵션(&amp;C)</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Dogecoin network</source>
+        <translation><numerusform>도지코인 네트워크에 %n 개의 연결이 활성화되어 있음</numerusform></translation>
+    </message>
+    <message>
+        <source>Indexing blocks on disk...</source>
+        <translation>디스크에서 블록 색인 중...</translation>
+    </message>
+    <message>
+        <source>Processing blocks on disk...</source>
+        <translation>디스크에서 블록 처리 중...</translation>
+    </message>
+    <message numerus="yes">
+        <source>Processed %n block(s) of transaction history.</source>
+        <translation><numerusform>%n 블록 만큼의 거래 기록이 처리되었습니다.</numerusform></translation>
+    </message>
+    <message>
+        <source>%1 behind</source>
+        <translation>%1 뒤에</translation>
+    </message>
+    <message>
+        <source>Last received block was generated %1 ago.</source>
+        <translation>최근에 받은 블록은 %1 전에 생성되었습니다.</translation>
+    </message>
+    <message>
+        <source>Transactions after this will not yet be visible.</source>
+        <translation>이 이후의 거래는 아직 표시되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <source>Up to date</source>
+        <translation>최신 정보</translation>
+    </message>
+    <message>
+        <source>Show the %1 help message to get a list with possible Dogecoin command-line options</source>
+        <translation>사용할 수 있는 도지코인 커맨드라인 옵션 목록을 가져오기 위해 %1 도움말 메시지 표시하기</translation>
+    </message>
+    <message>
+        <source>%1 client</source>
+        <translation>%1 클라이언트</translation>
+    </message>
+    <message>
+        <source>Connecting to peers...</source>
+        <translation>피어에 연결 중...</translation>
+    </message>
+    <message>
+        <source>Catching up...</source>
+        <translation>블록 따라잡기...</translation>
+    </message>
+    <message>
+        <source>Date: %1
+</source>
+        <translation>날짜: %1
+</translation>
+    </message>
+    <message>
+        <source>Amount: %1
+</source>
+        <translation>금액: %1
+</translation>
+    </message>
+    <message>
+        <source>Type: %1
+</source>
+        <translation>종류: %1
+</translation>
+    </message>
+    <message>
+        <source>Label: %1
+</source>
+        <translation>라벨: %1
+</translation>
+    </message>
+    <message>
+        <source>Address: %1
+</source>
+        <translation>주소: %1
+</translation>
+    </message>
+    <message>
+        <source>Sent transaction</source>
+        <translation>거래 보내기</translation>
+    </message>
+    <message>
+        <source>Incoming transaction</source>
+        <translation>들어오는 거래</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
+        <translation>HD 키 생성이 &lt;b&gt;활성화됨&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
+        <translation>HD 키 생성이 &lt;b&gt;비활성화됨&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
+        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt;되었고 현재 &lt;b&gt;잠금 해제&lt;/b&gt;됨</translation>
+    </message>
+    <message>
+        <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
+        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt;되었고 현재 &lt;b&gt;잠금 상태&lt;/b&gt;임</translation>
+    </message>
+    <message>
+        <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
+        <translation>치명적인 오류가 발생했습니다. 도지코인을 더는 안전하게 진행할 수 없어 곧 종료합니다.</translation>
+    </message>
+</context>
+<context>
+    <name>CoinControlDialog</name>
+    <message>
+        <source>Coin Selection</source>
+        <translation>코인 선택</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation>수량:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation>바이트:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation>금액:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation>수수료:</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation>더스트:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation>수수료 이후:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation>잔돈:</translation>
+    </message>
+    <message>
+        <source>(un)select all</source>
+        <translation>모두 선택(하지 않음)</translation>
+    </message>
+    <message>
+        <source>Tree mode</source>
+        <translation>트리 모드</translation>
+    </message>
+    <message>
+        <source>List mode</source>
+        <translation>리스트 모드</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation>거래액</translation>
+    </message>
+    <message>
+        <source>Received with label</source>
+        <translation>라벨로 받은 금액</translation>
+    </message>
+    <message>
+        <source>Received with address</source>
+        <translation>주소로 받은 금액</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>날짜</translation>
+    </message>
+    <message>
+        <source>Confirmations</source>
+        <translation>확인</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation>확인됨</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation>주소 복사</translation>
+    </message>
+    <message>
+        <source>Copy label</source>
+        <translation>라벨 복사</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>거래액 복사</translation>
+    </message>
+    <message>
+        <source>Copy transaction ID</source>
+        <translation>거래 ID 복사</translation>
+    </message>
+    <message>
+        <source>Lock unspent</source>
+        <translation>사용되지 않은 주소 잠금 처리</translation>
+    </message>
+    <message>
+        <source>Unlock unspent</source>
+        <translation>사용되지 않은 주소 잠금 해제</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation>수량 복사</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation>수수료 복사</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation>수수료 이후 복사</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation>바이트 복사</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation>더스트 복사</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation>잔돈 복사</translation>
+    </message>
+    <message>
+        <source>(%1 locked)</source>
+        <translation>(%1 잠금)</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation>예</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation>아니오</translation>
+    </message>
+    <message>
+        <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
+        <translation>수령인이 현재 더스트 임계값보다 적은 양을 수신하면 이 라벨이 빨간색으로 변합니다.</translation>
+    </message>
+    <message>
+        <source>Can vary +/- %1 koinu(s) per input.</source>
+        <translation>입력마다 +/- %1 코이누가 변할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation>(라벨 없음)</translation>
+    </message>
+    <message>
+        <source>change from %1 (%2)</source>
+        <translation>%1 (으)로부터 변경(%2)</translation>
+    </message>
+    <message>
+        <source>(change)</source>
+        <translation>(잔돈)</translation>
+    </message>
+</context>
+<context>
+    <name>EditAddressDialog</name>
+    <message>
+        <source>Edit Address</source>
+        <translation>주소 편집</translation>
+    </message>
+    <message>
+        <source>&amp;Label</source>
+        <translation>라벨(&amp;L)</translation>
+    </message>
+    <message>
+        <source>The label associated with this address list entry</source>
+        <translation>현재 선택된 주소 필드의 라벨</translation>
+    </message>
+    <message>
+        <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
+        <translation>이 주소록 항목과 관련된 주소입니다. 보내는 주소만 수정할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Address</source>
+        <translation>주소(&amp;A)</translation>
+    </message>
+    <message>
+        <source>New receiving address</source>
+        <translation>새로운 받는 주소</translation>
+    </message>
+    <message>
+        <source>New sending address</source>
+        <translation>새로운 보내는 주소</translation>
+    </message>
+    <message>
+        <source>Edit receiving address</source>
+        <translation>받는 주소 편집</translation>
+    </message>
+    <message>
+        <source>Edit sending address</source>
+        <translation>보내는 주소 편집</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is not a valid Dogecoin address.</source>
+        <translation>입력한 "%1" 주소는 올바른 도지코인 주소가 아닙니다.</translation>
+    </message>
+    <message>
+        <source>The entered address "%1" is already in the address book.</source>
+        <translation>입력된 주소 "%1" 은/는 이미 주소록에 있습니다.</translation>
+    </message>
+    <message>
+        <source>Could not unlock wallet.</source>
+        <translation>지갑을 잠금 해제할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>New key generation failed.</source>
+        <translation>새로운 키 생성이 실패하였습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>FreespaceChecker</name>
+    <message>
+        <source>A new data directory will be created.</source>
+        <translation>새로운 데이터 폴더가 생성됩니다.</translation>
+    </message>
+    <message>
+        <source>name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
+        <translation>폴더가 이미 존재합니다. 새로운 폴더 생성을 원한다면 %1 을/를 추가하세요.</translation>
+    </message>
+    <message>
+        <source>Path already exists, and is not a directory.</source>
+        <translation>경로가 이미 존재하고, 폴더가 아닙니다.</translation>
+    </message>
+    <message>
+        <source>Cannot create data directory here.</source>
+        <translation>데이터 폴더를 여기에 생성할 수 없습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>HelpMessageDialog</name>
+    <message>
+        <source>version</source>
+        <translation>버전</translation>
+    </message>
+    <message>
+        <source>(%1-bit)</source>
+        <translation>(%1-비트)</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>%1 정보(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Command-line options</source>
+        <translation>커맨드라인 옵션</translation>
+    </message>
+    <message>
+        <source>Usage:</source>
+        <translation>사용법:</translation>
+    </message>
+    <message>
+        <source>command-line options</source>
+        <translation>커맨드라인 옵션</translation>
+    </message>
+    <message>
+        <source>UI Options:</source>
+        <translation>UI 옵션:</translation>
+    </message>
+    <message>
+        <source>Choose data directory on startup (default: %u)</source>
+        <translation>실행 시 데이터 폴더 선택하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Set language, for example "ko_KR" (default: system locale)</source>
+        <translation>"ko_KR"과 같이 언어 설정하기(기본값: 시스템 로케일)</translation>
+    </message>
+    <message>
+        <source>Start minimized</source>
+        <translation>최소화된 상태에서 시작하기</translation>
+    </message>
+    <message>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>지불 요청을 위한 SSL 루트 인증서 설정하기(기본값: -system-)</translation>
+    </message>
+    <message>
+        <source>Show splash screen on startup (default: %u)</source>
+        <translation>실행 시 시작 화면 보기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Reset all settings changed in the GUI</source>
+        <translation>GUI를 통해 수정된 모든 설정 초기화하기</translation>
+    </message>
+</context>
+<context>
+    <name>Intro</name>
+    <message>
+        <source>Welcome</source>
+        <translation>환영합니다</translation>
+    </message>
+    <message>
+        <source>Welcome to %1.</source>
+        <translation>%1 에 오신 것을 환영합니다.</translation>
+    </message>
+    <message>
+        <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
+        <translation>프로그램이 처음 실행되는 것이므로, %1 이/가 데이터를 저장할 위치를 선택할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>%1 will download and store a copy of the Dogecoin block chain. At least %2GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
+        <translation>%1 은/는 도지코인 블록 체인의 복사본을 다운로드하고 저장합니다. 최소한 %2GB 의 데이터가 이 폴더에 저장되며, 시간이 지남에 따라 증가합니다. 지갑도 이 폴더에 저장됩니다.</translation>
+    </message>
+    <message>
+        <source>Use the default data directory</source>
+        <translation>기본 데이터 폴더 사용하기</translation>
+    </message>
+    <message>
+        <source>Use a custom data directory:</source>
+        <translation>사용자 정의 데이터 폴더 사용하기:</translation>
+    </message>
+    <message>
+        <source>Error: Specified data directory "%1" cannot be created.</source>
+        <translation>오류: 지정한 데이터 폴더 "%1" 을/를 생성할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n GB of free space available</source>
+        <translation><numerusform>%n GB 사용 가능</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>(of %n GB needed)</source>
+        <translation><numerusform>(%n GB 필요)</numerusform></translation>
+    </message>
+</context>
+<context>
+    <name>ModalOverlay</name>
+    <message>
+        <source>Form</source>
+        <translation>유형</translation>
+    </message>
+    <message>
+        <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
+        <translation>최근 거래가 아직 보이지 않을 것이므로, 지갑의 잔액이 틀릴 수도 있습니다. 이 정보는 아래 진행 상황처럼 도지코인 네트워크와 완전한 동기화가 완료되면 정확해집니다.</translation>
+    </message>
+    <message>
+        <source>Attempting to spend dogecoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
+        <translation>아직 표시되지 않은 거래의 영향을 받는 도지코인을 사용하려고 하는 것은 네트워크에서 허용되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Number of blocks left</source>
+        <translation>남은 블록 수</translation>
+    </message>
+    <message>
+        <source>Unknown...</source>
+        <translation>알 수 없음...</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation>최종 블록 시각</translation>
+    </message>
+    <message>
+        <source>Progress</source>
+        <translation>진행</translation>
+    </message>
+    <message>
+        <source>Progress increase per hour</source>
+        <translation>시간당 진행율 증가</translation>
+    </message>
+    <message>
+        <source>calculating...</source>
+        <translation>계산 중...</translation>
+    </message>
+    <message>
+        <source>Estimated time left until synced</source>
+        <translation>동기화 완료까지 예상 시간</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>숨기기</translation>
+    </message>
+    <message>
+        <source>Unknown. Syncing Headers (%1)...</source>
+        <translation>알 수 없음. 헤더 동기화 중(%1)...</translation>
+    </message>
+</context>
+<context>
+    <name>OpenURIDialog</name>
+    <message>
+        <source>Open URI</source>
+        <translation>URI 열기</translation>
+    </message>
+    <message>
+        <source>Open payment request from URI or file</source>
+        <translation>지급 요청 URI 또는 파일 열기</translation>
+    </message>
+    <message>
+        <source>URI:</source>
+        <translation>URI:</translation>
+    </message>
+    <message>
+        <source>Select payment request file</source>
+        <translation>지불 요청 파일 선택하기</translation>
+    </message>
+    <message>
+        <source>Select payment request file to open</source>
+        <translation>오픈할 지불 요청 파일 선택하기</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <source>Options</source>
+        <translation>환경 설정</translation>
+    </message>
+    <message>
+        <source>&amp;Main</source>
+        <translation>메인(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Automatically start %1 after logging in to the system.</source>
+        <translation>시스템 로그인 후에 %1 을/를 자동으로 시작합니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Start %1 on system login</source>
+        <translation>시스템 로그인 시 %1 시작(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Size of &amp;database cache</source>
+        <translation>데이터베이스 캐시 크기(&amp;D)</translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation>메가바이트</translation>
+    </message>
+    <message>
+        <source>Number of script &amp;verification threads</source>
+        <translation>스크립트 인증 쓰레드의 개수(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside</source>
+        <translation>외부로부터의 연결 승인하기</translation>
+    </message>
+    <message>
+        <source>Allow incoming connections</source>
+        <translation>연결 요청 허용하기</translation>
+    </message>
+    <message>
+        <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
+        <translation>프록시 IP 주소(예. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+    </message>
+    <message>
+        <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
+        <translation>창을 닫으면 종료하는 대신 트레이로 보냅니다. 이 옵션을 활성화하면 메뉴에서 종료를 선택한 후에만 애플리케이션이 종료됩니다.</translation>
+    </message>
+    <message>
+        <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
+        <translation>서드-파티 URL(예: 블록 탐색기)은 거래 탭의 컨텍스트 메뉴에 나타납니다. URL의 %s 은/는 거래 해시값으로 대체됩니다. 여러 URL은 수직 바 | 에서 나누어집니다.</translation>
+    </message>
+    <message>
+        <source>Third party transaction URLs</source>
+        <translation>서드-파티 거래 URLs</translation>
+    </message>
+    <message>
+        <source>Active command-line options that override above options:</source>
+        <translation>위의 옵션을 대체하는 활성화된 커맨드라인 옵션:</translation>
+    </message>
+    <message>
+        <source>Reset all client options to default.</source>
+        <translation>모든 클라이언트 옵션을 기본값으로 재설정합니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Options</source>
+        <translation>옵션 재설정(&amp;R)</translation>
+    </message>
+    <message>
+        <source>&amp;Network</source>
+        <translation>네트워크(&amp;N)</translation>
+    </message>
+    <message>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = 자동, &lt;0 = 지정된 코어 개수만큼 사용하지 않음)</translation>
+    </message>
+    <message>
+        <source>W&amp;allet</source>
+        <translation>지갑(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation>전문가</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>코인 상세 제어 기능을 활성화합니다(&amp;C)</translation>
+    </message>
+    <message>
+        <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
+        <translation>검증되지 않은 잔돈 쓰기를 비활성화하면, 거래가 적어도 1회 이상 검증되기 전까지 그 거래의 잔돈은 사용할 수 없습니다. 이는 잔액 계산 방법에도 영향을 미칩니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>검증되지 않은 잔돈 쓰기(&amp;S)</translation>
+    </message>
+    <message>
+        <source>Automatically open the Dogecoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
+        <translation>라우터에서 도지코인 클라이언트 포트를 자동적으로 엽니다. 라우터에서 UPnP를 지원하고 활성화했을 경우에만 동작합니다.</translation>
+    </message>
+    <message>
+        <source>Map port using &amp;UPnP</source>
+        <translation>사용 중인 &amp;UPnP 포트 매핑</translation>
+    </message>
+    <message>
+        <source>Connect to the Dogecoin network through a SOCKS5 proxy.</source>
+        <translation>SOCKS5 프록시를 통해 도지코인 네트워크에 연결합니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
+        <translation>SOCKS5 프록시를 통해 연결하기(&amp;C) (기본 프록시):</translation>
+    </message>
+    <message>
+        <source>Proxy &amp;IP:</source>
+        <translation>프록시 &amp;IP:</translation>
+    </message>
+    <message>
+        <source>&amp;Port:</source>
+        <translation>포트(&amp;P):</translation>
+    </message>
+    <message>
+        <source>Port of the proxy (e.g. 9050)</source>
+        <translation>프록시의 포트 번호(예: 9050)</translation>
+    </message>
+    <message>
+        <source>Used for reaching peers via:</source>
+        <translation>피어에 연결하기 위해 사용된 방법:</translation>
+    </message>
+    <message>
+        <source>Shows, if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
+        <translation>제공된 기본 SOCK5 프록시가 이 네트워크 유형을 통해 피어와 접속하는지 여부를 표시합니다.</translation>
+    </message>
+    <message>
+        <source>IPv4</source>
+        <translation>IPv4</translation>
+    </message>
+    <message>
+        <source>IPv6</source>
+        <translation>IPv6</translation>
+    </message>
+    <message>
+        <source>Tor</source>
+        <translation>Tor</translation>
+    </message>
+    <message>
+        <source>Connect to the Dogecoin network through a separate SOCKS5 proxy for Tor hidden services.</source>
+        <translation>Tor 히든 서비스를 위한 별도의 SOCKS5 프록시를 통해 도지코인 네트워크에 연결합니다.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
+        <translation>Tor 히든 서비스를 거쳐 피어에 연결하기 위해 별도의 SOCKS5 프록시 사용:</translation>
+    </message>
+    <message>
+        <source>&amp;Window</source>
+        <translation>창(&amp;W)</translation>
+    </message>
+    <message>
+        <source>&amp;Hide the icon from the system tray.</source>
+        <translation>시스템 트레이로부터 아이콘 숨기기(&amp;H)</translation>
+    </message>
+    <message>
+        <source>Hide tray icon</source>
+        <translation>트레이 아이콘 숨기기</translation>
+    </message>
+    <message>
+        <source>Show only a tray icon after minimizing the window.</source>
+        <translation>창을 최소화하면 트레이에 아이콘만 표시합니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize to the tray instead of the taskbar</source>
+        <translation>작업 표시줄 대신 트레이로 최소화(&amp;M)</translation>
+    </message>
+    <message>
+        <source>M&amp;inimize on close</source>
+        <translation>닫을 때 최소화(&amp;I)</translation>
+    </message>
+    <message>
+        <source>&amp;Display</source>
+        <translation>표시(&amp;D)</translation>
+    </message>
+    <message>
+        <source>User Interface &amp;language:</source>
+        <translation>사용자 인터페이스 언어(&amp;L):</translation>
+    </message>
+    <message>
+        <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
+        <translation>사용자 인터페이스 언어를 여기서 설정할 수 있습니다. 이 설정은 %1 을/를 다시 시작할 때 적용됩니다.</translation>
+    </message>
+    <message>
+        <source>&amp;Unit to show amounts in:</source>
+        <translation>거래액을 표시할 단위(&amp;U):</translation>
+    </message>
+    <message>
+        <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
+        <translation>인터페이스에 표시하고 코인을 보낼 때 사용할 기본 최소 단위를 선택하세요.</translation>
+    </message>
+    <message>
+        <source>Whether to show coin control features or not.</source>
+        <translation>코인 상세 제어 기능에 대한 표시 여부를 선택할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>&amp;OK</source>
+        <translation>확인(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <translation>취소(&amp;C)</translation>
+    </message>
+    <message>
+        <source>default</source>
+        <translation>기본값</translation>
+    </message>
+    <message>
+        <source>none</source>
+        <translation>없음</translation>
+    </message>
+    <message>
+        <source>Confirm options reset</source>
+        <translation>옵션 초기화를 확인</translation>
+    </message>
+    <message>
+        <source>Client restart required to activate changes.</source>
+        <translation>변경 사항을 적용하기 위해서 프로그램이 종료 후 재시작되어야 합니다.</translation>
+    </message>
+    <message>
+        <source>Client will be shut down. Do you want to proceed?</source>
+        <translation>클라이언트가 종료됩니다. 계속 진행하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>This change would require a client restart.</source>
+        <translation>이 변경 사항 적용을 위해 프로그램 재시작이 필요합니다.</translation>
+    </message>
+    <message>
+        <source>The supplied proxy address is invalid.</source>
+        <translation>지정한 프록시 주소가 잘못되었습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>OverviewPage</name>
+    <message>
+        <source>Form</source>
+        <translation>유형</translation>
+    </message>
+    <message>
+        <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</source>
+        <translation>표시된 정보가 오래된 것 같습니다. 도지코인 네트워크에 연결하고 난 다음에 지갑을 자동으로 동기화하지만, 아직 프로세스가 완료되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>Watch-only:</source>
+        <translation>조회 전용:</translation>
+    </message>
+    <message>
+        <source>Available:</source>
+        <translation>사용 가능</translation>
+    </message>
+    <message>
+        <source>Your current spendable balance</source>
+        <translation>현재 사용할 수 있는 잔액</translation>
+    </message>
+    <message>
+        <source>Pending:</source>
+        <translation>미확정</translation>
+    </message>
+    <message>
+        <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
+        <translation>아직 확인되지 않았고, 지출 가능한 잔액에 포함되지 않은 총 거래</translation>
+    </message>
+    <message>
+        <source>Immature:</source>
+        <translation>아직 사용 불가능:</translation>
+    </message>
+    <message>
+        <source>Mined balance that has not yet matured</source>
+        <translation>아직 사용할 수 없는 채굴된 잔액</translation>
+    </message>
+    <message>
+        <source>Balances</source>
+        <translation>잔액</translation>
+    </message>
+    <message>
+        <source>Total:</source>
+        <translation>총액:</translation>
+    </message>
+    <message>
+        <source>Your current total balance</source>
+        <translation>현재 총액</translation>
+    </message>
+    <message>
+        <source>Your current balance in watch-only addresses</source>
+        <translation>조회 전용 주소의 현재 잔액</translation>
+    </message>
+    <message>
+        <source>Spendable:</source>
+        <translation>사용 가능:</translation>
+    </message>
+    <message>
+        <source>Recent transactions</source>
+        <translation>최근 거래</translation>
+    </message>
+    <message>
+        <source>Unconfirmed transactions to watch-only addresses</source>
+        <translation>조회 전용 주소의 검증되지 않은 거래</translation>
+    </message>
+    <message>
+        <source>Mined balance in watch-only addresses that has not yet matured</source>
+        <translation>조회 전용 주소의 채굴된 코인 중 사용할 수 없는 잔액</translation>
+    </message>
+    <message>
+        <source>Current total balance in watch-only addresses</source>
+        <translation>조회 전용 주소의 현재 잔액</translation>
+    </message>
+</context>
+<context>
+    <name>PaymentServer</name>
+    <message>
+        <source>Payment request error</source>
+        <translation>지불 요청 오류</translation>
+    </message>
+    <message>
+        <source>Cannot start dogecoin: click-to-pay handler</source>
+        <translation>dogecoin: click-to-pay 핸들러를 시작할 수 없음</translation>
+    </message>
+    <message>
+        <source>URI handling</source>
+        <translation>URI 핸들링</translation>
+    </message>
+    <message>
+        <source>Payment request fetch URL is invalid: %1</source>
+        <translation>지불 요청의 URL이 올바르지 않음: %1</translation>
+    </message>
+    <message>
+        <source>Invalid payment address %1</source>
+        <translation>잘못된 지불 주소 %1</translation>
+    </message>
+    <message>
+        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
+        <translation>URI의 파싱에 문제가 발생했습니다! 잘못된 도지코인 주소나 URI 파라미터 구성에 오류가 존재할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Payment request file handling</source>
+        <translation>지불 요청 파일 처리</translation>
+    </message>
+    <message>
+        <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
+        <translation>지불 요청 파일을 읽을 수 없습니다! 잘못된 지불 요청 파일에 의해 발생하는 오류일 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Payment request rejected</source>
+        <translation>지불 요청이 거부됨</translation>
+    </message>
+    <message>
+        <source>Payment request network doesn't match client network.</source>
+        <translation>지불 요청 네트워크가 클라이언트 네트워크와 일치되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation>지불 요청이 만료되었습니다.</translation>
+    </message>
+    <message>
+        <source>Payment request is not initialized.</source>
+        <translation>지불 요청이 초기화되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>Unverified payment requests to custom payment scripts are unsupported.</source>
+        <translation>사용자 지정 결제 스크립트에 대한 확인되지 않은 지불 요청은 지원되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Invalid payment request.</source>
+        <translation>잘못된 지불 요청입니다.</translation>
+    </message>
+    <message>
+        <source>Requested payment amount of %1 is too small (considered dust).</source>
+        <translation>요청한 금액 %1 의 양이 너무 적습니다(스팸성 거래로 간주).</translation>
+    </message>
+    <message>
+        <source>Refund from %1</source>
+        <translation>%1 (으)로부터의 환불</translation>
+    </message>
+    <message>
+        <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
+        <translation>지불 요청 %1 은/는 너무 큽니다(%2 바이트, %3 바이트까지 허용됨).</translation>
+    </message>
+    <message>
+        <source>Error communicating with %1: %2</source>
+        <translation>%1 와/과의 통신 오류: %2</translation>
+    </message>
+    <message>
+        <source>Payment request cannot be parsed!</source>
+        <translation>지불 요청을 파싱할 수 없습니다!</translation>
+    </message>
+    <message>
+        <source>Bad response from server %1</source>
+        <translation>서버로부터 잘못된 응답 %1</translation>
+    </message>
+    <message>
+        <source>Network request error</source>
+        <translation>네트워크 요청 오류</translation>
+    </message>
+    <message>
+        <source>Payment acknowledged</source>
+        <translation>지불이 승인됨</translation>
+    </message>
+</context>
+<context>
+    <name>PeerTableModel</name>
+    <message>
+        <source>User Agent</source>
+        <translation>유저 에이전트</translation>
+    </message>
+    <message>
+        <source>Node/Service</source>
+        <translation>노드/서비스</translation>
+    </message>
+    <message>
+        <source>NodeId</source>
+        <translation>노드 ID</translation>
+    </message>
+    <message>
+        <source>Ping</source>
+        <translation>핑</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Amount</source>
+        <translation>거래액</translation>
+    </message>
+    <message>
+        <source>Enter a Dogecoin address (e.g. %1)</source>
+        <translation>도지코인 주소 입력하기(예: %1)</translation>
+    </message>
+    <message>
+        <source>%1 d</source>
+        <translation>%1 일</translation>
+    </message>
+    <message>
+        <source>%1 h</source>
+        <translation>%1 시간</translation>
+    </message>
+    <message>
+        <source>%1 m</source>
+        <translation>%1 분</translation>
+    </message>
+    <message>
+        <source>%1 s</source>
+        <translation>%1 초</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>없음</translation>
+    </message>
+    <message>
+        <source>N/A</source>
+        <translation>해당 사항 없음</translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation>%1 ms</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n second(s)</source>
+        <translation><numerusform>%n 초</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n minute(s)</source>
+        <translation><numerusform>%n 분</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation><numerusform>%n 시간</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation><numerusform>%n 일</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation><numerusform>%n 주</numerusform></translation>
+    </message>
+    <message>
+        <source>%1 and %2</source>
+        <translation>%1 그리고 %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation><numerusform>%n 년</numerusform></translation>
+    </message>
+    <message>
+        <source>%1 didn't yet exit safely...</source>
+        <translation>%1 이/가 아직 안전하게 종료되지 않았습니다...</translation>
+    </message>
+</context>
+<context>
+    <name>QObject::QObject</name>
+    <message>
+        <source>Error: Specified data directory "%1" does not exist.</source>
+        <translation>오류: 지정한 데이터 폴더 "%1" 은/는 존재하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>오류: 설정 파일을 파싱할 수 없음: %1. key=value 구문만 사용할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Error: %1</source>
+        <translation>오류: %1</translation>
+    </message>
+</context>
+<context>
+    <name>QRImageWidget</name>
+    <message>
+        <source>&amp;Save Image...</source>
+        <translation>이미지 저장(&amp;S)...</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Image</source>
+        <translation>이미지 복사(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Save QR Code</source>
+        <translation>QR 코드 저장</translation>
+    </message>
+    <message>
+        <source>PNG Image (*.png)</source>
+        <translation>PNG 이미지(*.png)</translation>
+    </message>
+</context>
+<context>
+    <name>RPCConsole</name>
+    <message>
+        <source>N/A</source>
+        <translation>해당 사항 없음</translation>
+    </message>
+    <message>
+        <source>Client version</source>
+        <translation>클라이언트 버전</translation>
+    </message>
+    <message>
+        <source>&amp;Information</source>
+        <translation>정보(&amp;I)</translation>
+    </message>
+    <message>
+        <source>Debug window</source>
+        <translation>디버그 창</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <source>Using BerkeleyDB version</source>
+        <translation>사용 중인 BerkeleyDB 버전</translation>
+    </message>
+    <message>
+        <source>Datadir</source>
+        <translation>데이터 폴더</translation>
+    </message>
+    <message>
+        <source>Startup time</source>
+        <translation>시작 시간</translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation>네트워크</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <source>Number of connections</source>
+        <translation>연결 수</translation>
+    </message>
+    <message>
+        <source>Block chain</source>
+        <translation>블록 체인</translation>
+    </message>
+    <message>
+        <source>Current number of blocks</source>
+        <translation>현재 블록 수</translation>
+    </message>
+    <message>
+        <source>Memory Pool</source>
+        <translation>메모리 풀</translation>
+    </message>
+    <message>
+        <source>Current number of transactions</source>
+        <translation>현재 거래 수</translation>
+    </message>
+    <message>
+        <source>Memory usage</source>
+        <translation>메모리 사용량</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation>받음</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation>보냄</translation>
+    </message>
+    <message>
+        <source>&amp;Peers</source>
+        <translation>피어(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Banned peers</source>
+        <translation>차단된 피어</translation>
+    </message>
+    <message>
+        <source>Select a peer to view detailed information.</source>
+        <translation>자세한 정보를 보려면 피어를 선택하세요.</translation>
+    </message>
+    <message>
+        <source>Whitelisted</source>
+        <translation>화이트리스트에 포함</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>방향</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>버전</translation>
+    </message>
+    <message>
+        <source>Starting Block</source>
+        <translation>시작 블록</translation>
+    </message>
+    <message>
+        <source>Synced Headers</source>
+        <translation>동기화된 헤더</translation>
+    </message>
+    <message>
+        <source>Synced Blocks</source>
+        <translation>동기화된 블록</translation>
+    </message>
+    <message>
+        <source>User Agent</source>
+        <translation>유저 에이전트</translation>
+    </message>
+    <message>
+        <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
+        <translation>%1 디버그 로그 파일을 현재 데이터 폴더에서 엽니다. 용량이 큰 로그 파일들은 수 초가 걸릴 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Decrease font size</source>
+        <translation>글자 크기 축소</translation>
+    </message>
+    <message>
+        <source>Increase font size</source>
+        <translation>글자 크기 확대</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation>서비스</translation>
+    </message>
+    <message>
+        <source>Ban Score</source>
+        <translation>밴 스코어</translation>
+    </message>
+    <message>
+        <source>Connection Time</source>
+        <translation>접속 시간</translation>
+    </message>
+    <message>
+        <source>Last Send</source>
+        <translation>마지막으로 보낸 시간</translation>
+    </message>
+    <message>
+        <source>Last Receive</source>
+        <translation>마지막으로 받은 시간</translation>
+    </message>
+    <message>
+        <source>Ping Time</source>
+        <translation>핑 시간</translation>
+    </message>
+    <message>
+        <source>The duration of a currently outstanding ping.</source>
+        <translation>현재 진행 중인 핑에 걸린 시간입니다.</translation>
+    </message>
+    <message>
+        <source>Ping Wait</source>
+        <translation>핑 대기</translation>
+    </message>
+    <message>
+        <source>Min Ping</source>
+        <translation>최소 핑</translation>
+    </message>
+    <message>
+        <source>Time Offset</source>
+        <translation>시간 오프셋</translation>
+    </message>
+    <message>
+        <source>Last block time</source>
+        <translation>최종 블록 시각</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation>열기(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Console</source>
+        <translation>콘솔(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Network Traffic</source>
+        <translation>네트워크 트래픽(&amp;N)</translation>
+    </message>
+    <message>
+        <source>&amp;Clear</source>
+        <translation>지우기(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Totals</source>
+        <translation>총액</translation>
+    </message>
+    <message>
+        <source>In:</source>
+        <translation>In:</translation>
+    </message>
+    <message>
+        <source>Out:</source>
+        <translation>Out:</translation>
+    </message>
+    <message>
+        <source>Debug log file</source>
+        <translation>디버그 로그 파일</translation>
+    </message>
+    <message>
+        <source>Clear console</source>
+        <translation>콘솔 초기화</translation>
+    </message>
+    <message>
+        <source>1 &amp;hour</source>
+        <translation>1시간(&amp;H)</translation>
+    </message>
+    <message>
+        <source>1 &amp;day</source>
+        <translation>1일(&amp;D)</translation>
+    </message>
+    <message>
+        <source>1 &amp;week</source>
+        <translation>1주(&amp;W)</translation>
+    </message>
+    <message>
+        <source>1 &amp;year</source>
+        <translation>1년(&amp;Y)</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect</source>
+        <translation>접속 끊기(&amp;D)</translation>
+    </message>
+    <message>
+        <source>Ban for</source>
+        <translation>차단</translation>
+    </message>
+    <message>
+        <source>&amp;Unban</source>
+        <translation>노드 차단 취소(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Welcome to the %1 RPC console.</source>
+        <translation>환영합니다. %1 RPC 콘솔입니다.</translation>
+    </message>
+    <message>
+        <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
+        <translation>기록을 찾아보려면 위 / 아래 화살표 키를, 화면을 지우려면 &lt;b&gt;Ctrl-L&lt;/b&gt; 키를 사용하세요.</translation>
+    </message>
+    <message>
+        <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
+        <translation>사용할 수 있는 명령을 둘러보려면 &lt;b&gt;help&lt;/b&gt;를 입력하세요.</translation>
+    </message>
+    <message>
+        <source>WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramification of a command.</source>
+        <translation>경고: 사기꾼이 사용자에게 여기에 명령을 입력하게 하여 지갑 내용을 훔칠 수 있다는 사실을 알려드립니다. 명령어를 완전히 이해하지 못한다면 콘솔을 사용하지 마세요.</translation>
+    </message>
+    <message>
+        <source>Network activity disabled</source>
+        <translation>네트워크 활동이 정지됨</translation>
+    </message>
+    <message>
+        <source>%1 B</source>
+        <translation>%1 바이트</translation>
+    </message>
+    <message>
+        <source>%1 KB</source>
+        <translation>%1 킬로바이트</translation>
+    </message>
+    <message>
+        <source>%1 MB</source>
+        <translation>%1 메가바이트</translation>
+    </message>
+    <message>
+        <source>%1 GB</source>
+        <translation>%1 기가바이트</translation>
+    </message>
+    <message>
+        <source>(node id: %1)</source>
+        <translation>(노드 ID: %1)</translation>
+    </message>
+    <message>
+        <source>via %1</source>
+        <translation>%1 경유</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>없음</translation>
+    </message>
+    <message>
+        <source>Inbound</source>
+        <translation>인바운드</translation>
+    </message>
+    <message>
+        <source>Outbound</source>
+        <translation>아웃바운드</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>예</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>아니오</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>알 수 없음</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveCoinsDialog</name>
+    <message>
+        <source>&amp;Amount:</source>
+        <translation>거래액(&amp;A):</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation>라벨(&amp;L):</translation>
+    </message>
+    <message>
+        <source>&amp;Message:</source>
+        <translation>메시지(&amp;M):</translation>
+    </message>
+    <message>
+        <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
+        <translation>이전에 사용된 받는 주소를 사용하려고 합니다. 주소의 재사용은 보안과 개인 정보 보호 측면에서 문제를 초래할 수 있습니다. 이전 지불 요청을 재생성하는 경우가 아니라면 주소 재사용을 권하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>R&amp;euse an existing receiving address (not recommended)</source>
+        <translation>현재의 받는 주소 재사용하기(&amp;E) (권장하지 않습니다)</translation>
+    </message>
+    <message>
+        <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dogecoin network.</source>
+        <translation>지불 요청에 첨부되는 메시지이며 선택 사항입니다. 이 메세지는 요청이 열릴 때 표시됩니다. 참고: 이 메시지는 도지코인 네트워크로 전송되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>An optional label to associate with the new receiving address.</source>
+        <translation>새로운 받는 주소와 연결할 라벨이며 선택 사항입니다.</translation>
+    </message>
+    <message>
+        <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
+        <translation>지불을 요청하기 위해 아래 형식을 사용하세요. 입력값은 &lt;b&gt;선택 사항&lt;/b&gt;입니다.</translation>
+    </message>
+    <message>
+        <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
+        <translation>요청할 금액 입력칸으로 선택 사항입니다. 빈 칸으로 두거나 특정 금액이 필요하지 않는 경우 0을 입력하세요.</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation>양식의 모든 필드값을 지웁니다.</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <source>Requested payments history</source>
+        <translation>지출 기록 확인</translation>
+    </message>
+    <message>
+        <source>&amp;Request payment</source>
+        <translation>지불 요청(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Show the selected request (does the same as double clicking an entry)</source>
+        <translation>선택된 요청을 표시하기(더블 클릭으로 항목을 표시할 수 있음)</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation>보기</translation>
+    </message>
+    <message>
+        <source>Remove the selected entries from the list</source>
+        <translation>목록에서 삭제할 항목 선택</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <source>Copy URI</source>
+        <translation>URI 복사</translation>
+    </message>
+    <message>
+        <source>Copy label</source>
+        <translation>라벨 복사</translation>
+    </message>
+    <message>
+        <source>Copy message</source>
+        <translation>메시지 복사</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>거래액 복사</translation>
+    </message>
+</context>
+<context>
+    <name>ReceiveRequestDialog</name>
+    <message>
+        <source>QR Code</source>
+        <translation>QR 코드</translation>
+    </message>
+    <message>
+        <source>Copy &amp;URI</source>
+        <translation>URI 복사(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Copy &amp;Address</source>
+        <translation>주소 복사(&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Save Image...</source>
+        <translation>이미지 저장(&amp;S)...</translation>
+    </message>
+    <message>
+        <source>Request payment to %1</source>
+        <translation>%1 에 지불 요청하기</translation>
+    </message>
+    <message>
+        <source>Payment information</source>
+        <translation>지불 정보</translation>
+    </message>
+    <message>
+        <source>URI</source>
+        <translation>URI</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation>주소</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation>거래액</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation>라벨</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation>메시지</translation>
+    </message>
+    <message>
+        <source>Resulting URI too long, try to reduce the text for label / message.</source>
+        <translation>URI 결과가 너무 깁니다. 라벨 / 메세지의 텍스트를 줄여보세요.</translation>
+    </message>
+    <message>
+        <source>Error encoding URI into QR Code.</source>
+        <translation>URI를 QR 코드로 인코딩하는 중 오류가 발생했습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>RecentRequestsTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation>날짜</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation>라벨</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation>메시지</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation>(라벨 없음)</translation>
+    </message>
+    <message>
+        <source>(no message)</source>
+        <translation>(메세지가 없습니다)</translation>
+    </message>
+    <message>
+        <source>(no amount requested)</source>
+        <translation>(요청한 거래액 없음)</translation>
+    </message>
+    <message>
+        <source>Requested</source>
+        <translation>요청됨</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsDialog</name>
+    <message>
+        <source>Send Coins</source>
+        <translation>코인 보내기</translation>
+    </message>
+    <message>
+        <source>Coin Control Features</source>
+        <translation>코인 컨트롤 기능들</translation>
+    </message>
+    <message>
+        <source>Inputs...</source>
+        <translation>입력...</translation>
+    </message>
+    <message>
+        <source>automatically selected</source>
+        <translation>자동 선택됨</translation>
+    </message>
+    <message>
+        <source>Insufficient funds!</source>
+        <translation>자금이 부족합니다!</translation>
+    </message>
+    <message>
+        <source>Quantity:</source>
+        <translation>수량:</translation>
+    </message>
+    <message>
+        <source>Bytes:</source>
+        <translation>바이트:</translation>
+    </message>
+    <message>
+        <source>Amount:</source>
+        <translation>거래액:</translation>
+    </message>
+    <message>
+        <source>Fee:</source>
+        <translation>수수료:</translation>
+    </message>
+    <message>
+        <source>After Fee:</source>
+        <translation>수수료 이후:</translation>
+    </message>
+    <message>
+        <source>Change:</source>
+        <translation>잔돈:</translation>
+    </message>
+    <message>
+        <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
+        <translation>이 기능이 활성화되면, 잔돈 주소가 공란이거나 무효인 경우, 잔돈은 새롭게 생성된 주소로 송금됩니다.</translation>
+    </message>
+    <message>
+        <source>Custom change address</source>
+        <translation>주소 변경</translation>
+    </message>
+    <message>
+        <source>Transaction Fee:</source>
+        <translation>거래 수수료:</translation>
+    </message>
+    <message>
+        <source>Choose...</source>
+        <translation>선택하기...</translation>
+    </message>
+    <message>
+        <source>collapse fee-settings</source>
+        <translation>수수료 설정 접기</translation>
+    </message>
+    <message>
+        <source>per kilobyte</source>
+        <translation>킬로바이트 당</translation>
+    </message>
+    <message>
+        <source>If the custom fee is set to 1000 koinu and the transaction is only 250 bytes, then "per kilobyte" only pays 250 koinu in fee, while "total at least" pays 1000 koinu. For transactions bigger than a kilobyte both pay by kilobyte.</source>
+        <translation>사용자 정의 수수료가 1000 코이누로 지정되고 거래의 크기가 250 바이트일 경우, 1 킬로바이트당 250 코이누만 지불되지만, "최소 수수료"에선 1000 코이누가 지불됩니다. 1 킬로바이트가 넘는 거래인 경우 어떠한 경우에든 1 킬로바이트 기준으로 지불됩니다.</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>숨기기</translation>
+    </message>
+    <message>
+        <source>total at least</source>
+        <translation>최소 수수료</translation>
+    </message>
+    <message>
+        <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for dogecoin transactions than the network can process.</source>
+        <translation>블록의 용량보다 거래의 볼륨이 적은 경우에는 최소한의 수수료만으로도 충분합니다. 그러나 도지코인 네트워크의 처리량보다 더 많은 거래 요구가 있다면 영원히 검증이 안된 거래로 남을 수도 있습니다.</translation>
+    </message>
+    <message>
+        <source>(read the tooltip)</source>
+        <translation>(툴팁을 꼭 읽어보세요)</translation>
+    </message>
+    <message>
+        <source>Recommended:</source>
+        <translation>권장:</translation>
+    </message>
+    <message>
+        <source>Custom:</source>
+        <translation>사용자 정의:</translation>
+    </message>
+    <message>
+        <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
+        <translation>(스마트 수수료가 아직 초기화되지 않았습니다. 블록 분석이 완전하게 끝날 때까지 기다려주세요...)</translation>
+    </message>
+    <message>
+        <source>normal</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <source>fast</source>
+        <translation>빠름</translation>
+    </message>
+    <message>
+        <source>Send to multiple recipients at once</source>
+        <translation>한 번에 다수의 수령인들에게 보내기</translation>
+    </message>
+    <message>
+        <source>Add &amp;Recipient</source>
+        <translation>수령인 추가하기(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Clear all fields of the form.</source>
+        <translation>양식의 모든 필드를 지웁니다.</translation>
+    </message>
+    <message>
+        <source>Dust:</source>
+        <translation>더스트:</translation>
+    </message>
+    <message>
+        <source>Confirmation time target:</source>
+        <translation>승인 시간 목표:</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation>모두 지우기(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Balance:</source>
+        <translation>잔액:</translation>
+    </message>
+    <message>
+        <source>Confirm the send action</source>
+        <translation>전송 기능 확인</translation>
+    </message>
+    <message>
+        <source>S&amp;end</source>
+        <translation>보내기(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Copy quantity</source>
+        <translation>수량 복사</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>거래액 복사</translation>
+    </message>
+    <message>
+        <source>Copy fee</source>
+        <translation>수수료 복사</translation>
+    </message>
+    <message>
+        <source>Copy after fee</source>
+        <translation>수수료 이후 복사</translation>
+    </message>
+    <message>
+        <source>Copy bytes</source>
+        <translation>바이트 복사</translation>
+    </message>
+    <message>
+        <source>Copy dust</source>
+        <translation>더스트 복사</translation>
+    </message>
+    <message>
+        <source>Copy change</source>
+        <translation>잔돈 복사</translation>
+    </message>
+    <message>
+        <source>%1 to %2</source>
+        <translation>%1 을/를 %2 (으)로</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to send?</source>
+        <translation>정말로 보내시겠습니까?</translation>
+    </message>
+    <message>
+        <source>added as transaction fee</source>
+        <translation>거래 수수료로 추가됨</translation>
+    </message>
+    <message>
+        <source>Total Amount %1</source>
+        <translation>총 액수 %1</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation>또는</translation>
+    </message>
+    <message>
+        <source>Confirm send coins</source>
+        <translation>코인 전송 확인</translation>
+    </message>
+    <message>
+        <source>The recipient address is not valid. Please recheck.</source>
+        <translation>수령인 주소가 정확하지 않습니다. 재확인 바랍니다.</translation>
+    </message>
+    <message>
+        <source>The amount to pay must be larger than 0.</source>
+        <translation>지불하는 금액은 0 보다 커야 합니다.</translation>
+    </message>
+    <message>
+        <source>The amount exceeds your balance.</source>
+        <translation>잔고를 초과하였습니다.</translation>
+    </message>
+    <message>
+        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
+        <translation>%1 의 거래 수수료를 포함하면 잔고를 초과합니다.</translation>
+    </message>
+    <message>
+        <source>Duplicate address found: addresses should only be used once each.</source>
+        <translation>중복된 주소 발견: 주소는 각각 한 번만 사용해야 합니다.</translation>
+    </message>
+    <message>
+        <source>Transaction creation failed!</source>
+        <translation>거래 생성을 실패하였습니다!</translation>
+    </message>
+    <message>
+        <source>The transaction was rejected with the following reason: %1</source>
+        <translation>거래가 다음의 이유로 거부됨: %1</translation>
+    </message>
+    <message>
+        <source>A fee higher than %1 is considered an absurdly high fee.</source>
+        <translation>%1 보다 높은 수수료는 엄청나게 높은 수수료로 간주됩니다.</translation>
+    </message>
+    <message>
+        <source>Payment request expired.</source>
+        <translation>지불 요청이 만료되었습니다.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n block(s)</source>
+        <translation><numerusform>%n 블록</numerusform></translation>
+    </message>
+    <message>
+        <source>Pay only the required fee of %1</source>
+        <translation>수수료 %1 만 지불하기</translation>
+    </message>
+    <message numerus="yes">
+        <source>Estimated to begin confirmation within %n block(s).</source>
+        <translation><numerusform>%n 블록 안에 승인이 시작될 것으로 추정됩니다.</numerusform></translation>
+    </message>
+    <message>
+        <source>Warning: Invalid Bitcoin address</source>
+        <translation>경고: 잘못된 도지코인 주소</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown change address</source>
+        <translation>경고: 알 수 없는 주소 변경</translation>
+    </message>
+    <message>
+        <source>Confirm custom change address</source>
+        <translation>사용자 지정 주소 변경 확인</translation>
+    </message>
+    <message>
+        <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
+        <translation>변경을 위해 선택한 주소는 이 지갑의 일부가 아닙니다. 지갑에 있는 일부 또는 모든 금액이 이 주소로 보내질 수 있습니다. 확실합니까?</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation>(라벨 없음)</translation>
+    </message>
+</context>
+<context>
+    <name>SendCoinsEntry</name>
+    <message>
+        <source>A&amp;mount:</source>
+        <translation>금액(&amp;M):</translation>
+    </message>
+    <message>
+        <source>Pay &amp;To:</source>
+        <translation>송금할 대상(&amp;T):</translation>
+    </message>
+    <message>
+        <source>&amp;Label:</source>
+        <translation>라벨(&amp;L):</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation>이전에 사용한 주소 선택하기</translation>
+    </message>
+    <message>
+        <source>This is a normal payment.</source>
+        <translation>이것은 정상적인 지불입니다.</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address to send the payment to</source>
+        <translation>지불을 보낼 도지코인 주소</translation>
+    </message>
+    <message>
+        <source>Alt+A</source>
+        <translation>Alt+A</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation>클립보드에서 주소 붙여넣기</translation>
+    </message>
+    <message>
+        <source>Alt+P</source>
+        <translation>Alt+P</translation>
+    </message>
+    <message>
+        <source>Remove this entry</source>
+        <translation>항목 지우기</translation>
+    </message>
+    <message>
+        <source>The fee will be deducted from the amount being sent. The recipient will receive less dogecoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
+        <translation>수수료가 송금되는 금액에서 공제됩니다. 수령자는 금액 필드에서 입력한 금액보다 적은 금액을 받게 됩니다. 받는 사람이 여러 명인 경우 수수료는 균등하게 나누어집니다.</translation>
+    </message>
+    <message>
+        <source>S&amp;ubtract fee from amount</source>
+        <translation>송금액에서 수수료 공제(&amp;U)</translation>
+    </message>
+    <message>
+        <source>Message:</source>
+        <translation>메시지:</translation>
+    </message>
+    <message>
+        <source>This is an unauthenticated payment request.</source>
+        <translation>인증되지 않은 지불 요청입니다.</translation>
+    </message>
+    <message>
+        <source>This is an authenticated payment request.</source>
+        <translation>인증된 지불 요청입니다.</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to the list of used addresses</source>
+        <translation>이 주소의 라벨을 입력하여 사용된 주소 목록에 추가하기</translation>
+    </message>
+    <message>
+        <source>A message that was attached to the dogecoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Dogecoin network.</source>
+        <translation>dogecoin: URI에 첨부된 메시지는 참조를 위해 거래와 함께 저장됩니다. 참고: 이 메시지는 도지코인 네트워크를 통해 전송되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Pay To:</source>
+        <translation>송금할 대상:</translation>
+    </message>
+    <message>
+        <source>Memo:</source>
+        <translation>메모:</translation>
+    </message>
+    <message>
+        <source>Enter a label for this address to add it to your address book</source>
+        <translation>이 주소의 라벨을 입력하여 주소록 추가하기</translation>
+    </message>
+</context>
+<context>
+    <name>SendConfirmationDialog</name>
+    <message>
+        <source>Yes</source>
+        <translation>예</translation>
+    </message>
+</context>
+<context>
+    <name>ShutdownWindow</name>
+    <message>
+        <source>%1 is shutting down...</source>
+        <translation>%1 이/가 종료 중...</translation>
+    </message>
+    <message>
+        <source>Do not shut down the computer until this window disappears.</source>
+        <translation>이 창이 사라지기 전까지 컴퓨터를 끄지 마세요.</translation>
+    </message>
+</context>
+<context>
+    <name>SignVerifyMessageDialog</name>
+    <message>
+        <source>Signatures - Sign / Verify a Message</source>
+        <translation>서명 - 사인 / 메시지 확인</translation>
+    </message>
+    <message>
+        <source>&amp;Sign Message</source>
+        <translation>메시지 서명(&amp;S)</translation>
+    </message>
+    <message>
+        <source>You can sign messages/agreements with your addresses to prove you can receive dogecoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
+        <translation>주소로 메시지/계약서에 서명하여 보낸 도지코인을 받을 수 있음을 증명할 수 있습니다. 피싱 공격으로 말미암아 여러분의 서명을 통해 속아 넘어가게 할 수 있으므로, 서명하지 않은 모든 모호한 요소를 주의하세요. 조항들이 완전 무결한지 확인 후 동의하는 경우에만 서명하세요.</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address to sign the message with</source>
+        <translation>메시지에 서명할 도지코인 주소</translation>
+    </message>
+    <message>
+        <source>Choose previously used address</source>
+        <translation>이전에 사용한 주소 선택하기</translation>
+    </message>
+    <message>
+        <source>Alt+A</source>
+        <translation>Alt+A</translation>
+    </message>
+    <message>
+        <source>Paste address from clipboard</source>
+        <translation>클립보드로부터 주소 복사하기</translation>
+    </message>
+    <message>
+        <source>Alt+P</source>
+        <translation>Alt+P</translation>
+    </message>
+    <message>
+        <source>Enter the message you want to sign here</source>
+        <translation>여기에 서명할 메시지 입력하기</translation>
+    </message>
+    <message>
+        <source>Signature</source>
+        <translation>서명</translation>
+    </message>
+    <message>
+        <source>Copy the current signature to the system clipboard</source>
+        <translation>현재 서명을 시스템 클립보드에 복사</translation>
+    </message>
+    <message>
+        <source>Sign the message to prove you own this Dogecoin address</source>
+        <translation>이 도지코인 주소를 소유하고 있음을 증명하기 위해 메시지 서명하기</translation>
+    </message>
+    <message>
+        <source>Sign &amp;Message</source>
+        <translation>메시지 서명(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Reset all sign message fields</source>
+        <translation>메시지 필드의 모든 서명 재설정</translation>
+    </message>
+    <message>
+        <source>Clear &amp;All</source>
+        <translation>모두 지우기(&amp;A)</translation>
+    </message>
+    <message>
+        <source>&amp;Verify Message</source>
+        <translation>메시지 검증(&amp;V)</translation>
+    </message>
+    <message>
+        <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
+        <translation>메시지를 검증하기 위해 아래 칸에 각각 지갑 주소와 메시지(메시지 원본의 띄어쓰기, 들여쓰기, 행 나눔 등이 정확하게 입력되어야 하므로 원본을 복사해서 입력하세요), 전자 서명을 입력하세요. 이 기능은 메시지 검증이 주 목적이며, 네트워크 침입자에 의해 변조되지 않도록 전자 서명 해독에 불필요한 시간을 소모하지 마세요.</translation>
+    </message>
+    <message>
+        <source>The Dogecoin address the message was signed with</source>
+        <translation>메세지의 서명에 사용된 도지코인 주소</translation>
+    </message>
+    <message>
+        <source>Verify the message to ensure it was signed with the specified Dogecoin address</source>
+        <translation>메시지가 지정된 도지코인 주소로 서명되었는지 확인</translation>
+    </message>
+    <message>
+        <source>Verify &amp;Message</source>
+        <translation>메시지 검증(&amp;M)</translation>
+    </message>
+    <message>
+        <source>Reset all verify message fields</source>
+        <translation>모든 검증 메시지 필드 재설정</translation>
+    </message>
+    <message>
+        <source>Click "Sign Message" to generate signature</source>
+        <translation>서명을 생성하기 위해 "메시지 서명" 클릭하기</translation>
+    </message>
+    <message>
+        <source>The entered address is invalid.</source>
+        <translation>입력한 주소가 잘못되었습니다.</translation>
+    </message>
+    <message>
+        <source>Please check the address and try again.</source>
+        <translation>주소를 확인하고 다시 시도하세요.</translation>
+    </message>
+    <message>
+        <source>The entered address does not refer to a key.</source>
+        <translation>입력한 주소는 키에서 참조하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Wallet unlock was cancelled.</source>
+        <translation>지갑 잠금 해제를 취소했습니다.</translation>
+    </message>
+    <message>
+        <source>Private key for the entered address is not available.</source>
+        <translation>입력한 주소에 대한 개인 키가 없습니다.</translation>
+    </message>
+    <message>
+        <source>Message signing failed.</source>
+        <translation>메시지 서명에 실패했습니다.</translation>
+    </message>
+    <message>
+        <source>Message signed.</source>
+        <translation>메시지를 서명했습니다.</translation>
+    </message>
+    <message>
+        <source>The signature could not be decoded.</source>
+        <translation>서명을 해독할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Please check the signature and try again.</source>
+        <translation>서명을 확인하고 다시 시도하세요.</translation>
+    </message>
+    <message>
+        <source>The signature did not match the message digest.</source>
+        <translation>메시지 다이제스트와 서명이 일치하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Message verification failed.</source>
+        <translation>메시지 검증에 실패했습니다.</translation>
+    </message>
+    <message>
+        <source>Message verified.</source>
+        <translation>메시지를 검증했습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <source>[testnet]</source>
+        <translation>[테스트넷]</translation>
+    </message>
+</context>
+<context>
+    <name>TrafficGraphWidget</name>
+    <message>
+        <source>KB/s</source>
+        <translation>KB/s</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDesc</name>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation><numerusform>%n개의 더 많은 블록 열기</numerusform></translation>
+    </message>
+    <message>
+        <source>Open until %1</source>
+        <translation>%1 까지 열림</translation>
+    </message>
+    <message>
+        <source>conflicted with a transaction with %1 confirmations</source>
+        <translation>%1 승인이 있는 거래와 충돌함</translation>
+    </message>
+    <message>
+        <source>%1/offline</source>
+        <translation>%1/오프라인</translation>
+    </message>
+    <message>
+        <source>0/unconfirmed, %1</source>
+        <translation>0/미승인, %1</translation>
+    </message>
+    <message>
+        <source>in memory pool</source>
+        <translation>메모리 풀 안에 있음</translation>
+    </message>
+    <message>
+        <source>not in memory pool</source>
+        <translation>메모리 풀 안에 없음</translation>
+    </message>
+    <message>
+        <source>abandoned</source>
+        <translation>버려진</translation>
+    </message>
+    <message>
+        <source>%1/unconfirmed</source>
+        <translation>%1/미확인</translation>
+    </message>
+    <message>
+        <source>%1 confirmations</source>
+        <translation>%1 확인됨</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>상태</translation>
+    </message>
+    <message>
+        <source>, has not been successfully broadcast yet</source>
+        <translation>. 아직 성공적으로 통보하지 않음</translation>
+    </message>
+    <message numerus="yes">
+        <source>, broadcast through %n node(s)</source>
+        <translation><numerusform>, %n 개 노드를 통해 전파</numerusform></translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>날짜</translation>
+    </message>
+    <message>
+        <source>Source</source>
+        <translation>소스</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation>생성됨</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation>From</translation>
+    </message>
+    <message>
+        <source>unknown</source>
+        <translation>알 수 없음</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation>To</translation>
+    </message>
+    <message>
+        <source>own address</source>
+        <translation>자신의 주소</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation>조회 전용</translation>
+    </message>
+    <message>
+        <source>label</source>
+        <translation>라벨</translation>
+    </message>
+    <message>
+        <source>Credit</source>
+        <translation>입금액</translation>
+    </message>
+    <message numerus="yes">
+        <source>matures in %n more block(s)</source>
+        <translation><numerusform>%n 개의 더 많은 블록 숙성</numerusform></translation>
+    </message>
+    <message>
+        <source>not accepted</source>
+        <translation>허용되지 않음</translation>
+    </message>
+    <message>
+        <source>Debit</source>
+        <translation>출금액</translation>
+    </message>
+    <message>
+        <source>Total debit</source>
+        <translation>총 출금액</translation>
+    </message>
+    <message>
+        <source>Total credit</source>
+        <translation>총 입금액</translation>
+    </message>
+    <message>
+        <source>Transaction fee</source>
+        <translation>거래 수수료</translation>
+    </message>
+    <message>
+        <source>Net amount</source>
+        <translation>총 거래액</translation>
+    </message>
+    <message>
+        <source>Message</source>
+        <translation>메시지</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation>설명</translation>
+    </message>
+    <message>
+        <source>Transaction ID</source>
+        <translation>거래 ID</translation>
+    </message>
+    <message>
+        <source>Transaction total size</source>
+        <translation>거래 총 크기</translation>
+    </message>
+    <message>
+        <source>Output index</source>
+        <translation>출력 인덱스</translation>
+    </message>
+    <message>
+        <source>Merchant</source>
+        <translation>상인</translation>
+    </message>
+    <message>
+        <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
+        <translation>신규 채굴된 코인이 사용되기 위해서는 %1 개의 블록이 경과되어야 합니다. 블록을 생성할 때 블록 체인에 추가되도록 네트워크에 전파되는 과정을 거치는데, 블록 체인에 포함되지 못하고 실패한다면 해당 블록의 상태는 '미승인'으로 표현되고 도지코인 또한 사용될 수 없습니다. 이 현상은 다른 노드가 비슷한 시간대에 동시에 블록을 생성할 때 종종 발생할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Debug information</source>
+        <translation>디버깅 정보</translation>
+    </message>
+    <message>
+        <source>Transaction</source>
+        <translation>거래</translation>
+    </message>
+    <message>
+        <source>Inputs</source>
+        <translation>입력</translation>
+    </message>
+    <message>
+        <source>Amount</source>
+        <translation>거래액</translation>
+    </message>
+    <message>
+        <source>true</source>
+        <translation>참</translation>
+    </message>
+    <message>
+        <source>false</source>
+        <translation>거짓</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionDescDialog</name>
+    <message>
+        <source>This pane shows a detailed description of the transaction</source>
+        <translation>이 창은 거래의 세부내역을 표시함</translation>
+    </message>
+    <message>
+        <source>Details for %1</source>
+        <translation>%1 에 대한 세부 정보</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionTableModel</name>
+    <message>
+        <source>Date</source>
+        <translation>날짜</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>형식</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation>라벨</translation>
+    </message>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation><numerusform>%n 개의 더 많은 블록 열기</numerusform></translation>
+    </message>
+    <message>
+        <source>Open until %1</source>
+        <translation>%1 까지 열림</translation>
+    </message>
+    <message>
+        <source>Offline</source>
+        <translation>오프라인</translation>
+    </message>
+    <message>
+        <source>Unconfirmed</source>
+        <translation>미확인</translation>
+    </message>
+    <message>
+        <source>Abandoned</source>
+        <translation>버려진</translation>
+    </message>
+    <message>
+        <source>Confirming (%1 of %2 recommended confirmations)</source>
+        <translation>승인 중(권장되는 승인 회수 %2 대비 현재 승인 수 %1)</translation>
+    </message>
+    <message>
+        <source>Confirmed (%1 confirmations)</source>
+        <translation>승인됨(%1 확인됨)</translation>
+    </message>
+    <message>
+        <source>Conflicted</source>
+        <translation>충돌</translation>
+    </message>
+    <message>
+        <source>Immature (%1 confirmations, will be available after %2)</source>
+        <translation>충분히 숙성되지 않은 상태(%1 승인, %2 후에 사용할 수 있음)</translation>
+    </message>
+    <message>
+        <source>This block was not received by any other nodes and will probably not be accepted!</source>
+        <translation>이 블록은 다른 노드로부터 받지 않아 허용되지 않을 것입니다!</translation>
+    </message>
+    <message>
+        <source>Generated but not accepted</source>
+        <translation>생성되었으나 거절됨</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation>받은 주소</translation>
+    </message>
+    <message>
+        <source>Received from</source>
+        <translation>보낸 주소</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation>보낸 주소</translation>
+    </message>
+    <message>
+        <source>Payment to yourself</source>
+        <translation>자신에게 지불</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation>채굴</translation>
+    </message>
+    <message>
+        <source>watch-only</source>
+        <translation>조회 전용</translation>
+    </message>
+    <message>
+        <source>(n/a)</source>
+        <translation>(없음)</translation>
+    </message>
+    <message>
+        <source>(no label)</source>
+        <translation>(라벨 없음)</translation>
+    </message>
+    <message>
+        <source>Transaction status. Hover over this field to show number of confirmations.</source>
+        <translation>거래 상황. 마우스를 올리면 검증 횟수가 표시됩니다.</translation>
+    </message>
+    <message>
+        <source>Date and time that the transaction was received.</source>
+        <translation>거래가 이루어진 날짜와 시간입니다.</translation>
+    </message>
+    <message>
+        <source>Type of transaction.</source>
+        <translation>거래의 종류입니다.</translation>
+    </message>
+    <message>
+        <source>Whether or not a watch-only address is involved in this transaction.</source>
+        <translation>조회 전용 주소가 이 거래에 참여하는지 여부입니다.</translation>
+    </message>
+    <message>
+        <source>User-defined intent/purpose of the transaction.</source>
+        <translation>거래의 사용자 정의 의도/목적입니다.</translation>
+    </message>
+    <message>
+        <source>Amount removed from or added to balance.</source>
+        <translation>잔액에서 제거되거나 추가된 금액입니다.</translation>
+    </message>
+</context>
+<context>
+    <name>TransactionView</name>
+    <message>
+        <source>All</source>
+        <translation>전체</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation>오늘</translation>
+    </message>
+    <message>
+        <source>This week</source>
+        <translation>이번 주</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <translation>이번 달</translation>
+    </message>
+    <message>
+        <source>Last month</source>
+        <translation>지난 달</translation>
+    </message>
+    <message>
+        <source>This year</source>
+        <translation>올해</translation>
+    </message>
+    <message>
+        <source>Range...</source>
+        <translation>조회 기간...</translation>
+    </message>
+    <message>
+        <source>Received with</source>
+        <translation>받은 주소</translation>
+    </message>
+    <message>
+        <source>Sent to</source>
+        <translation>보낸 주소</translation>
+    </message>
+    <message>
+        <source>To yourself</source>
+        <translation>자기 거래</translation>
+    </message>
+    <message>
+        <source>Mined</source>
+        <translation>채굴</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>기타</translation>
+    </message>
+    <message>
+        <source>Enter address or label to search</source>
+        <translation>검색하기 위한 주소 또는 라벨 입력하기</translation>
+    </message>
+    <message>
+        <source>Min amount</source>
+        <translation>최소 거래액</translation>
+    </message>
+    <message>
+        <source>Abandon transaction</source>
+        <translation>버려진 거래</translation>
+    </message>
+    <message>
+        <source>Copy address</source>
+        <translation>주소 복사하기</translation>
+    </message>
+    <message>
+        <source>Copy label</source>
+        <translation>라벨 복사하기</translation>
+    </message>
+    <message>
+        <source>Copy amount</source>
+        <translation>거래액 복사하기</translation>
+    </message>
+    <message>
+        <source>Copy transaction ID</source>
+        <translation>거래 ID 복사하기</translation>
+    </message>
+    <message>
+        <source>Copy raw transaction</source>
+        <translation>원시 거래 복사하기</translation>
+    </message>
+    <message>
+        <source>Copy full transaction details</source>
+        <translation>거래 세부 내역 복사하기</translation>
+    </message>
+    <message>
+        <source>Edit label</source>
+        <translation>라벨 수정하기</translation>
+    </message>
+    <message>
+        <source>Show transaction details</source>
+        <translation>거래 세부 내역 보기</translation>
+    </message>
+    <message>
+        <source>Export Transaction History</source>
+        <translation>거래 기록 내보내기</translation>
+    </message>
+    <message>
+        <source>Comma separated file (*.csv)</source>
+        <translation>쉼표로 구분된 파일(*.csv)</translation>
+    </message>
+    <message>
+        <source>Confirmed</source>
+        <translation>확인됨</translation>
+    </message>
+    <message>
+        <source>Watch-only</source>
+        <translation>조회 전용</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>날짜</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>형식</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation>라벨</translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation>주소</translation>
+    </message>
+    <message>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Exporting Failed</source>
+        <translation>내보내기 실패</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the transaction history to %1.</source>
+        <translation>%1 (으)로 거래 기록을 저장하는데 오류가 있었습니다.</translation>
+    </message>
+    <message>
+        <source>Exporting Successful</source>
+        <translation>내보내기 성공</translation>
+    </message>
+    <message>
+        <source>The transaction history was successfully saved to %1.</source>
+        <translation>거래 기록이 성공적으로 %1 에 저장되었습니다.</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>조회 기간:</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>~</translation>
+    </message>
+</context>
+<context>
+    <name>UnitDisplayStatusBarControl</name>
+    <message>
+        <source>Unit to show amounts in. Click to select another unit.</source>
+        <translation>거래액을 표시하는 단위입니다. 클릭해서 다른 단위를 선택할 수 있습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>WalletFrame</name>
+    <message>
+        <source>No wallet has been loaded.</source>
+        <translation>지갑 불러오기가 안됩니다.</translation>
+    </message>
+</context>
+<context>
+    <name>WalletModel</name>
+    <message>
+        <source>Send Coins</source>
+        <translation>코인 보내기</translation>
+    </message>
+</context>
+<context>
+    <name>WalletView</name>
+    <message>
+        <source>&amp;Export</source>
+        <translation>내보내기(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Export the data in the current tab to a file</source>
+        <translation>현재 탭에 있는 데이터를 파일로 내보내기</translation>
+    </message>
+    <message>
+        <source>Backup Wallet</source>
+        <translation>지갑 백업</translation>
+    </message>
+    <message>
+        <source>Wallet Data (*.dat)</source>
+        <translation>지갑 데이터(*.dat)</translation>
+    </message>
+    <message>
+        <source>Backup Failed</source>
+        <translation>백업 실패</translation>
+    </message>
+    <message>
+        <source>There was an error trying to save the wallet data to %1.</source>
+        <translation>지갑 데이터를 %1 폴더에 저장하는 동안 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <source>Backup Successful</source>
+        <translation>백업 성공</translation>
+    </message>
+    <message>
+        <source>The wallet data was successfully saved to %1.</source>
+        <translation>지갑 정보가 %1 에 성공적으로 저장되었습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>dogecoin-core</name>
+    <message>
+        <source>Options:</source>
+        <translation>옵션:</translation>
+    </message>
+    <message>
+        <source>Specify data directory</source>
+        <translation>데이터 폴더 지정</translation>
+    </message>
+    <message>
+        <source>Connect to a node to retrieve peer addresses, and disconnect</source>
+        <translation>노드에 연결하여 피어 주소를 검색하고 연결 끊기</translation>
+    </message>
+    <message>
+        <source>Specify your own public address</source>
+        <translation>공개 주소 지정하기</translation>
+    </message>
+    <message>
+        <source>Accept command line and JSON-RPC commands</source>
+        <translation>커맨드라인과 JSON-RPC 명령 수락하기</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)</source>
+        <translation>외부 접속 승인하기(기본값: -proxy 또는 -connect / -noconnect가 없는 경우 1)</translation>
+    </message>
+    <message>
+        <source>Connect only to the specified node(s); -noconnect or -connect=0 alone to disable automatic connections</source>
+        <translation>지정된 노드에만 연결하기: 자동 연결을 사용하지 않으려면 -noconnect 또는 -connect=0 을 단독으로 사용함</translation>
+    </message>
+    <message>
+        <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
+        <translation>MIT 소프트웨어 라이선스에 따라 배포되며, 함께 제공되는 파일 %s 또는 %s 을/를 참고하세요.</translation>
+    </message>
+    <message>
+        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
+        <translation>&lt;category&gt;가 제공되지 않거나 &lt;category&gt; = 1 인 경우, 모든 디버깅 정보를 출력합니다.</translation>
+    </message>
+    <message>
+        <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
+        <translation>블록 축소가 최소치의 %d MiB 밑으로 설정되어 있습니다. 더 높은 값을 사용해보세요.</translation>
+    </message>
+    <message>
+        <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
+        <translation>블록 축소: 마지막 지갑 동기화 지점이 축소된 데이터보다 과거입니다. -reindex가 필요합니다(정지된 노드의 경우 모든 블록 체인을 다시 다운로드합니다).</translation>
+    </message>
+    <message>
+        <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
+        <translation>블록 축소 모드에서는 재검색이 불가능합니다. -reindex 명령을 사용해서 모든 블록 체인을 다시 다운로드해야 합니다.</translation>
+    </message>
+    <message>
+        <source>Error: A fatal internal error occurred, see debug.log for details</source>
+        <translation>오류: 치명적인 내부 오류가 발생했습니다. 자세한 내용은 debug.log를 확인해주세요.</translation>
+    </message>
+    <message>
+        <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
+        <translation>송금 거래 시 추가되는 수수료(%s/kB) (기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Pruning blockstore...</source>
+        <translation>블록 데이터 축소 중...</translation>
+    </message>
+    <message>
+        <source>Run in the background as a daemon and accept commands</source>
+        <translation>백그라운드에서 데몬으로 실행하고 명령 수락하기</translation>
+    </message>
+    <message>
+        <source>Unable to start HTTP server. See debug log for details.</source>
+        <translation>HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인하세요.</translation>
+    </message>
+    <message>
+        <source>Dogecoin Core</source>
+        <translation>도지코인 코어</translation>
+    </message>
+    <message>
+        <source>The %s developers</source>
+        <translation>%s 개발자</translation>
+    </message>
+    <message>
+        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
+        <translation>충분한 데이터가 축적되지 않은 상태에서의 수수료 추정 기능이 사용하는 수수료 비율(%s/kB) (기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
+        <translation>거래의 중계를 하지 않더라도 화이트리스트에 포함된 피어에서 받은 트랜잭션은 중계하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
+        <translation>선택된 주소로 고정하며 항상 리슨(Listen)합니다. IPv6 프로토콜인 경우 [host]:port 방식의 표기법을 사용합니다.</translation>
+    </message>
+    <message>
+        <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
+        <translation>데이터 폴더 %s 에 락을 걸 수 없었습니다. %s 이/가 이미 실행 중인 것으로 보입니다.</translation>
+    </message>
+    <message>
+        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
+        <translation>모든 지갑 거래를 삭제하고 시작 시 -rescan을 통해 블록 체인의 해당 부분만 복구하기</translation>
+    </message>
+    <message>
+        <source>Error loading %s: You can't enable HD on a already existing non-HD wallet</source>
+        <translation>%s 불러오기 오류: 비-HD 지갑이 존재하는 상태에서 HD 지갑을 활성화할 수 없음</translation>
+    </message>
+    <message>
+        <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
+        <translation>%s 불러오기 오류: 주소 키는 모두 정확하게 로드되었으나, 거래 데이터와 주소록 필드에서 누락이나 오류가 존재할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
+        <translation>지갑 거래 변경 시 명령 실행하기(%s 안의 명령어가 TxID로 바뀜)</translation>
+    </message>
+    <message>
+        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
+        <translation>압축 블록 재구성을 위해 메모리에 보관할 추가 거래(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
+        <translation>이 블록이 체인에 있는 경우 해당 블록과 그 조상이 유효하다고 가정하고 스크립트 확인을 건너뛸 수 있음(0 은 모두 확인, 기본값: %s, 테스트넷: %s)</translation>
+    </message>
+    <message>
+        <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
+        <translation>허용되는 최대 피어 시간 오프셋 조정 중간값. 시간에 대한 지역적 관점은 이 값만큼 전방 또는 후방의 피어에 의해 영향을 받을 수 있습니다. (기본값: %u 초)</translation>
+    </message>
+    <message>
+        <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
+        <translation>컴퓨터의 날짜와 시간이 올바른지 확인하세요! 시간이 잘못되면 %s 은/는 제대로 동작하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
+        <translation>%s 이/가 유용하다고 생각한다면 프로젝트에 기여해주세요. 이 소프트웨어에 대한 보다 자세한 정보는 %s 을/를 방문해주세요.</translation>
+    </message>
+    <message>
+        <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
+        <translation>블록 생성 시 거래가 포함되도록 최저 수수료율을 설정하세요(%s/kB 단위). (기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>스크립트 인증 쓰레드의 개수 설정하기(%u-%d, 0 = 자동, &lt;0 = 지정된 코어 개수만큼 사용하지 않음, 기본값: %d)</translation>
+    </message>
+    <message>
+        <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
+        <translation>블록 데이터베이스에 미래의 블록이 포함되어 있습니다. 이것은 사용자 컴퓨터의 날짜와 시간이 올바르게 설정되어 있지 않을때 나타날 수 있습니다. 만약 사용자 컴퓨터의 날짜와 시간이 올바르다고 확신할 때에만 블록 데이터베이스를 재구성하세요.</translation>
+    </message>
+    <message>
+        <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
+        <translation>출시 전의 테스트 빌드 - 스스로의 책임 하에 사용하세요 - 이므로, 채굴이나 상업적 용도의 프로그램으로 사용하지 마세요.</translation>
+    </message>
+    <message>
+        <source>Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain</source>
+        <translation>데이터베이스를 포크 전 상태로 돌리지 못했습니다. 블록 체인을 다시 다운로드해주세요.</translation>
+    </message>
+    <message>
+        <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
+        <translation>리슨(Listen) 포트를 할당하기 위해 UPnP 사용하기(기본값: 열려 있거나 -proxy 옵션을 사용하지 않을 시 1)</translation>
+    </message>
+    <message>
+        <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
+        <translation>JSON-RPC 연결용 사용자 이름과 해시화된 비밀번호. &lt;userpw&gt; 필드는 &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt; 포맷으로 구성되어 있습니다. 전형적인 파이썬 스크립트에선 share/rpcuser가 포함되어 있습니다. 그런 다음 클라이언트는 rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; 쌍의 인수를 사용하여 정상적으로 연결합니다. 이 옵션은 여러 번 지정할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
+        <translation>지갑은 메모리 풀 체인 제한(기본값: %u)을 위반하는 거래를 생성하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
+        <translation>경고: 모든 네트워크가 동의해야 합니다! 일부 채굴자들에게 문제가 있는 것으로 보입니다.</translation>
+    </message>
+    <message>
+        <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
+        <translation>경고: 현재 도지코인 버전이 다른 네트워크 참여자들과 동일하지 않은 것 같습니다! 당신 또는 다른 참여자들이 동일한 도지코인 버전으로 업그레이드할 필요가 있습니다.</translation>
+    </message>
+    <message>
+        <source>You need to rebuild the database using -reindex-chainstate to change -txindex</source>
+        <translation>-txindex를 바꾸기 위해서는 -reindex-chainstate를 사용해서 데이터베이스를 재구성해야 합니다.</translation>
+    </message>
+    <message>
+        <source>%s corrupt, salvage failed</source>
+        <translation>%s 손상되었고, 복구 실패함</translation>
+    </message>
+    <message>
+        <source>-maxmempool must be at least %d MB</source>
+        <translation>-maxmempool은 최소한 %d MB 필요함</translation>
+    </message>
+    <message>
+        <source>&lt;category&gt; can be:</source>
+        <translation>&lt;category&gt; 지정 가능:</translation>
+    </message>
+    <message>
+        <source>Append comment to the user agent string</source>
+        <translation>사용자 에이전트 문자열에 코멘트 첨부</translation>
+    </message>
+    <message>
+        <source>Attempt to recover private keys from a corrupt wallet on startup</source>
+        <translation>시작 시 망가진 wallet.dat에서 개인 키 복원 시도하기</translation>
+    </message>
+    <message>
+        <source>Block creation options:</source>
+        <translation>블록 생성 옵션:</translation>
+    </message>
+    <message>
+        <source>Cannot resolve -%s address: '%s'</source>
+        <translation>%s 주소를 확인할 수 없음: '%s'</translation>
+    </message>
+    <message>
+        <source>Chain selection options:</source>
+        <translation>체인 선택 옵션:</translation>
+    </message>
+    <message>
+        <source>Change index out of range</source>
+        <translation>범위 밖의 인덱스 변경</translation>
+    </message>
+    <message>
+        <source>Connection options:</source>
+        <translation>연결 설정:</translation>
+    </message>
+    <message>
+        <source>Copyright (C) %i-%i</source>
+        <translation>Copyright (C) %i-%i</translation>
+    </message>
+    <message>
+        <source>Corrupted block database detected</source>
+        <translation>손상된 블록 데이터베이스 감지됨</translation>
+    </message>
+    <message>
+        <source>Debugging/Testing options:</source>
+        <translation>디버그 및 테스트 설정</translation>
+    </message>
+    <message>
+        <source>Do not load the wallet and disable wallet RPC calls</source>
+        <translation>지갑 불러오기를 하지 마시고, 지갑 RPC 연결을 차단하세요.</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation>블록 데이터베이스를 다시 생성하시겠습니까?</translation>
+    </message>
+    <message>
+        <source>Enable publish hash block in &lt;address&gt;</source>
+        <translation>&lt;address&gt;에 대한 해시 블록 공개 활성화</translation>
+    </message>
+    <message>
+        <source>Enable publish hash transaction in &lt;address&gt;</source>
+        <translation>&lt;address&gt;에 대한 해시 거래 공개 활성화</translation>
+    </message>
+    <message>
+        <source>Enable publish raw block in &lt;address&gt;</source>
+        <translation>&lt;address&gt;에 대한 원시 블록 공개 활성화</translation>
+    </message>
+    <message>
+        <source>Enable publish raw transaction in &lt;address&gt;</source>
+        <translation>&lt;address&gt;에 대한 원시 거래 공개 활성화</translation>
+    </message>
+    <message>
+        <source>Enable transaction replacement in the memory pool (default: %u)</source>
+        <translation>메모리 풀 내의 거래 치환(replacement) 활성화(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Error initializing block database</source>
+        <translation>블록 데이터베이스 초기화 오류</translation>
+    </message>
+    <message>
+        <source>Error initializing wallet database environment %s!</source>
+        <translation>지갑 데이터베이스 환경 %s 초기화 오류입니다!</translation>
+    </message>
+    <message>
+        <source>Error loading %s</source>
+        <translation>%s 불러오기 오류</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet corrupted</source>
+        <translation>%s 불러오기 오류: 지갑 손상됨</translation>
+    </message>
+    <message>
+        <source>Error loading %s: Wallet requires newer version of %s</source>
+        <translation>%s 불러오기 오류: 지갑은 새 버전의 %s 이/가 필요함</translation>
+    </message>
+    <message>
+        <source>Error loading %s: You can't disable HD on a already existing HD wallet</source>
+        <translation>%s 불러오기 오류: 이미 HD 지갑이 존재하는 상태에서 HD 지갑을 비활성화할 수 없음</translation>
+    </message>
+    <message>
+        <source>Error loading block database</source>
+        <translation>블록 데이터베이스를 불러오는데 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error opening block database</source>
+        <translation>블록 데이터베이스를 여는데 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error: Disk space is low!</source>
+        <translation>오류: 디스크 공간이 부족합니다!</translation>
+    </message>
+    <message>
+        <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
+        <translation>어떤 포트도 반응하지 않습니다. 원한다면 -listen=0 을 사용하세요.</translation>
+    </message>
+    <message>
+        <source>Importing...</source>
+        <translation>들여오기 중...</translation>
+    </message>
+    <message>
+        <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
+        <translation>올바르지 않거나 생성된 블록을 찾을 수 없습니다. 네트워크에 대한 잘못된 데이터 폴더인가요?</translation>
+    </message>
+    <message>
+        <source>Initialization sanity check failed. %s is shutting down.</source>
+        <translation>무결성 확인 초기화가 실패했습니다. %s 이/가 종료됩니다.</translation>
+    </message>
+    <message>
+        <source>Invalid -onion address: '%s'</source>
+        <translation>잘못된 -onion 주소: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
+        <translation>-%s=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s'</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
+        <translation>-fallbackfee=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s'</translation>
+    </message>
+    <message>
+        <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
+        <translation>거래 메모리 풀의 용량을 &lt;n&gt;메가바이트 아래로 유지하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Loading banlist...</source>
+        <translation>차단 리스트를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Location of the auth cookie (default: data dir)</source>
+        <translation>인증 쿠키의 위치(기본값: data dir)</translation>
+    </message>
+    <message>
+        <source>Not enough file descriptors available.</source>
+        <translation>사용 가능한 파일 디스크립터가 부족합니다.</translation>
+    </message>
+    <message>
+        <source>Only connect to nodes in network &lt;net&gt; (ipv4, ipv6 or onion)</source>
+        <translation>&lt;net&gt; 네트워크로만 접속하기(ipv4, ipv6 혹은 onion)</translation>
+    </message>
+    <message>
+        <source>Print this help message and exit</source>
+        <translation>도움말 메시지 출력 후 종료</translation>
+    </message>
+    <message>
+        <source>Print version and exit</source>
+        <translation>버전 출력 후 종료</translation>
+    </message>
+    <message>
+        <source>Prune cannot be configured with a negative value.</source>
+        <translation>블록 축소는 음수로 설정할 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -txindex.</source>
+        <translation>블록 축소 모드는 -txindex와 호환되지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Rebuild chain state and block index from the blk*.dat files on disk</source>
+        <translation>현재의 blk*.dat 파일들로부터 블록 체인 색인을 재구성합니다.</translation>
+    </message>
+    <message>
+        <source>Rebuild chain state from the currently indexed blocks</source>
+        <translation>현재 색인된 블록들로부터 블록 체인을 재구성합니다.</translation>
+    </message>
+    <message>
+        <source>Rewinding blocks...</source>
+        <translation>블록 되감는 중...</translation>
+    </message>
+    <message>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>데이터베이스 케시 크기를 메가바이트로 설정하기(%d 부터 %d, 기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Set maximum block size in bytes (default: %d)</source>
+        <translation>최대 블록 크기를 Bytes로 지정하기(기본: %d)</translation>
+    </message>
+    <message>
+        <source>Specify wallet file (within data directory)</source>
+        <translation>데이터 폴더 안에 지갑 파일 선택하기</translation>
+    </message>
+    <message>
+        <source>The source code is available from %s.</source>
+        <translation>소스 코드는 %s 에서 확인하실 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Unable to bind to %s on this computer. %s is probably already running.</source>
+        <translation>이 컴퓨터의 %s 에 바인딩할 수 없습니다. 아마도 %s 이/가 실행 중인 것 같습니다.</translation>
+    </message>
+    <message>
+        <source>Unsupported argument -benchmark ignored, use -debug=bench.</source>
+        <translation>지원하지 않는 인수 -benchmark는 무시됩니다. -debug=bench 형태로 사용하세요.</translation>
+    </message>
+    <message>
+        <source>Unsupported argument -debugnet ignored, use -debug=net.</source>
+        <translation>지원하지 않는 인수 -debugnet은 무시됩니다. -debug=net 형태로 사용하세요.</translation>
+    </message>
+    <message>
+        <source>Unsupported argument -tor found, use -onion.</source>
+        <translation>지원하지 않는 인수 -tor를 찾았습니다. -onion를 사용해주세요.</translation>
+    </message>
+    <message>
+        <source>Use UPnP to map the listening port (default: %u)</source>
+        <translation>리슨(Listen) 포트를 할당하기 위해 UPnP 사용하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Use the test chain</source>
+        <translation>테스트 체인 사용</translation>
+    </message>
+    <message>
+        <source>User Agent comment (%s) contains unsafe characters.</source>
+        <translation>사용자 정의 코멘트(%s)에 안전하지 않은 글자가 포함되어 있습니다.</translation>
+    </message>
+    <message>
+        <source>Verifying blocks...</source>
+        <translation>블록 검증 중...</translation>
+    </message>
+    <message>
+        <source>Verifying wallet...</source>
+        <translation>지갑 검증 중...</translation>
+    </message>
+    <message>
+        <source>Wallet %s resides outside data directory %s</source>
+        <translation>지갑 %s 은/는 데이터 폴더 %s 밖에 위치함</translation>
+    </message>
+    <message>
+        <source>Wallet debugging/testing options:</source>
+        <translation>지갑 디버깅/테스트 옵션:</translation>
+    </message>
+    <message>
+        <source>Wallet needed to be rewritten: restart %s to complete</source>
+        <translation>지갑 신규 작성 필요: 완료하려면 %s 을/를 다시 시작하세요.</translation>
+    </message>
+    <message>
+        <source>Wallet options:</source>
+        <translation>지갑 옵션:</translation>
+    </message>
+    <message>
+        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
+        <translation>지정된 소스에서 JSON-RPC 연결을 허용합니다. 유효한 &lt;ip&gt;는 하나의 IP 주소(예 1.2.3.4), 네트워크/넷마스크(예 1.2.3.4/255.255.255.0) 혹은 네트워크/CIDR(예 1.2.3.4/24)입니다. 이 옵션은 어러 번 설정할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
+        <translation>선택된 주소로 고정하여 화이트리스트에 포함된 피어에 접속합니다. IPv6 프로토콜인 경우 [host]:port 방식의 표기법을 사용합니다.</translation>
+    </message>
+    <message>
+        <source>Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)</source>
+        <translation>선택된 주소로 고정하여 JSON-RPC 연결을 리슨(Listen)합니다. IPv6 프로토콜인 경우 [host]:port 방식의 표기법을 사용합니다. 이 옵션은 복수로 지정할 수 있습니다. (기본값: 모든 인터페이스에 고정)</translation>
+    </message>
+    <message>
+        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
+        <translation>umask 077 대신 시스템 기본 퍼미션으로 새 파일 생성하기(지갑 기능이 비활성화 상태에서만 유효함)</translation>
+    </message>
+    <message>
+        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
+        <translation>자신의 IP 주소 탐색하기(기본값: 열려 있거나 -externalip 나 -proxy 옵션이 없으면 1)</translation>
+    </message>
+    <message>
+        <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
+        <translation>오류: 들어오는 연결을 리슨(Listen)하는데 실패함(리슨 반환된 오류 %s)</translation>
+    </message>
+    <message>
+        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
+        <translation>이 사항과 관련있는 경고가 발생하거나 아주 긴 포크가 발생했을 때 명령어 실행하기(cmd 명령어 목록에서 %s 은/는 메시지로 대체됨)</translation>
+    </message>
+    <message>
+        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
+        <translation>해당 금액(%s/kB)보다 적은 수수료는 중계, 채굴, 거래 생성에서 수수료 면제로 간주됨(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
+        <translation>paytxfee가 설정되어 있지 않다면, 평균 n 블록 안에 승인이 이루어지도록 충분한 수수료가 포함됨(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
+        <translation>유효하지 않은 금액 -maxtxfee=&lt;amount&gt;: '%s' (거래가 막히는 상황을 방지하게 위해 적어도 %s 의 중계 수수료를 지정해야 함)</translation>
+    </message>
+    <message>
+        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
+        <translation>중계 및 채굴을 할 때 데이터 운송 거래에서 데이터의 최대 크기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
+        <translation>인증 정보를 프록시 연결마다 무작위로 합니다. 이는 Tor 스트림을 격리시킬 수 있습니다. (기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
+        <translation>높은 우선 순위/낮은 수수료 거래의 바이트 단위의 최대 크기 설정하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to send after the fee has been deducted</source>
+        <translation>수수료를 차감한 후 송금할 거래 금액이 너무 적음</translation>
+    </message>
+    <message>
+        <source>Use hierarchical deterministic key generation (HD) after BIP32. Only has effect during wallet creation/first start</source>
+        <translation>BIP32 이후에는 계층적 결정성 키 생성(HD)을 사용하세요. 지갑 생성/처음 시작 시에만 효과가 있습니다.</translation>
+    </message>
+    <message>
+        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
+        <translation>화이트리스트에 포함된 피어는 이미 메모리 풀에 포함되어 있어도 DoS 차단이 되지 않으며, 그들의 거래가 항상 중계됩니다. 이는 예를 들면 게이트웨이에서 유용합니다.</translation>
+    </message>
+    <message>
+        <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
+        <translation>축소 모드를 해제하고 데이터베이스를 재구성하기 위해 -reindex를 사용해야 합니다. 이 명령은 모든 블록 체인을 다시 다운로드할 것입니다.</translation>
+    </message>
+    <message>
+        <source>(default: %u)</source>
+        <translation>(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Accept public REST requests (default: %u)</source>
+        <translation>공개 REST 요청을 허가(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Automatically create Tor hidden service (default: %d)</source>
+        <translation>Tor 서비스를 자동으로 생성하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Connect through SOCKS5 proxy</source>
+        <translation>SOCK5 프록시를 통해 연결하기</translation>
+    </message>
+    <message>
+        <source>Error reading from database, shutting down.</source>
+        <translation>블록 데이터베이스를 불러오는데 오류가 발생하여 종료됩니다.</translation>
+    </message>
+    <message>
+        <source>Imports blocks from external blk000??.dat file on startup</source>
+        <translation>외부 blk000??.dat 파일에서 블록 가져오기</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
+        <translation>-paytxfee=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s' (최소 %s 이상이어야 됨)</translation>
+    </message>
+    <message>
+        <source>Invalid netmask specified in -whitelist: '%s'</source>
+        <translation>-whitelist에 지정된 잘못된 넷마스크: '%s'</translation>
+    </message>
+    <message>
+        <source>Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
+        <translation>최대 &lt;n&gt;개의 연결할 수 없는 거래를 메모리에 저장하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Need to specify a port with -whitebind: '%s'</source>
+        <translation>-whitebind를 이용하여 포트 지정 필요: '%s'</translation>
+    </message>
+    <message>
+        <source>Node relay options:</source>
+        <translation>노드 중계 옵션:</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>RPC 서버 설정</translation>
+    </message>
+    <message>
+        <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
+        <translation>시스템 한계로 인하여 -maxconnections를 %d 에서 %d (으)로 줄였습니다.</translation>
+    </message>
+    <message>
+        <source>Rescan the block chain for missing wallet transactions on startup</source>
+        <translation>시작 시 누락된 지갑 거래에 대해 블록 체인을 다시 검색합니다</translation>
+    </message>
+    <message>
+        <source>Send trace/debug info to console instead of debug.log file</source>
+        <translation>추적 오류 정보를 degug.log 자료로 보내는 대신 콘솔로 보내기</translation>
+    </message>
+    <message>
+        <source>Send transactions as zero-fee transactions if possible (default: %u)</source>
+        <translation>가능한 경우 수수료 없이 거래 보내기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>모든 디버그 설정 보기(설정: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
+        <translation>클라이언트 시작 시 debug.log 파일 비우기(기본값: -debug 옵션 없을 때 1)</translation>
+    </message>
+    <message>
+        <source>Signing transaction failed</source>
+        <translation>거래를 서명하는데 실패함</translation>
+    </message>
+    <message>
+        <source>The transaction amount is too small to pay the fee</source>
+        <translation>거래액이 수수료를 지불하기엔 너무 적음</translation>
+    </message>
+    <message>
+        <source>This is experimental software.</source>
+        <translation>이 소프트웨어는 시험적입니다.</translation>
+    </message>
+    <message>
+        <source>Tor control port password (default: empty)</source>
+        <translation>Tor 관리 포트 암호(기본값: 공란)</translation>
+    </message>
+    <message>
+        <source>Tor control port to use if onion listening enabled (default: %s)</source>
+        <translation>onion 리슨 활성화된 경우 사용할 Tor 관리 포트(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Transaction amount too small</source>
+        <translation>거래액이 너무 적음</translation>
+    </message>
+    <message>
+        <source>Transaction too large for fee policy</source>
+        <translation>수수료 정책에 비해 거래가 너무 큼</translation>
+    </message>
+    <message>
+        <source>Transaction too large</source>
+        <translation>너무 큰 거래</translation>
+    </message>
+    <message>
+        <source>Upgrade wallet to latest format on startup</source>
+        <translation>시작 시 지갑 포맷을 최신으로 업그레이드함</translation>
+    </message>
+    <message>
+        <source>Username for JSON-RPC connections</source>
+        <translation>JSON-RPC 연결에 사용할 사용자 이름</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+    <message>
+        <source>Warning: unknown new rules activated (versionbit %i)</source>
+        <translation>경고: 알려지지 않은 새로운 규칙이 활성화됨(버전비트 %i)</translation>
+    </message>
+    <message>
+        <source>Whether to operate in a blocks only mode (default: %u)</source>
+        <translation>블록 전용 모드로 동작할 지 여부(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Zapping all transactions from wallet...</source>
+        <translation>지갑의 모든 거래 내역 건너뛰기...</translation>
+    </message>
+    <message>
+        <source>ZeroMQ notification options:</source>
+        <translation>ZeroMQ 알림 옵션:</translation>
+    </message>
+    <message>
+        <source>Password for JSON-RPC connections</source>
+        <translation>JSON-RPC 연결에 사용할 비밀번호</translation>
+    </message>
+    <message>
+        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
+        <translation>최고의 블록이 변하면 명령 실행하기(cmd에 있는 %s 은/는 블록 해시에 의해 대체됨)</translation>
+    </message>
+    <message>
+        <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
+        <translation>-addnode, -seednode, -connect 옵션에 대해 DNS 탐색 허용</translation>
+    </message>
+    <message>
+        <source>Loading addresses...</source>
+        <translation>주소를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
+        <translation>(1 = 거래의 메타 데이터(계좌 정보와 지불 요구 정보와 같은)를 유지함, 2 = 거래 메타 데이터 파기)</translation>
+    </message>
+    <message>
+        <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
+        <translation>-maxtxfee 값이 너무 큽니다! 하나의 거래에 너무 큰 수수료가 지불됩니다.</translation>
+    </message>
+    <message>
+        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
+        <translation>메모리 풀에 있는 거래 기록을 &lt;n&gt;시간 후 부터는 유지하지 않기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Equivalent bytes per sigop in transactions for relay and mining (default: %u)</source>
+        <translation>릴레이 및 마이닝 거래의 sigop 당 동등한 바이트(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
+        <translation>해당 금액(%s/kB)보다 적은 수수료는 수수료 면제로 간주됨(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
+        <translation>피어들이 로컬 중계 정책을 위반하더라도 화이트리스트에 포함된 피어인 경우 강제로 중계하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
+        <translation>-checkblocks을 통한 블록 점검(0-4, 기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
+        <translation>getrawtransaction를 RPC CALL을 통해 완전한 거래 인덱스 유지(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
+        <translation>이상 행동을 하는 네트워크 참여자들을 다시 연결시키는데 걸리는 시간(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
+        <translation>디버그 정보 출력(기본값: %u, &lt;category&gt; 제공은 선택 사항)</translation>
+    </message>
+    <message>
+        <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)</source>
+        <translation>보유한 피어 주소가 적은 경우, DNS 조회를 통해 피어 주소 요청하기(-connect / -noconnect가 아니라면 기본값은 1)</translation>
+    </message>
+    <message>
+        <source>Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)</source>
+        <translation>non-segwit(0) 또는 segwit(1)이 아닌 자세한 정보 표시 모드로 반환된 원시 거래 또는 블록 hex의 직렬화 설정하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
+        <translation>블룸 필터를 통해 블록과 거래 필터링 지원(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you may pay when fee estimates are not available.</source>
+        <translation>이것은 수수료 견적을 이용할 수 없을 때 지불할 수 있는 거래 수수료입니다.</translation>
+    </message>
+    <message>
+        <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
+        <translation>이 제품에는 OpenSSL 프로젝트에서 OpenSSL 툴킷 %s (으)로 사용하기 위해 개발한 소프트웨어와 Eric Young이 작성한 암호화 소프트웨어 및 Thomas Bernard가 작성한 UPnP 소프트웨어가 포함되어 있습니다.</translation>
+    </message>
+    <message>
+        <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
+        <translation>네트워크 버전 문자(%i)의 길이가 최대 길이(%i)를 초과합니다. UA 코멘트의 개수나 길이를 줄이세요.</translation>
+    </message>
+    <message>
+        <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
+        <translation>아웃바운드 트래픽을 설정된 목표치 이하로 유지하기(24시간 당 MiB 기준), 0 = 무제한(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
+        <translation>지원하지 않는 인수 -socks를 찾았습니다. 설정된 SOCKS의 버전은 더이상 사용할 수 없으며, SOCK5 프록시만을 지원합니다.</translation>
+    </message>
+    <message>
+        <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
+        <translation>지원하지 않는 인수 -whitelistalwaysrelay는 무시됩니다. -whitelistrelay나 -whitelistforcerelay를 사용해주세요.</translation>
+    </message>
+    <message>
+        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
+        <translation>Tor 서비스를 이용하여 피어에게 연결하기 위해 분리된 SOCKS5 프록시 사용하기(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Warning: Unknown block versions being mined! It's possible unknown rules are in effect</source>
+        <translation>경고: 알려지지 않은 버전의 블록이 채굴되었습니다! 알려지지 않은 규칙이 적용되었을 가능성이 있습니다.</translation>
+    </message>
+    <message>
+        <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
+        <translation>경고: 지갑 파일이 손상되어 데이터가 복구되었습니다. 원래의 %s 파일은 %s 후에 %s 이름으로 저장됩니다. 잔액과 거래 내역이 정확하지 않다면 백업 파일로부터 복원해야 합니다.</translation>
+    </message>
+    <message>
+        <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
+        <translation>설정된 IP 주소(보기 1.2.3.4) 혹은 CIDR로 작성된 네트워크(보기 1.2.3.0/24)로 화이트리스트에 포함된 피어에 접속합니다. 이 설정은 복수로 지정할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>%s is set very high!</source>
+        <translation>%s 이/가 매우 높게 설정되었습니다!</translation>
+    </message>
+    <message>
+        <source>(default: %s)</source>
+        <translation>(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Always query for peer addresses via DNS lookup (default: %u)</source>
+        <translation>DNS lookup을 통해 항상 피어 주소에 대한 쿼리 보내기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>How many blocks to check at startup (default: %u, 0 = all)</source>
+        <translation>시작 시 점검할 블록 개수(기본값: %u, 0 = 모두)</translation>
+    </message>
+    <message>
+        <source>Include IP addresses in debug output (default: %u)</source>
+        <translation>디버그 출력에 IP 주소 포함하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Invalid -proxy address: '%s'</source>
+        <translation>잘못된 -proxy 주소: '%s'</translation>
+    </message>
+    <message>
+        <source>Keypool ran out, please call keypoolrefill first</source>
+        <translation>Keypool이 종료되었습니다. 먼저 keypoolrefill을 호출하세요.</translation>
+    </message>
+    <message>
+        <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
+        <translation>JSON-RPC 연결을 &lt;port&gt; 포트로 리슨하기(기본값: %u 혹은 테스트넷: %u)</translation>
+    </message>
+    <message>
+        <source>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
+        <translation>&lt;port&gt; 포트로 연결 리슨하기(기본값: %u 혹은 테스트넷: %u)</translation>
+    </message>
+    <message>
+        <source>Maintain at most &lt;n&gt; connections to peers (default: %u)</source>
+        <translation>피어 연결 수를 &lt;n&gt;개로 유지(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Make the wallet broadcast transactions</source>
+        <translation>지갑 브로드캐스트 거래 만들기</translation>
+    </message>
+    <message>
+        <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
+        <translation>접속별 최대 수신 버퍼. &lt;n&gt; × 1000바이트(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
+        <translation>접속별 최대 전송 버퍼. &lt;n&gt; × 1000바이트(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Prepend debug output with timestamp (default: %u)</source>
+        <translation>디버그 출력에 타임스탬프 포함하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Relay and mine data carrier transactions (default: %u)</source>
+        <translation>데이터 운송 거래 중계 및 채굴(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Relay non-P2SH multisig (default: %u)</source>
+        <translation>비 P2SH 다중 서명 중계(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Send transactions with full-RBF opt-in enabled (default: %u)</source>
+        <translation>full-RBF opt-in이 활성화된 거래 전송하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Set key pool size to &lt;n&gt; (default: %u)</source>
+        <translation>키 풀 사이즈를 &lt;n&gt;로 설정하기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Set maximum BIP141 block weight (default: %d)</source>
+        <translation>최대 BIP141 블록 가중치 설정하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Set the number of threads to service RPC calls (default: %d)</source>
+        <translation>원격 프로시져 호출 서비스를 위한 쓰레드 개수 설정하기(기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Specify configuration file (default: %s)</source>
+        <translation>설정 파일 지정하기(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
+        <translation>밀리초 단위로 연결 제한 시간 설정하기(최솟값: 1, 기본값: %d)</translation>
+    </message>
+    <message>
+        <source>Specify pid file (default: %s)</source>
+        <translation>pid 파일 지정하기(기본값: %s)</translation>
+    </message>
+    <message>
+        <source>Spend unconfirmed change when sending transactions (default: %u)</source>
+        <translation>거래를 보낼 때 검증되지 않은 잔돈 쓰기(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Starting network threads...</source>
+        <translation>네트워크 쓰레드 시작 중...</translation>
+    </message>
+    <message>
+        <source>The wallet will avoid paying less than the minimum relay fee.</source>
+        <translation>지갑은 최소 중계 수수료보다 적은 금액을 지불하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>This is the minimum transaction fee you pay on every transaction.</source>
+        <translation>이것은 모든 거래에서 지불하는 최소 거래 수수료입니다.</translation>
+    </message>
+    <message>
+        <source>This is the transaction fee you will pay if you send a transaction.</source>
+        <translation>이것은 거래를 보낼 때 지불할 거래 수수료입니다.</translation>
+    </message>
+    <message>
+        <source>Threshold for disconnecting misbehaving peers (default: %u)</source>
+        <translation>비정상적인 피어의 연결을 차단시키기 위한 임계값(기본값: %u)</translation>
+    </message>
+    <message>
+        <source>Transaction amounts must not be negative</source>
+        <translation>거래액은 반드시 정수여야 함</translation>
+    </message>
+    <message>
+        <source>Transaction has too long of a mempool chain</source>
+        <translation>거래가 너무 긴 메모리 풀 체인을 갖고 있음</translation>
+    </message>
+    <message>
+        <source>Transaction must have at least one recipient</source>
+        <translation>거래에는 최소한 한 명의 수령인이 있어야 함</translation>
+    </message>
+    <message>
+        <source>Unknown network specified in -onlynet: '%s'</source>
+        <translation>-onlynet에 지정한 네트워크를 알 수 없음: '%s'</translation>
+    </message>
+    <message>
+        <source>Insufficient funds</source>
+        <translation>자금 부족</translation>
+    </message>
+    <message>
+        <source>Loading block index...</source>
+        <translation>블록 인덱스를 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Add a node to connect to and attempt to keep the connection open</source>
+        <translation>노드를 추가하여 연결하고 연결 상태를 계속 유지하려고 시도함</translation>
+    </message>
+    <message>
+        <source>Loading wallet...</source>
+        <translation>지갑을 불러오는 중...</translation>
+    </message>
+    <message>
+        <source>Cannot downgrade wallet</source>
+        <translation>지갑을 다운그레이드할 수 없음</translation>
+    </message>
+    <message>
+        <source>Cannot write default address</source>
+        <translation>기본 계좌에 기록할 수 없음</translation>
+    </message>
+    <message>
+        <source>Rescanning...</source>
+        <translation>재검색 중...</translation>
+    </message>
+    <message>
+        <source>Done loading</source>
+        <translation>로딩 완료</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Fixes #2214 

The Korean translation has the following errors and needs to be fixed.
This PR contains corrections the following errors:
- Typos
- Incorrect translation
- 'Bitcoin' instead of 'Dogecoin' in Korean translation
- 'Satoshi' instead of 'Koinu' in Korean translation
- etc.

File: src/qt/locale/bitcoin_ko_KR.ts