### PR TITLE
Fix errors of bitcoin_ko_KR.ts file for 1.21-dev

### DIFF
--- a/src/qt/locale/bitcoin_ko.ts
+++ b/src/qt/locale/bitcoin_ko.ts
@@ -3,7 +3,7 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation>지갑 주소나 라벨을 수정하려면 우클릭을 하십시오.</translation>
+        <translation>지갑 주소나 라벨을 수정하려면 우클릭을 하세요.</translation>
     </message>
     <message>
         <source>Create a new address</source>
@@ -27,11 +27,11 @@
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>목록에 현재 선택한 주소를 삭제</translation>
+        <translation>목록에 현재 선택한 주소 삭제</translation>
     </message>
     <message>
         <source>Enter address or label to search</source>
-        <translation>검색하려는 주소 또는 라벨을 입력하십시오.</translation>
+        <translation>검색하려는 주소 또는 라벨 입력</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -47,11 +47,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation>코인을 보낼 주소를 선택하십시오.</translation>
+        <translation>코인을 보낼 주소 선택</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation>코인을 받을 주소를 선택하십시오.</translation>
+        <translation>코인을 받을 주소 선택</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -67,12 +67,12 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>비트코인을 보내는 계좌 주소입니다. 코인을 보내기 전에 금액과 받는 주소를 항상 확인하십시오.</translation>
+        <translation>도지코인을 보내는 계좌 주소입니다. 코인을 보내기 전에 금액과 받는 주소를 항상 확인하세요.</translation>
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. Use the 'Create new receiving address' button in the receive tab to create new addresses.
 Signing is only possible with addresses of the type 'legacy'.</source>
-        <translation>비트코인을 받는 계좌 주소입니다. 신규 주소를 만들려면 수신 탭의 '새 수신 주소를 생성하기' 버튼을 사용하십시오.
+        <translation>도지코인을 받는 계좌 주소입니다. 신규 주소를 만들려면 수신 탭의 '새로운 받는 주소 생성' 버튼을 사용하세요.
 서명은 '레거시' 타입의 주소만 가능합니다.</translation>
     </message>
     <message>
@@ -101,7 +101,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <translation>%1 으로 주소 리스트를 저장하는 동안 오류가 발생했습니다. 다시 시도해 주십시오.</translation>
+        <translation>%1 (으)로 주소 리스트를 저장하는 동안 오류가 발생했습니다. 다시 시도해주세요.</translation>
     </message>
 </context>
 <context>
@@ -151,7 +151,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation>지갑 잠금을 해제</translation>
+        <translation>지갑 잠금 해제</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
@@ -171,11 +171,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>경고: 만약 암호화 된 지갑의 비밀번호를 잃어버릴 경우, &lt;b&gt;모든 비트코인들을 잃어버릴 수 있습니다&lt;/b&gt;!</translation>
+        <translation>경고: 만약 암호화된 지갑의 암호를 잃어버릴 경우, &lt;b&gt;모든 도지코인을 잃어버릴 수 있습니다&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation>지갑 암호화를 허용하시겠습니까?</translation>
+        <translation>지갑 암호화를 수락하시겠습니까?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
@@ -183,15 +183,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter the new passphrase for the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>새로운 지갑 비밀번호를 입력하세요. &lt;br/&gt; 암호는 &lt;b&gt;10개 이상의 랜덤 문자&lt;/b&gt; 또는 &lt;b&gt;8개 이상의 단어&lt;/b&gt;를 사용해주세요.</translation>
+        <translation>새로운 지갑 암호를 입력하세요. &lt;br/&gt;암호는 &lt;b&gt;10개 이상의 랜덤 문자&lt;/b&gt; 또는 &lt;b&gt;8개 이상의 단어&lt;/b&gt;를 사용해주세요.</translation>
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase for the wallet.</source>
-        <translation>지갑의 이전 비밀번호와 새로운 비밀번호를 입력하세요.</translation>
+        <translation>지갑의 이전 암호와 새로운 암호를 입력하세요.</translation>
     </message>
     <message>
         <source>Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>지갑을 암호화 해도 컴퓨터에 바이러스가 있을시 안전하지 않다는 것을 참고하세요.</translation>
+        <translation>지갑을 암호화해도 컴퓨터에 바이러스가 있을 경우 안전하지 않다는 것을 참고하세요.</translation>
     </message>
     <message>
         <source>Wallet to be encrypted</source>
@@ -199,15 +199,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Your wallet is about to be encrypted. </source>
-        <translation>지갑이 암호화 되기 직전입니다.</translation>
+        <translation>지갑이 암호화되기 직전입니다. </translation>
     </message>
     <message>
         <source>Your wallet is now encrypted. </source>
-        <translation>지갑이 암호화 되었습니다.</translation>
+        <translation>지갑이 암호화되었습니다. </translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>중요: 본인 지갑 파일에서 만든 예전 백업들은 새로 생성한, 암호화된 지갑 파일로 교체해야 합니다. 보안상 이유로, 이전에 암호화하지 않은 지갑 파일의 백업은 새로운 암호화된 지갑을 사용하게 된 순간 부터 쓸모가 없어집니다.</translation>
+        <translation>중요: 본인 지갑 파일에서 만든 예전 백업들은 새로 생성한, 암호화된 지갑 파일로 교체해야 합니다. 보안 상의 이유로, 이전에 암호화하지 않은 지갑 파일의 백업은 새로 암호화된 지갑을 사용하게 된 순간부터 쓸모가 없어집니다.</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
@@ -215,7 +215,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation>지갑 암호화가 내부 오류로 인해 실패했습니다.  당신의 지갑은 암호화 되지 않았습니다.</translation>
+        <translation>지갑 암호화가 내부 오류로 인해 실패했습니다. 당신의 지갑은 암호화되지 않았습니다.</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
@@ -223,7 +223,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation>지갑 잠금해제 실패</translation>
+        <translation>지갑 잠금 해제 실패</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
@@ -239,18 +239,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation>경고: Caps Lock키가 켜져있습니다!</translation>
+        <translation>경고: Caps Lock 키가 켜져 있습니다!</translation>
     </message>
 </context>
 <context>
     <name>BanTableModel</name>
     <message>
         <source>IP/Netmask</source>
-        <translation>IP주소/넷마스크</translation>
+        <translation>IP 주소/넷마스크</translation>
     </message>
     <message>
         <source>Banned Until</source>
-        <translation>해당 일정까지 밴됨:</translation>
+        <translation>해당 일정까지 차단됨:</translation>
     </message>
 </context>
 <context>
@@ -261,7 +261,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Synchronizing with network...</source>
-        <translation>네트워크와 동기화중...</translation>
+        <translation>네트워크와 동기화 중...</translation>
     </message>
     <message>
         <source>&amp;Overview</source>
@@ -269,7 +269,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>지갑의 일반적 개요를 보여주기</translation>
+        <translation>지갑의 일반적 개요 보여주기</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
@@ -277,7 +277,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation>거래내역을 검색하기</translation>
+        <translation>거래 내역 검색하기</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -285,7 +285,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Quit application</source>
-        <translation>어플리케이션 종료</translation>
+        <translation>애플리케이션 종료</translation>
     </message>
     <message>
         <source>&amp;About %1</source>
@@ -293,7 +293,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation>%1 정보를 표시합니다</translation>
+        <translation>%1 정보 표시하기</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
@@ -301,7 +301,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation>Qt 정보를 표시합니다</translation>
+        <translation>Qt 정보 표시하기</translation>
     </message>
     <message>
         <source>&amp;Options...</source>
@@ -349,11 +349,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Click to enable network activity again.</source>
-        <translation>네트워크 활동을 다시 시작하려면 클릭하십시오.</translation>
+        <translation>네트워크 활동을 다시 시작하려면 클릭하세요.</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)...</source>
-        <translation>헤더 동기화 중 (%1%)...</translation>
+        <translation>헤더 동기화 중(%1%)...</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk...</source>
@@ -361,15 +361,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Proxy is &lt;b&gt;enabled&lt;/b&gt;: %1</source>
-        <translation>프록시가 &lt;b&gt;활성화&lt;/b&gt; 되었습니다: %1</translation>
+        <translation>프록시가 &lt;b&gt;활성화&lt;/b&gt;되었습니다: %1</translation>
     </message>
     <message>
         <source>Send coins to a Bitcoin address</source>
-        <translation>코인을 비트코인 주소로 전송합니다.</translation>
+        <translation>코인을 도지코인 주소로 전송합니다.</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>지갑을 다른장소에 백업합니다.</translation>
+        <translation>지갑을 다른 장소에 백업합니다.</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
@@ -393,11 +393,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show or hide the main Window</source>
-        <translation>메인창 보이기 또는 숨기기</translation>
+        <translation>메인 창 보이기 또는 숨기기</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>지갑에 포함된 개인키 암호화하기</translation>
+        <translation>지갑에 포함된 개인 키 암호화하기</translation>
     </message>
     <message>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
@@ -405,7 +405,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>해당 비트코인 주소로 서명되었는지 확인하기 위해 메시지를 검증합니다.</translation>
+        <translation>해당 도지코인 주소로 서명되었는지 확인하기 위해 메시지를 검증합니다.</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -425,23 +425,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation>지불 요청하기 (QR 코드와 bitcoin을 생성합니다: URIs)</translation>
+        <translation>지불 요청하기(QR 코드와 dogecoin: URI 생성)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation>한번 이상 사용된 보내는 주소와 라벨의 목록을 보이기</translation>
+        <translation>한 번 이상 사용된 보내는 주소와 라벨의 목록 보이기</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation>한번 이상 사용된 받는 주소와 라벨의 목록을 보이기</translation>
+        <translation>한 번 이상 사용된 받는 주소와 라벨의 목록 보이기</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation>명령줄 옵션(&amp;C)</translation>
+        <translation>커맨드라인 옵션(&amp;C)</translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network</source>
-        <translation><numerusform>비트코인 네트워크에 %n 개의 연결이 활성화 되고 있습니다.</numerusform></translation>
+        <translation><numerusform>도지코인 네트워크에 %n 개의 연결이 활성화되어 있습니다.</numerusform></translation>
     </message>
     <message>
         <source>Indexing blocks on disk...</source>
@@ -453,11 +453,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message numerus="yes">
         <source>Processed %n block(s) of transaction history.</source>
-        <translation><numerusform>%n 블록 만큼의 거래 기록이 처리됩니다.</numerusform></translation>
+        <translation><numerusform>%n 블록만큼의 거래 기록이 처리됩니다.</numerusform></translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>%1 뒷처지는 중</translation>
+        <translation>%1 뒤쳐지는 중</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
@@ -489,7 +489,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction</source>
-        <translation>부분적으로 서명된 비트코인 트랜잭션 불러오기</translation>
+        <translation>부분적으로 서명된 도지코인 거래(PSBT) 불러오기</translation>
     </message>
     <message>
         <source>Load PSBT from clipboard...</source>
@@ -497,7 +497,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Load Partially Signed Bitcoin Transaction from clipboard</source>
-        <translation>클립보드로부터 부분적으로 서명된 비트코인 트랜잭션 불러오기</translation>
+        <translation>클립보드로부터 부분적으로 서명된 도지코인 거래(PSBT) 불러오기</translation>
     </message>
     <message>
         <source>Node window</source>
@@ -505,7 +505,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open node debugging and diagnostic console</source>
-        <translation>노드 디버깅 및 진단 콘솔 열기 </translation>
+        <translation>노드 디버깅 및 진단 콘솔 열기</translation>
     </message>
     <message>
         <source>&amp;Sending addresses</source>
@@ -517,7 +517,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open a bitcoin: URI</source>
-        <translation>bitcoin 열기: URI</translation>
+        <translation>dogecoin: URI 열기</translation>
     </message>
     <message>
         <source>Open Wallet</source>
@@ -525,7 +525,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open a wallet</source>
-        <translation>지갑 하나 열기</translation>
+        <translation>지갑 열기</translation>
     </message>
     <message>
         <source>Close Wallet...</source>
@@ -545,7 +545,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Bitcoin command-line options</source>
-        <translation>사용할 수 있는 비트코인 명령줄 옵션 목록을 가져오기 위해 %1 도움말 메시지를 표시합니다.</translation>
+        <translation>사용할 수 있는 도지코인 커맨드라인 옵션 목록을 가져오기 위해 %1 도움말 메시지 표시하기</translation>
     </message>
     <message>
         <source>&amp;Mask values</source>
@@ -577,7 +577,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Main Window</source>
-        <translation>메인창</translation>
+        <translation>메인 창</translation>
     </message>
     <message>
         <source>%1 client</source>
@@ -585,7 +585,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Connecting to peers...</source>
-        <translation>피어에 연결중...</translation>
+        <translation>피어에 연결 중...</translation>
     </message>
     <message>
         <source>Catching up...</source>
@@ -641,35 +641,35 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation>들어오고 있는 거래</translation>
+        <translation>들어오는 거래</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation>HD 키 생성이 &lt;b&gt;활성화되었습니다&lt;/b&gt;</translation>
+        <translation>HD 키 생성이 &lt;b&gt;활성화됨&lt;/b&gt;</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation>HD 키 생성이 &lt;b&gt;비활성화되었습니다&lt;/b&gt;</translation>
+        <translation>HD 키 생성이 &lt;b&gt;비활성화됨&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Private key &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation>개인키 &lt;b&gt;비활성화됨&lt;/b&gt;</translation>
+        <translation>개인 키 &lt;b&gt;비활성화됨&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt; 되었고 현재 &lt;b&gt;잠금해제&lt;/b&gt; 되었습니다</translation>
+        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt;되었고 현재 &lt;b&gt;잠금 해제&lt;/b&gt;됨</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt; 되었고 현재 &lt;b&gt;잠겨&lt;/b&gt; 있습니다</translation>
+        <translation>지갑이 &lt;b&gt;암호화&lt;/b&gt;되었고 현재 &lt;b&gt;잠금 상태&lt;/b&gt;임</translation>
     </message>
     <message>
         <source>Original message:</source>
-        <translation>원본 메세지:</translation>
+        <translation>원본 메시지:</translation>
     </message>
     <message>
         <source>A fatal error occurred. %1 can no longer continue safely and will quit.</source>
-        <translation>치명적인 오류가 발생했습니다. %1 를 더이상 안전하게 진행할 수 없어 곧 종료합니다.</translation>
+        <translation>치명적인 오류가 발생했습니다. %1 을/를 더이상 안전하게 진행할 수 없어 곧 종료합니다.</translation>
     </message>
 </context>
 <context>
@@ -724,11 +724,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Received with label</source>
-        <translation>입금과 함께 수신된 라벨</translation>
+        <translation>라벨로 입금</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation>입금과 함께 수신된 주소</translation>
+        <translation>주소로 입금</translation>
     </message>
     <message>
         <source>Date</source>
@@ -756,11 +756,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Copy transaction ID</source>
-        <translation>거래 아이디 복사</translation>
+        <translation>거래 ID 복사</translation>
     </message>
     <message>
         <source>Lock unspent</source>
-        <translation>사용되지 않은 주소를 잠금 처리합니다.</translation>
+        <translation>사용하지 않은 주소 잠금 처리</translation>
     </message>
     <message>
         <source>Unlock unspent</source>
@@ -780,7 +780,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Copy bytes</source>
-        <translation>bytes 복사</translation>
+        <translation>바이트 복사</translation>
     </message>
     <message>
         <source>Copy dust</source>
@@ -800,15 +800,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>no</source>
-        <translation>아니요</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation>수령인이 현재 더스트 임계값보다 작은 양을 수신하면 이 라벨이 빨간색으로 변합니다.</translation>
+        <translation>수령인이 현재 더스트 임계값보다 적은 양을 수신하면 이 라벨이 빨간색으로 변합니다.</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>입력마다 +/- %1 사토시(satoshi)가 바뀔 수 있습니다.</translation>
+        <translation>입력마다 +/- %1 코이누(koinu)가 바뀔 수 있습니다.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -816,7 +816,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation>%1 로부터 변경 (%2)</translation>
+        <translation>%1 (으)로부터 변경 (%2)</translation>
     </message>
     <message>
         <source>(change)</source>
@@ -827,11 +827,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>CreateWalletActivity</name>
     <message>
         <source>Creating Wallet &lt;b&gt;%1&lt;/b&gt;...</source>
-        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 생성중...</translation>
+        <translation>지갑 &lt;b&gt;%1&lt;/b&gt; 생성 중...</translation>
     </message>
     <message>
         <source>Create wallet failed</source>
-        <translation>지갑 생성하기 실패</translation>
+        <translation>지갑 생성 실패</translation>
     </message>
     <message>
         <source>Create wallet warning</source>
@@ -850,7 +850,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</source>
-        <translation>지갑 암호화하기. 해당 지갑은 당신이 설정한 문자열 비밀번호로 암호화될 겁니다.</translation>
+        <translation>지갑을 암호화합니다. 해당 지갑은 당신이 설정한 문자열 암호로 암호화됩니다.</translation>
     </message>
     <message>
         <source>Encrypt Wallet</source>
@@ -858,15 +858,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disable private keys for this wallet. Wallets with private keys disabled will have no private keys and cannot have an HD seed or imported private keys. This is ideal for watch-only wallets.</source>
-        <translation>이 지갑에 대한 개인 키를 비활성화합니다. 개인 키가 비활성화 된 지갑에는 개인 키가 없으며 HD 시드 또는 가져온 개인 키를 가질 수 없습니다. 이는 조회-전용 지갑에 이상적입니다.</translation>
+        <translation>이 지갑에 대한 개인 키를 비활성화합니다. 개인 키가 비활성화된 지갑에는 개인 키가 없으며 HD 시드 또는 가져온 개인 키를 가질 수 없습니다. 이는 조회-전용 지갑에 이상적입니다.</translation>
     </message>
     <message>
         <source>Disable Private Keys</source>
-        <translation>개인키 비활성화 하기</translation>
+        <translation>개인 키 비활성화하기</translation>
     </message>
     <message>
         <source>Make a blank wallet. Blank wallets do not initially have private keys or scripts. Private keys and addresses can be imported, or an HD seed can be set, at a later time.</source>
-        <translation>빈 지갑을 만드십시오. 빈 지갑은 처음에는 개인 키나 스크립트를 가지고 있지 않습니다. 개인 키와 주소를 가져 오거나 HD 시드를 설정하는 것은 나중에 할 수 있습니다.</translation>
+        <translation>빈 지갑을 만드세요. 빈 지갑은 처음에는 개인 키나 스크립트를 가지고 있지 않습니다. 개인 키와 주소를 가져오거나 HD 시드를 설정하는 것은 나중에 할 수 있습니다.</translation>
     </message>
     <message>
         <source>Make Blank Wallet</source>
@@ -886,7 +886,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Compiled without sqlite support (required for descriptor wallets)</source>
-        <translation>에스큐엘라이트 지원 없이 컴파일 되었습니다. (디스크립터 지갑에 요구됩니다.)</translation>
+        <translation>sqlite 지원 없이 컴파일되었습니다. (디스크립터 지갑에 필요)</translation>
     </message>
 </context>
 <context>
@@ -905,7 +905,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation>본 주소록 입력은 주소와 연계되었습니다.  이것은 보내는 주소들을 위해서만 변경될수 있습니다.</translation>
+        <translation>이 주소록 항목과 관련된 주소입니다. 이것은 보내는 주소들을 위해서만 변경될 수 있습니다.</translation>
     </message>
     <message>
         <source>&amp;Address</source>
@@ -913,7 +913,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>New sending address</source>
-        <translation>새 보내는 주소</translation>
+        <translation>새로운 보내는 주소</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
@@ -925,19 +925,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation>입력한 "%1" 주소는 올바른 비트코인 주소가 아닙니다.</translation>
+        <translation>입력한 "%1" 주소는 올바른 도지코인 주소가 아닙니다.</translation>
     </message>
     <message>
         <source>Address "%1" already exists as a receiving address with label "%2" and so cannot be added as a sending address.</source>
-        <translation>주소 "%1"은 이미 라벨 "%2"로 받는 주소에 존재하여 보내는 주소로 추가될 수 없습니다.</translation>
+        <translation>주소 "%1" 은/는 이미 라벨 "%2" (으)로 받는 주소에 존재하여 보내는 주소로 추가될 수 없습니다.</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book with label "%2".</source>
-        <translation>입력된 주소 "%1"은 라벨 "%2"로 이미 주소록에 있습니다.</translation>
+        <translation>입력된 주소 "%1" 은/는 라벨 "%2" (으)로 이미 주소록에 있습니다.</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation>지갑을 잠금해제 할 수 없습니다.</translation>
+        <translation>지갑을 잠금 해제할 수 없습니다.</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
@@ -956,11 +956,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>폴더가 이미 존재합니다. 새로운 폴더 생성을 원한다면 %1 명령어를 추가하세요.</translation>
+        <translation>폴더가 이미 존재합니다. 새로운 폴더 생성을 원한다면 %1 을/를 추가하세요.</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation>경로가 이미 존재합니다. 그리고 그것은 폴더가 아닙니다.</translation>
+        <translation>경로가 이미 존재하고, 폴더가 아닙니다.</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
@@ -979,7 +979,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation>명령줄 옵션</translation>
+        <translation>커맨드라인 옵션</translation>
     </message>
 </context>
 <context>
@@ -990,63 +990,63 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation>%1에 오신것을 환영합니다.</translation>
+        <translation>%1에 오신 것을 환영합니다.</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation>프로그램이 처음으로 실행되고 있습니다. %1가 어디에 데이터를 저장할지 선택할 수 있습니다.</translation>
+        <translation>프로그램이 처음으로 실행되고 있습니다. %1 이/가 어디에 데이터를 저장할지 선택할 수 있습니다.</translation>
     </message>
     <message>
         <source>When you click OK, %1 will begin to download and process the full %4 block chain (%2GB) starting with the earliest transactions in %3 when %4 initially launched.</source>
-        <translation>'확인'을 클릭하면, %1은 모든 %4 블록 체인 (%2GB) 장부를 가장 최근 거래 부터 %3 안에 다운로드하고 처리하는데, 이것은 %4가 활성화 될때 시작됩니다. </translation>
+        <translation>'확인'을 클릭하면, %1 은/는 모든 %4 블록 체인(%2GB) 장부를 가장 최근 거래부터 %3 안에 다운로드하고 처리하는데, 이것은 %4 이/가 활성화될 때 시작됩니다.</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</source>
-        <translation>이 설정을 되돌리면 전체 블록 체인을 다시 다운로드 해야 합니다. 전체 체인을 먼저 다운로드하고 나중에 정리하는 것이 더 빠릅니다. 일부 고급 기능을 비활성화합니다.</translation>
+        <translation>이 설정을 되돌리면 전체 블록 체인을 다시 다운로드해야 합니다. 전체 체인을 먼저 다운로드하고 나중에 정리하는 것이 더 빠릅니다. 일부 고급 기능을 비활성화합니다.</translation>
     </message>
     <message>
         <source>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</source>
-        <translation>초기 동기화는 매우 오래 걸리며 이전에는 본 적 없는 하드웨어 문제를 발생시킬 수 있습니다. %1을 실행할 때마다 중단 된 곳에서 다시 계속 다운로드 됩니다.</translation>
+        <translation>초기 동기화는 매우 오래 걸리며, 이전에는 본 적 없는 하드웨어 문제를 발생시킬 수 있습니다. %1 을/를 실행할 때마다 중단된 곳에서 다시 계속 다운로드됩니다.</translation>
     </message>
     <message>
         <source>If you have chosen to limit block chain storage (pruning), the historical data must still be downloaded and processed, but will be deleted afterward to keep your disk usage low.</source>
-        <translation>블록 체인 저장 영역을 제한하도록 선택한 경우 (블록 정리), 이력 데이터는 계속해서 다운로드 및 처리 되지만, 차후 디스크 용량을 줄이기 위해 삭제됩니다.</translation>
+        <translation>블록 체인 저장 영역을 제한하도록 선택한 경우(블록 정리), 이력 데이터는 계속해서 다운로드 및 처리되지만, 차후 디스크 용량을 줄이기 위해 삭제됩니다.</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation>기본 데이터 폴더를 사용하기</translation>
+        <translation>기본 데이터 폴더 사용하기</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation>커스텀 데이터 폴더 사용:</translation>
+        <translation>사용자 지정 데이터 폴더 사용:</translation>
     </message>
     <message>
         <source>Bitcoin</source>
-        <translation>비트코인</translation>
+        <translation>도지코인</translation>
     </message>
     <message>
         <source>Discard blocks after verification, except most recent %1 GB (prune)</source>
-        <translation>가장 최근의 %1 GB를 제외하고 확인 후 블록 폐기 (정리)</translation>
+        <translation>가장 최근의 %1 GB를 제외하고, 확인 후 블록 폐기(정리)</translation>
     </message>
     <message>
         <source>At least %1 GB of data will be stored in this directory, and it will grow over time.</source>
-        <translation>최소 %1 GB의 데이터가 이 디렉토리에 저장되며 시간이 지남에 따라 증가할 것입니다.</translation>
+        <translation>최소 %1 GB의 데이터가 이 폴더에 저장되며, 시간이 지남에 따라 증가할 것입니다.</translation>
     </message>
     <message>
         <source>Approximately %1 GB of data will be stored in this directory.</source>
-        <translation>약 %1 GB의 데이터가 이 디렉토리에 저장됩니다.</translation>
+        <translation>약 %1 GB의 데이터가 이 폴더에 저장됩니다.</translation>
     </message>
     <message>
         <source>%1 will download and store a copy of the Bitcoin block chain.</source>
-        <translation>%1은 비트코인 블록체인의 사본을 다운로드하여 저장합니다.</translation>
+        <translation>%1 은/는 도지코인 블록 체인의 복사본을 다운로드하여 저장합니다.</translation>
     </message>
     <message>
         <source>The wallet will also be stored in this directory.</source>
-        <translation>지갑도 이 디렉토리에 저장됩니다.</translation>
+        <translation>지갑도 이 폴더에 저장됩니다.</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation>오류: 지정한 데이터 디렉토리 "%1" 를 생성할 수 없습니다.</translation>
+        <translation>오류: 지정한 데이터 폴더 "%1" 을/를 생성할 수 없습니다.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1054,15 +1054,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message numerus="yes">
         <source>%n GB of free space available</source>
-        <translation><numerusform>%n GB 사용가능</numerusform></translation>
+        <translation><numerusform>%n GB 사용 가능</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>(of %n GB needed)</source>
-        <translation><numerusform>(%n GB가 필요합니다.)</numerusform></translation>
+        <translation><numerusform>(%n GB 필요)</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>(%n GB needed for full chain)</source>
-        <translation><numerusform>(Full 체인이 되려면 %n GB 가 필요합니다.)</numerusform></translation>
+        <translation><numerusform>(풀 체인(full chain)이 되려면 %n GB 필요)</numerusform></translation>
     </message>
 </context>
 <context>
@@ -1073,15 +1073,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the bitcoin network, as detailed below.</source>
-        <translation>최근 거래는 아직 보이지 않을 수 있습니다. 따라서 당신의 지갑의 잔액이 틀릴 수도 있습니다. 이 정보는 당신의 지갑이 비트코인 네트워크와 완전한 동기화를 완료하면, 아래의 설명과 같이 정확해집니다.</translation>
+        <translation>최근 거래가 아직 보이지 않을 것이므로, 지갑의 잔액이 틀릴 수도 있습니다. 이 정보는 아래 진행 상황처럼 도지코인 네트워크와 완전한 동기화가 완료되면 정확해집니다.</translation>
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation>아직 표시되지 않은 거래의 영향을 받는 비트코인을 사용하려고 하는 것은 네트워크에서 허가되지 않습니다.</translation>
+        <translation>아직 표시되지 않은 거래의 영향을 받는 도지코인을 사용하려고 하는 것은 네트워크에서 허용되지 않습니다.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
-        <translation>남은 블록의 수</translation>
+        <translation>남은 블록 수</translation>
     </message>
     <message>
         <source>Unknown...</source>
@@ -1097,11 +1097,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation>시간당 진행 증가율</translation>
+        <translation>시간당 진행율 증가</translation>
     </message>
     <message>
         <source>calculating...</source>
-        <translation>계산중...</translation>
+        <translation>계산 중...</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
@@ -1117,7 +1117,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.</source>
-        <translation>%1가 현재 동기화 중입니다. 이것은 피어에서 헤더와 블록을 다운로드하고 블록 체인의 끝에 도달 할 때까지 유효성을 검사합니다.</translation>
+        <translation>%1 이/가 현재 동기화 중입니다. 이것은 피어에서 헤더와 블록을 다운로드하고 블록 체인의 끝에 도달할 때까지 유효성을 검사합니다.</translation>
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1, %2%)...</source>
@@ -1128,7 +1128,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>OpenURIDialog</name>
     <message>
         <source>Open bitcoin URI</source>
-        <translation>비트코인 URI 열기</translation>
+        <translation>도지코인 URI 열기</translation>
     </message>
     <message>
         <source>URI:</source>
@@ -1143,7 +1143,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open wallet warning</source>
-        <translation>지갑 열기 경고</translation>
+        <translation>지갑 경고 열기</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -1158,7 +1158,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation>환경설정</translation>
+        <translation>환경 설정</translation>
     </message>
     <message>
         <source>&amp;Main</source>
@@ -1166,11 +1166,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation>시스템 로그인 후 %1을 자동으로 시작합니다.</translation>
+        <translation>시스템 로그인 후 %1 을/를 자동으로 시작합니다.</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
-        <translation>시스템 로그인시 %1 시작(&amp;S)</translation>
+        <translation>시스템 로그인 시 %1 시작(&amp;S)</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
@@ -1182,7 +1182,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation>프록시 아이피 주소 (예: IPv4:127.0.0.1 / IPv6: ::1)</translation>
+        <translation>프록시 IP 주소(예: IPv4:127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Shows if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
@@ -1190,7 +1190,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Hide the icon from the system tray.</source>
-        <translation>시스템 트레이로 부터 아이콘 숨기기</translation>
+        <translation>시스템 트레이로부터 아이콘 숨기기</translation>
     </message>
     <message>
         <source>&amp;Hide tray icon</source>
@@ -1198,15 +1198,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation>창을 닫으면 종료 대신 축소하기. 이 옵션을 활성화하면 메뉴에서 종료를 선택한 후에만 어플리케이션이 종료됩니다.</translation>
+        <translation>창을 닫으면 종료하는 대신 트레이로 보냅니다. 이 옵션을 활성화하면 메뉴에서 종료를 선택한 후에만 애플리케이션이 종료됩니다.</translation>
     </message>
     <message>
         <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation>서드-파티 URL들 (예: 블록 탐색기)는 거래 탭에 컨텍스트 메뉴로 나타납니다. URL의 %s는 거래 해시값으로 대체됩니다. 여러 URL들은 수직 바 | 에서 나누어 집니다.</translation>
+        <translation>서드-파티 URL(예: 블록 탐색기)은 거래 탭의 컨텍스트 메뉴에 나타납니다. URL의 %s 은/는 거래 해시값으로 대체됩니다. 여러 URL은 수직 바 | 에서 나누어집니다.</translation>
     </message>
     <message>
         <source>Open the %1 configuration file from the working directory.</source>
-        <translation>작업 디렉토리에서 %1 설정 파일을 엽니다.</translation>
+        <translation>작업 폴더에서 %1 설정 파일을 엽니다.</translation>
     </message>
     <message>
         <source>Open Configuration File</source>
@@ -1226,11 +1226,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</source>
-        <translation>일부분의 고급 기능을 취소 하지만 모든 블록들은 검증될 것입니다. 이 설정을 되돌리려면 처음부터 블록체인을 다시 다운로드 받아야 합니다. 실제 디스크 사용량은 더 많을수도 있습니다.</translation>
+        <translation>일부분의 고급 기능을 취소하지만 모든 블록들은 검증될 것입니다. 이 설정을 되돌리려면 처음부터 블록 체인을 다시 다운로드해야 합니다. 실제 디스크 사용량은 더 많을 수도 있습니다.</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation>블록 데이터를 지정된 크기로 축소합니다.(&amp;b) :</translation>
+        <translation>블록 데이터를 지정된 크기로 축소(&amp;b):</translation>
     </message>
     <message>
         <source>GB</source>
@@ -1238,7 +1238,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation>이 설정을 되돌리려면 처음부터 블록체인을 다시 다운로드 받아야 합니다.</translation>
+        <translation>이 설정을 되돌리려면 처음부터 블록 체인을 다시 다운로드해야 합니다.</translation>
     </message>
     <message>
         <source>MiB</source>
@@ -1246,7 +1246,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation>(0 = 자동, &lt;0 = 지정된 코어 개수만큼 사용 안함)</translation>
+        <translation>(0 = 자동, &lt;0 = 지정된 코어 개수만큼 사용하지 않음)</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
@@ -1258,19 +1258,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation>코인 상세 제어기능을 활성화합니다 (&amp;C)</translation>
+        <translation>코인 상세 제어 기능을 활성화(&amp;C)</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation>검증되지 않은 잔돈 쓰기를 비활성화하면, 거래가 적어도 1회 이상 검증되기 전까지 그 거래의 거스름돈은 사용할 수 없습니다. 이는 잔액 계산 방법에도 영향을 미칩니다.</translation>
+        <translation>검증되지 않은 잔돈 쓰기를 비활성화하면, 거래가 적어도 1회 이상 검증되기 전까지 그 거래의 잔돈은 사용할 수 없습니다. 이는 잔액 계산 방법에도 영향을 미칩니다.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation>검증되지 않은 잔돈 쓰기 (&amp;S)</translation>
+        <translation>검증되지 않은 잔돈 쓰기(&amp;S)</translation>
     </message>
     <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>라우터에서 비트코인 클라이언트 포트를 자동적으로 엽니다. 라우터에서 UPnP를 지원하고 활성화 했을 경우에만 동작합니다.</translation>
+        <translation>라우터에서 도지코인 클라이언트 포트를 자동으로 엽니다. 라우터에서 UPnP를 지원하고 활성화했을 경우에만 동작합니다.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -1282,15 +1282,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Allow incomin&amp;g connections</source>
-        <translation>연결 요청을 허용 (&amp;G)</translation>
+        <translation>연결 요청 허용(&amp;G)</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a SOCKS5 proxy.</source>
-        <translation>SOCKS5 프록시를 통해 비트코인 네트워크에 연결합니다.</translation>
+        <translation>SOCKS5 프록시를 통해 도지코인 네트워크에 연결합니다.</translation>
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation>SOCKS5 프록시를 거쳐 연결합니다(&amp;C) (기본 프록시):</translation>
+        <translation>SOCKS5 프록시를 거쳐 연결(&amp;C) (기본 프록시):</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
@@ -1302,7 +1302,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation>프록시의 포트번호 (예: 9050)</translation>
+        <translation>프록시의 포트 번호(예: 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
@@ -1326,7 +1326,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>창을 최소화 하면 트레이에 아이콘만 표시합니다.</translation>
+        <translation>창을 최소화하면 트레이에 아이콘만 표시합니다.</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
@@ -1334,7 +1334,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation>닫을때 최소화(&amp;I)</translation>
+        <translation>닫을 때 최소화(&amp;I)</translation>
     </message>
     <message>
         <source>&amp;Display</source>
@@ -1346,7 +1346,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation>사용자 인터페이스 언어를 여기서 설정할 수 있습니다. 이 설정은 %1을 다시 시작할 때 적용됩니다.</translation>
+        <translation>사용자 인터페이스 언어를 여기서 설정할 수 있습니다. 이 설정은 %1 을/를 다시 시작할 때 적용됩니다.</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
@@ -1354,27 +1354,27 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>인터페이스에 표시하고 코인을 보낼때 사용할 기본 최소화 단위를 선택하십시오.</translation>
+        <translation>인터페이스에 표시하고 코인을 보낼 때 사용할 기본 최소화 단위를 선택하세요.</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation>코인 상세 제어기능에 대한 표시 여부를 선택할 수 있습니다.</translation>
+        <translation>코인 상세 제어 기능에 대한 표시 여부를 선택할 수 있습니다.</translation>
     </message>
     <message>
         <source>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</source>
-        <translation>Tor onion 서비스를 위한 별도의 SOCKS5 프록시를 통해 Bitcoin 네트워크에 연결합니다.</translation>
+        <translation>Tor onion 서비스를 위한 별도의 SOCKS5 프록시를 통해 도지코인 네트워크에 연결합니다.</translation>
     </message>
     <message>
         <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</source>
-        <translation>Tor onion 서비스를 통해 피어에 도달하려면 별도의 SOCKS &amp; 5 프록시를 사용하십시오.</translation>
+        <translation>Tor onion 서비스를 거쳐 피어에 연결하기 위해 별도의 SOCKS&amp;5 프록시 사용:</translation>
     </message>
     <message>
         <source>&amp;Third party transaction URLs</source>
-        <translation>제 3자 거래 URL들(&amp;T)</translation>
+        <translation>써드-파티 거래 URL(&amp;T)</translation>
     </message>
     <message>
         <source>Options set in this dialog are overridden by the command line or in the configuration file:</source>
-        <translation>이 다이얼로그에서 설정한 옵션은 커맨드라인이나 설정파일에 의해 바뀔 수 있습니다:</translation>
+        <translation>이 대화상자에서 설정한 옵션은 커맨드라인이나 설정 파일에 의해 바뀔 수 있음:</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -1386,7 +1386,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>default</source>
-        <translation>기본 값</translation>
+        <translation>기본값</translation>
     </message>
     <message>
         <source>none</source>
@@ -1394,7 +1394,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Confirm options reset</source>
-        <translation>옵션 초기화를 확실화하기</translation>
+        <translation>옵션 초기화 확인</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
@@ -1402,7 +1402,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
-        <translation>클라이언트가 종료됩니다, 계속 진행하시겠습니까?</translation>
+        <translation>클라이언트가 종료됩니다. 계속 진행하시겠습니까?</translation>
     </message>
     <message>
         <source>Configuration options</source>
@@ -1410,7 +1410,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The configuration file is used to specify advanced user options which override GUI settings. Additionally, any command-line options will override this configuration file.</source>
-        <translation>GUI 설정을 우선하는 고급 사용자 옵션을 지정하는 데 사용되는 설정파일 입니다. 추가로 모든 명령 줄 옵션도 이 설정 파일보다 우선시 됩니다.</translation>
+        <translation>GUI 설정을 우선하는 고급 사용자 옵션을 지정하는 데 사용되는 설정 파일입니다. 추가로 모든 커맨드라인 옵션도 이 설정 파일보다 우선시 됩니다.</translation>
     </message>
     <message>
         <source>Error</source>
@@ -1437,7 +1437,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>표시된 정보가 오래된 것 같습니다. 당신의 지갑은 비트코인 네트워크에 연결된 뒤 자동으로 동기화 하지만, 아직 과정이 끝나지 않았습니다.</translation>
+        <translation>표시된 정보가 오래된 것 같습니다. 당신의 지갑은 도지코인 네트워크에 연결된 뒤 자동으로 동기화하지만, 아직 프로세스가 끝나지 않았습니다.</translation>
     </message>
     <message>
         <source>Watch-only:</source>
@@ -1457,7 +1457,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>아직 확인되지 않아 사용가능한 잔액에 반영되지 않은 거래 총액</translation>
+        <translation>아직 확인되지 않아 사용 가능한 잔액에 반영되지 않은 거래 총액</translation>
     </message>
     <message>
         <source>Immature:</source>
@@ -1465,7 +1465,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation>아직 사용 가능하지 않은 채굴된 잔액</translation>
+        <translation>아직 사용할 수 없는 채굴된 잔액</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1497,7 +1497,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation>조회-전용 주소의 채굴된 잔액 중 사용가능하지 않은 금액</translation>
+        <translation>조회-전용 주소의 채굴된 잔액 중 사용할 수 없는 금액</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
@@ -1505,14 +1505,14 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Privacy mode activated for the Overview tab. To unmask the values, uncheck Settings-&gt;Mask values.</source>
-        <translation>개요 탭에서 개인 정보 보호 모드가 활성화되었습니다. 값의 마스크를 해제하려면 '설정-&gt; 마스크 값' 선택을 취소하십시오.</translation>
+        <translation>개요 탭에서 개인 정보 보호 모드가 활성화되었습니다. 값의 마스크를 해제하려면, '설정-&gt;마스크값' 선택을 취소하세요.</translation>
     </message>
 </context>
 <context>
     <name>PSBTOperationsDialog</name>
     <message>
         <source>Dialog</source>
-        <translation>다이얼로그</translation>
+        <translation>대화상자</translation>
     </message>
     <message>
         <source>Sign Tx</source>
@@ -1544,19 +1544,19 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not sign any more inputs.</source>
-        <translation>더 이상 추가적인 인풋에 대해 서명할 수 없음</translation>
+        <translation>더이상 추가적인 입력에 대해 서명할 수 없음</translation>
     </message>
     <message>
         <source>Signed transaction successfully. Transaction is ready to broadcast.</source>
-        <translation>거래 서명완료. 거래를 전파할 준비가 되었습니다.</translation>
+        <translation>거래 서명이 완료되었습니다. 거래를 전파할 준비가 되었습니다.</translation>
     </message>
     <message>
         <source>Unknown error processing transaction.</source>
-        <translation>거래 처리 과정에 알 수 없는 오류 발생</translation>
+        <translation>거래 처리 과정에 알 수 없는 오류가 발생했습니다.</translation>
     </message>
     <message>
         <source>Transaction broadcast successfully! Transaction ID: %1</source>
-        <translation>거래가 성공적으로 전파되었습니다! 거래 ID : %1</translation>
+        <translation>거래가 성공적으로 전파되었습니다! 거래 ID: %1</translation>
     </message>
     <message>
         <source>Transaction broadcast failed: %1</source>
@@ -1564,7 +1564,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>PSBT copied to clipboard.</source>
-        <translation>클립보드로 PSBT 복사</translation>
+        <translation>클립보드로 PSBT를 복사했습니다.</translation>
     </message>
     <message>
         <source>Save Transaction Data</source>
@@ -1572,15 +1572,15 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary) (*.psbt)</source>
-        <translation>부분적으로 서명된 비트코인 트랜잭션 (2진 표기) (*.psbt)</translation>
+        <translation>부분적으로 서명된 도지코인 거래(2진 표기) (*.psbt)</translation>
     </message>
     <message>
         <source>PSBT saved to disk.</source>
-        <translation>PSBT가 디스크에 저장 됨</translation>
+        <translation>PSBT가 디스크에 저장되었습니다.</translation>
     </message>
     <message>
         <source> * Sends %1 to %2</source>
-        <translation>* %1을 %2로 보냅니다.</translation>
+        <translation>* %1 을/를 %2 (으)로 보냄</translation>
     </message>
     <message>
         <source>Unable to calculate transaction fee or total transaction amount.</source>
@@ -1600,7 +1600,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction has %1 unsigned inputs.</source>
-        <translation>거래가 %1 개의 서명 되지 않은 입력을 갖고 있습니다.</translation>
+        <translation>거래가 %1 개의 서명되지 않은 입력을 갖고 있습니다.</translation>
     </message>
     <message>
         <source>Transaction is missing some information about inputs.</source>
@@ -1608,7 +1608,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Transaction still needs signature(s).</source>
-        <translation>거래가 아직 서명(들)을 필요로 합니다.</translation>
+        <translation>거래가 아직 서명을 필요로 합니다.</translation>
     </message>
     <message>
         <source>(But this wallet cannot sign transactions.)</source>
@@ -1635,7 +1635,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation>비트코인을 시작할 수 없습니다: 지급을 위한 클릭 핸들러</translation>
+        <translation>도지코인을 시작할 수 없습니다: 지불을 위한 클릭 핸들러</translation>
     </message>
     <message>
         <source>URI handling</source>
@@ -1643,7 +1643,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>'bitcoin://' is not a valid URI. Use 'bitcoin:' instead.</source>
-        <translation>'bitcoin://"은 잘못된 URI입니다. 'bitcoin:'을 사용하십시오.</translation>
+        <translation>'dogecoin://'는 잘못된 URI입니다. 'dogecoin:'을 사용하세요.</translation>
     </message>
     <message>
         <source>Cannot process payment request because BIP70 is not supported.</source>
@@ -1651,11 +1651,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Due to widespread security flaws in BIP70 it's strongly recommended that any merchant instructions to switch wallets be ignored.</source>
-        <translation>BIP70의 보안적 결함에 의하여, "지갑을 바꾸라"라는 판매자 지침은 대부분 무시하는 것을 강력하게 권장합니다.</translation>
+        <translation>BIP70의 보안적 결함으로 인해 "지갑을 바꾸라"라는 판매자 지침은 대부분 무시할 것을 강력하게 권장합니다.</translation>
     </message>
     <message>
         <source>If you are receiving this error you should request the merchant provide a BIP21 compatible URI.</source>
-        <translation>만약 이 오류 메시지가 보인다면, 판매자에게 BIP21이 호환되는 URI를 제공해달라고 요청해주십시오.</translation>
+        <translation>만약 이 오류 메시지가 보인다면, 판매자에게 BIP21이 호환되는 URI를 제공해달라고 요청하세요.</translation>
     </message>
     <message>
         <source>Invalid payment address %1</source>
@@ -1663,11 +1663,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation>URI의 파싱에 문제가 발생했습니다. 잘못된 비트코인 주소나 URI 파라미터 구성에 오류가 존재할 수 있습니다.</translation>
+        <translation>URI의 파싱에 문제가 발생했습니다. 잘못된 도지코인 주소나 URI 파라미터 구성에 오류가 존재할 수 있습니다.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation>지불 요청 파일 처리중</translation>
+        <translation>지불 요청 파일 처리</translation>
     </message>
 </context>
 <context>
@@ -1705,7 +1705,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation>비트코인 주소를 입력하세요 (예: %1)</translation>
+        <translation>도지코인 주소 입력(예: %1)</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -1729,7 +1729,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>N/A</source>
-        <translation>없음</translation>
+        <translation>해당 사항 없음</translation>
     </message>
     <message>
         <source>%1 ms</source>
@@ -1757,7 +1757,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 and %2</source>
-        <translation>%1 과 %2</translation>
+        <translation>%1 와/과 %2</translation>
     </message>
     <message numerus="yes">
         <source>%n year(s)</source>
@@ -1781,11 +1781,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation>오류: 지정한 데이터 폴더 "%1"은 존재하지 않습니다.</translation>
+        <translation>오류: 지정한 데이터 폴더 "%1" 은/는 존재하지 않습니다.</translation>
     </message>
     <message>
         <source>Error: Cannot parse configuration file: %1.</source>
-        <translation>오류: 설성 파일 %1을 파싱할 수 없습니다</translation>
+        <translation>오류: 설성 파일 %1 을/를 파싱할 수 없습니다</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1797,7 +1797,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>%1 didn't yet exit safely...</source>
-        <translation>%1가 아직 안전하게 종료되지 않았습니다...</translation>
+        <translation>%1 이/가 아직 안전하게 종료되지 않음...</translation>
     </message>
     <message>
         <source>unknown</source>
@@ -1816,7 +1816,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>URI 결과가 너무 깁니다. 라벨 / 메세지를 줄이세요.</translation>
+        <translation>URI 결과가 너무 깁니다. 라벨 / 메시지를 줄이세요.</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
@@ -1839,7 +1839,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>RPCConsole</name>
     <message>
         <source>N/A</source>
-        <translation>N/A</translation>
+        <translation>해당 사항 없음</translation>
     </message>
     <message>
         <source>Client version</source>
@@ -1871,7 +1871,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>To specify a non-default location of the blocks directory use the '%1' option.</source>
-        <translation>기본 위치가 아닌 곳으로 블럭 폴더를 지정하려면 '%1' 옵션을 사용하세요.</translation>
+        <translation>기본 위치가 아닌 곳으로 블록 폴더를 지정하려면 '%1' 옵션을 사용하세요.</translation>
     </message>
     <message>
         <source>Startup time</source>
@@ -1907,7 +1907,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Wallet: </source>
-        <translation>지갑:</translation>
+        <translation>지갑: </translation>
     </message>
     <message>
         <source>(none)</source>
@@ -1947,7 +1947,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Starting Block</source>
-        <translation>시작된 블록</translation>
+        <translation>시작 블록</translation>
     </message>
     <message>
         <source>Synced Headers</source>
@@ -1959,7 +1959,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>The mapped Autonomous System used for diversifying peer selection.</source>
-        <translation>피어 선택을 다양 화하는 데 사용되는 매핑 된 자율 시스템입니다.</translation>
+        <translation>피어 선택을 다양화하는 데 사용되는 매핑된 자율 시스템입니다.</translation>
     </message>
     <message>
         <source>Mapped AS</source>
@@ -1979,7 +1979,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation>%1 디버그 로그파일을 현재 데이터 폴더에서 엽니다. 용량이 큰 로그 파일들은 몇 초가 걸릴 수 있습니다.</translation>
+        <translation>%1 디버그 로그 파일을 현재 데이터 폴더에서 엽니다. 용량이 큰 로그 파일들은 수 초가 걸릴 수 있습니다.</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -2011,11 +2011,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Ping Time</source>
-        <translation>Ping 시간</translation>
+        <translation>핑 시간</translation>
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation>현재 진행중인 PING에 걸린 시간.</translation>
+        <translation>현재 진행 중인 핑에 걸린 시간입니다.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
@@ -2059,7 +2059,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Debug log file</source>
-        <translation>로그 파일 디버그</translation>
+        <translation>로그 파일 디버깅</translation>
     </message>
     <message>
         <source>Clear console</source>
@@ -2087,7 +2087,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Ban for</source>
-        <translation>차단사유:</translation>
+        <translation>차단 사유:</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
@@ -2095,23 +2095,23 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.</source>
-        <translation>%1 RPC 콘솔에 오신걸 환영합니다.</translation>
+        <translation>환영합니다. %1 RPC 콘솔입니다.</translation>
     </message>
     <message>
         <source>Use up and down arrows to navigate history, and %1 to clear screen.</source>
-        <translation>기록을 탐색하려면 '위'와 '아래' 화살표를 사용하고, 화면을 지우려면 %1을 사용하십시오.</translation>
+        <translation>기록을 탐색하려면 '위'와 '아래' 화살표를 사용하고, 화면을 지우려면 %1 을/를 사용하세요.</translation>
     </message>
     <message>
         <source>Type %1 for an overview of available commands.</source>
-        <translation>사용할 수 있는 명령을 둘러보려면 %1 를 입력하십시요.</translation>
+        <translation>사용할 수 있는 명령을 둘러보려면 %1 을/를 입력하세요.</translation>
     </message>
     <message>
         <source>For more information on using this console type %1.</source>
-        <translation>더 많은 정보를 보기 위해선 콘솔에 %1를 치세요.</translation>
+        <translation>더 많은 정보를 보기 위해서 콘솔에 %1 을/를 입력하세요.</translation>
     </message>
     <message>
         <source>WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</source>
-        <translation>경고 : 사기꾼들이 사용자들에게 여기에 명령을 입력하게 해 지갑 내용을 훔친 사건이 발생하였습니다. 명령어를 완전히 이해하지 못한다면 이 콘솔을 사용하지 마십시오.</translation>
+        <translation>경고: 사기꾼들이 사용자들에게 여기에 명령을 입력하게 해 지갑 내용을 훔친 사건이 발생하였습니다. 명령어를 완전히 이해하지 못한다면 이 콘솔을 사용하지 마세요.</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
@@ -2147,7 +2147,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Unknown</source>
-        <translation>알수없음</translation>
+        <translation>알 수 없음</translation>
     </message>
 </context>
 <context>
@@ -2166,31 +2166,31 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation>지불 요청에 첨부되는 선택가능한 메시지 입니다. 이 메세지는 요청이 열릴 때 표시될 것 입니다. 메모: 이 메시지는 비트코인 네트워크로 전송되지 않습니다.</translation>
+        <translation>지불 요청에 첨부되는 선택 가능한 메시지입니다. 이 메시지는 요청이 열릴 때 표시될 것입니다. 참고: 이 메시지는 도지코인 네트워크로 전송되지 않습니다.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation>새로운 받기 주소와 결합될 부가적인 라벨.</translation>
+        <translation>새로운 받는 주소와 연결할 라벨이며 선택 사항입니다.</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>지급을 요청하기 위해 아래 형식을 사용하세요. 입력값은 &lt;b&gt;선택 사항&lt;/b&gt; 입니다.</translation>
+        <translation>지불을 요청하기 위해 아래 형식을 사용하세요. 입력값은 &lt;b&gt;선택 사항&lt;/b&gt;입니다.</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation>요청할 금액 입력칸으로 선택 사항입니다. 빈 칸으로 두거나 특정 금액이 필요하지 않는 경우 0을 입력하십시오.</translation>
+        <translation>요청할 금액 입력칸으로 선택 사항입니다. 빈 칸으로 두거나 특정 금액이 필요하지 않는 경우 0을 입력하세요.</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</source>
-        <translation>새 수신 주소와 연결할 선택적 레이블 (사용자가 송장을 식별하는 데 사용함). 지불 요청에도 첨부됩니다.</translation>
+        <translation>새로운 받는 주소(사용자가 송장을 식별하는 데 사용함)와 연결할 라벨이며 선택 사항입니다. 지불 요청에도 첨부됩니다.</translation>
     </message>
     <message>
         <source>An optional message that is attached to the payment request and may be displayed to the sender.</source>
-        <translation>지불 요청에 첨부되고 발신자에게 표시 될 수있는 선택적 메시지입니다.</translation>
+        <translation>지불 요청에 첨부되고 발신자에게 표시될 수 있는 선택적 메시지입니다.</translation>
     </message>
     <message>
         <source>&amp;Create new receiving address</source>
-        <translation>새로운 수신 주소 생성(&amp;C)</translation>
+        <translation>새로운 받는 주소 생성(&amp;C)</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
@@ -2202,7 +2202,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</source>
-        <translation>네이티브 세그윗 주소(Bech32 또는 BIP-173)는 거래 수수료를 줄여주고 오입력을 방지하지만 구버전 지갑은 이를 지원하지 않습니다. 체크하지 않으면 구버전 지갑과 호환되는 주소가 대신 생성됩니다.</translation>
+        <translation>네이티브 세그윗 주소(Bech32 또는 BIP-173)는 거래 수수료를 줄여주고 오입력을 방지하지만, 구버전 지갑은 이를 지원하지 않습니다. 체크하지 않으면, 구버전 지갑과 호환되는 주소가 대신 생성됩니다.</translation>
     </message>
     <message>
         <source>Generate native segwit (Bech32) address</source>
@@ -2214,7 +2214,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation>선택된 요청을 표시하기 (더블 클릭으로도 항목을 표시할 수 있습니다)</translation>
+        <translation>선택된 요청 표시하기(더블 클릭으로도 항목을 표시할 수 있음)</translation>
     </message>
     <message>
         <source>Show</source>
@@ -2222,7 +2222,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation>목록에서 선택된 항목을 삭제</translation>
+        <translation>목록에서 선택된 항목 삭제</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -2246,18 +2246,18 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation>지갑을 잠금해제 할 수 없습니다.</translation>
+        <translation>지갑을 잠금 해제할 수 없습니다.</translation>
     </message>
     <message>
         <source>Could not generate new %1 address</source>
-        <translation>새로운 %1 주소를 생성 할 수 없습니다.</translation>
+        <translation>새로운 %1 주소를 생성할 수 없습니다.</translation>
     </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>Request payment to ...</source>
-        <translation>결제 요청을 다음에게...</translation>
+        <translation>지불 요청을 다음에게...</translation>
     </message>
     <message>
         <source>Address:</source>
@@ -2293,7 +2293,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Request payment to %1</source>
-        <translation>%1에 지불을 요청</translation>
+        <translation>%1 에 지불을 요청</translation>
     </message>
     <message>
         <source>Payment information</source>
@@ -2320,7 +2320,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>(no message)</source>
-        <translation>(메세지가 없습니다)</translation>
+        <translation>(메시지 없음)</translation>
     </message>
     <message>
         <source>(no amount requested)</source>
@@ -2335,11 +2335,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation>코인 전송내기</translation>
+        <translation>코인 전송하기</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation>코인 컨트롤 기능들</translation>
+        <translation>코인 제어 기능들</translation>
     </message>
     <message>
         <source>Inputs...</source>
@@ -2379,7 +2379,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation>이 기능이 활성화되면 거스름돈 주소가 공란이거나 무효인 경우, 거스름돈은 새롭게 생성된 주소로 송금됩니다.</translation>
+        <translation>이 기능이 활성화되면, 잔돈 주소가 공란이거나 무효인 경우, 잔돈은 새롭게 생성된 주소로 송금됩니다.</translation>
     </message>
     <message>
         <source>Custom change address</source>
@@ -2391,11 +2391,11 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     </message>
     <message>
         <source>Choose...</source>
-        <translation>선택 하기...</translation>
+        <translation>선택하기...</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation>고장 대체 수수료를 사용하게 될 경우 보낸 거래가 승인이 완료 될 때까지 몇 시간 혹은 몇 일 (혹은 영원히) 이 걸릴 수 있습니다. 수동으로 수수료를 선택하거나 전체 체인의 유효성이 검증될 때까지 기다리십시오.</translation>
+        <translation>장애 대체 수수료를 사용하게 될 경우 보낸 거래가 승인이 완료될 때까지 몇 시간 혹은 몇 일(혹은 영원히)이 걸릴 수 있습니다. 수동으로 수수료를 선택하거나 전체 체인의 유효성이 검증될 때까지 기다리세요.</translation>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
@@ -2405,9 +2405,9 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
 Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
-        <translation>거래 가상 크기의 kB (1,000 바이트)당 수수료을 지정하십시오.
+        <translation>거래 가상 크기의 kB(1,000 바이트) 당 수수료을 지정하세요.
 
-참고 : 수수료는 바이트 단위로 계산되므로 거래 크기가 500 바이트 (1kB의 절반)일때에 수수료가 "kB당 100 사토시"면 궁극적으로 50 사토시의 수수료만 발생합니다.</translation>
+참고: 수수료는 바이트 단위로 계산되므로, 거래 크기가 500 바이트(1kB의 절반)일 때 수수료가 "kB 당 100 코이누"면 궁극적으로 50 코이누의 수수료만 발생합니다.</translation>
     </message>
     <message>
         <source>per kilobyte</source>
@@ -2423,15 +2423,15 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Custom:</source>
-        <translation>사용자 정의:</translation>
+        <translation>사용자 지정:</translation>
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(Smart fee가 아직 초기화 되지 않았습니다. 블록 분석이 완전하게 끝날 때 까지 기다려주십시오...)</translation>
+        <translation>(스마트 수수료가 아직 초기화되지 않았습니다. 블록 분석이 완전하게 끝날 때까지 기다려주세요...)</translation>
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation>다수의 수령인들에게 한번에 보내기</translation>
+        <translation>한 번에 다수의 수령인들에게 보내기</translation>
     </message>
     <message>
         <source>Add &amp;Recipient</source>
@@ -2451,11 +2451,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>When there is less transaction volume than space in the blocks, miners as well as relaying nodes may enforce a minimum fee. Paying only this minimum fee is just fine, but be aware that this can result in a never confirming transaction once there is more demand for bitcoin transactions than the network can process.</source>
-        <translation>거래량이 블록에 남은 공간보다 적은 경우, 채굴자나 중계 노드들이 최소 수수료를 허용할 수 있습니다. 최소 수수료만 지불하는건 괜찮지만, 네트워크가 처리할 수 있는 용량을 넘는 비트코인 거래가 있을 경우에는 이 거래가 승인이 안될 수 있다는 점을 유의하세요.</translation>
+        <translation>거래량이 블록에 남은 공간보다 적은 경우, 채굴자나 중계 노드들이 최소 수수료를 허용할 수 있습니다. 최소 수수료만 지불하는건 괜찮지만, 네트워크가 처리할 수 있는 용량을 넘는 도지코인 거래가 있을 경우에는 이 거래가 승인이 안될 수 있다는 점을 유의하세요.</translation>
     </message>
     <message>
         <source>A too low fee might result in a never confirming transaction (read the tooltip)</source>
-        <translation>너무 적은 수수료로는 거래 승인이 안될 수도 있습니다 (툴팁을 참고하세요)</translation>
+        <translation>너무 적은 수수료로는 거래 승인이 안될 수도 있음(툴팁 참고)</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
@@ -2467,7 +2467,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</source>
-        <translation>'수수료-대체' (BIP-125) 옵션은 보낸 거래의 수수료 상향을 지원해 줍니다. 이 옵션이 없을 경우 거래 지연을 방지하기 위해 더 높은 수수료가 권장됩니다.</translation>
+        <translation>'수수료로-대체'(BIP-125) 옵션은 보낸 거래의 수수료 상향을 지원해줍니다. 이 옵션이 없을 경우, 거래 지연을 방지하기 위해 더 높은 수수료가 권장됩니다.</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2519,11 +2519,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Cr&amp;eate Unsigned</source>
-        <translation>사인되지 않은 것을 생성(&amp;e)</translation>
+        <translation>서명되지 않은 것을 생성(&amp;e)</translation>
     </message>
     <message>
         <source>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation>오프라인 %1 지갑 또는 PSBT가 호환되는 하드웨어 지갑과의 사용을 위한 '부분적으로 서명 된 비트 코인 트랜잭션(PSBT)'를 생성합니다.</translation>
+        <translation>오프라인 %1 지갑 또는 PSBT가 호환되는 하드웨어 지갑과의 사용을 위한 '부분적으로 서명된 도지코인 거래(PSBT)'를 생성합니다.</translation>
     </message>
     <message>
         <source> from wallet '%1'</source>
@@ -2531,15 +2531,15 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>%1 to '%2'</source>
-        <translation>%1을 '%2'로</translation>
+        <translation>%1 을/를 '%2' (으)로</translation>
     </message>
     <message>
         <source>%1 to %2</source>
-        <translation>%1을 %2로</translation>
+        <translation>%1 을/를 %2 (으)로</translation>
     </message>
     <message>
         <source>Do you want to draft this transaction?</source>
-        <translation>이 거래 초안을 작성 하시겠습니까?</translation>
+        <translation>이 거래 초안을 작성하시겠습니까?</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
@@ -2551,11 +2551,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Save Transaction Data</source>
-        <translation>트랜잭션 데이터 저장</translation>
+        <translation>거래 데이터 저장</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (Binary) (*.psbt)</source>
-        <translation>부분적으로 서명된 비트코인 트랜잭션 (2진 표기) (*.psbt)</translation>
+        <translation>부분적으로 서명된 도지코인 거래(2진 표기) (*.psbt)</translation>
     </message>
     <message>
         <source>PSBT saved</source>
@@ -2567,15 +2567,15 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>You can increase the fee later (signals Replace-By-Fee, BIP-125).</source>
-        <translation>추후에 거래 수수료를 올릴 수 있습니다 ('수수료로-대체', BIP-125 지원)</translation>
+        <translation>추후에 거래 수수료를 올릴 수 있습니다('수수료로-대체', BIP-125 지원).</translation>
     </message>
     <message>
         <source>Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can save or copy and then sign with e.g. an offline %1 wallet, or a PSBT-compatible hardware wallet.</source>
-        <translation>거래 제안을 검토해 주십시오. 이것은 당신이 저장하거나 복사한 뒤 e.g. 오프라인 %1 지갑 또는 PSBT 호환 하드웨어 지갑으로 서명할 수 있는 PSBT (부분적으로 서명된 비트코인 트랜잭션)를 생성할 것입니다.</translation>
+        <translation>거래 제안을 검토해주세요. 이것은 당신이 저장하거나 복사한 뒤 예를 들어 오프라인 %1 지갑 또는 PSBT 호환 하드웨어 지갑으로 서명할 수 있는 PSBT(부분적으로 서명된 도지코인 거래)를 생성합니다.</translation>
     </message>
     <message>
         <source>Please, review your transaction.</source>
-        <translation>거래를 재검토 하십시오</translation>
+        <translation>거래를 다시 검토하세요.</translation>
     </message>
     <message>
         <source>Transaction fee</source>
@@ -2591,11 +2591,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>To review recipient list click "Show Details..."</source>
-        <translation>수령인 목록을 검토하려면 "거래 세부 내역 보기..." 를 클릭하십시오</translation>
+        <translation>수령인 목록을 검토하려면 "거래 세부 내역 보기..."를 클릭하세요</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation>코인 전송을 확인</translation>
+        <translation>코인 전송 확인</translation>
     </message>
     <message>
         <source>Confirm transaction proposal</source>
@@ -2611,7 +2611,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation>수령인 주소가 정확하지 않습니다. 재확인 바랍니다</translation>
+        <translation>수령인 주소가 정확하지 않습니다. 다시 확인바랍니다.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
@@ -2627,7 +2627,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation>중복된 주소 발견: 주소는 한번만 사용되어야 합니다.</translation>
+        <translation>중복된 주소 발견: 주소는 한 번만 사용되어야 합니다.</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
@@ -2635,7 +2635,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation>%1 보다 큰 수수료는 지나치게 높은 수수료 입니다.</translation>
+        <translation>%1 보다 큰 수수료는 지나치게 높은 수수료입니다.</translation>
     </message>
     <message>
         <source>Payment request expired.</source>
@@ -2647,19 +2647,19 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation>경고: 잘못된 비트코인 주소입니다</translation>
+        <translation>경고: 잘못된 도지코인 주소</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation>경고: 알려지지 않은 주소 변경입니다</translation>
+        <translation>경고: 알려지지 않은 주소 변경</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation>맞춤 주소 변경 확인</translation>
+        <translation>사용자 지정 주소 변경 확인</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation>거스름돈을 위해 선택한 주소는 이 지갑의 일부가 아닙니다. 지갑에 있는 일부 또는 모든 금액을 이 주소로 보낼 수 있습니다. 확실합니까?</translation>
+        <translation>잔돈을 위해 선택한 주소는 이 지갑의 일부가 아닙니다. 지갑에 있는 일부 또는 모든 금액을 이 주소로 보낼 수 있습니다. 확실합니까?</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2682,11 +2682,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation>이전에 사용한 주소를 선택하기</translation>
+        <translation>이전에 사용한 주소 선택하기</translation>
     </message>
     <message>
         <source>The Bitcoin address to send the payment to</source>
-        <translation>이 비트코인 주소로 송금됩니다</translation>
+        <translation>이 도지코인 주소로 송금</translation>
     </message>
     <message>
         <source>Alt+A</source>
@@ -2694,7 +2694,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>클립보드로 부터 주소 붙여넣기</translation>
+        <translation>클립보드로부터 주소 붙여넣기</translation>
     </message>
     <message>
         <source>Alt+P</source>
@@ -2726,19 +2726,19 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>This is an unauthenticated payment request.</source>
-        <translation>인증 되지 않은 지불 요청입니다.</translation>
+        <translation>인증되지 않은 지불 요청입니다.</translation>
     </message>
     <message>
         <source>This is an authenticated payment request.</source>
-        <translation>인증 된 지불 요청 입니다.</translation>
+        <translation>인증된 지불 요청입니다.</translation>
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>이 주소에 라벨을 입력하면 사용된 주소 목록에 라벨이 표시됩니다</translation>
+        <translation>이 주소의 라벨을 입력하여 사용된 주소 목록에 추가</translation>
     </message>
     <message>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation>bitcoin: URI에 추가된 메시지는 참고를 위해 거래내역과 함께 저장될 것입니다. Note: 이 메시지는 비트코인 네트워크로 전송되지 않습니다.</translation>
+        <translation>dogecoin: URI 에 추가된 메시지는 참고를 위해 거래 내역과 함께 저장됩니다. 참고: 이 메시지는 도지코인 네트워크로 전송되지 않습니다.</translation>
     </message>
     <message>
         <source>Pay To:</source>
@@ -2753,7 +2753,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down...</source>
-        <translation>%1이 종료 중입니다...</translation>
+        <translation>%1 이/가 종료 중...</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -2764,7 +2764,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation>서명 - 싸인 / 메시지 검증</translation>
+        <translation>서명 - 사인 / 메시지 검증</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
@@ -2772,11 +2772,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>당신이 해당 주소로 비트코인을 받을 수 있다는 것을 증명하기 위해 메시지/합의문을 그 주소로 서명할 수 있습니다. 피싱 공격이 당신을 속일 수 있으므로 임의의 내용이나 모호한 내용에 서명하지 않도록 주의하세요. 당신이 동의하는 명확한 조항들에만 서명하세요.</translation>
+        <translation>주소로 메시지/계약서에 서명하여 보낸 도지코인을 받을 수 있음을 증명할 수 있습니다. 피싱 공격으로 말미암아 여러분의 서명을 통해 속아 넘어가게 할 수 있으므로, 서명하지 않은 모든 모호한 요소를 주의하세요. 조항들이 완전 무결한지 확인 후 동의하는 경우에만 서명하세요.</translation>
     </message>
     <message>
         <source>The Bitcoin address to sign the message with</source>
-        <translation>메세지를 서명할 비트코인 주소</translation>
+        <translation>메시지를 서명할 도지코인 주소</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -2796,7 +2796,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
-        <translation>여기에 서명할 메시지를 입력하세요</translation>
+        <translation>여기에 서명할 메시지 입력</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -2808,7 +2808,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>당신이 이 비트코인 주소를 소유한다는 증명을 위해 메시지를 서명합니다</translation>
+        <translation>이 도지코인 주소를 소유하고 있음을 증명하기 위해 메시지 서명하기</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -2816,7 +2816,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation>모든 입력항목을 초기화합니다</translation>
+        <translation>모든 입력 항목 초기화</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
@@ -2828,23 +2828,23 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation>메시지를 검증하기 위해 아래 칸에 각각 지갑 주소와 메시지, 서명을 입력하세요 (메시지 원본의 띄어쓰기, 들여쓰기, 행 나눔 등이 정확하게 입력되어야 하므로 원본을 복사해서 입력하세요). 네트워크 침입자의 속임수에 넘어가지 않도록 서명된 메시지 내용 이외의 내용은 참고하지 않도록 유의하세요. 이 기능은 단순히 서명한 쪽에서 해당 주소로 송금을 받을 수 있다는 것을 증명하는 것 뿐이며 그 이상은 어떤 것도 보증하지 않습니다.</translation>
+        <translation>메시지를 검증하기 위해 아래 칸에 각각 지갑 주소와 메시지(메시지 원본의 띄어쓰기, 들여쓰기, 행 나눔 등이 정확하게 입력되어야 하므로 원본을 복사해서 입력하세요), 전자 서명을 입력하세요. 이 기능은 메시지 검증이 주 목적이며, 네트워크 침입자에 의해 변조되지 않도록 전자 서명 해독에 불필요한 시간을 소모하지 마세요.</translation>
     </message>
     <message>
         <source>The Bitcoin address the message was signed with</source>
-        <translation>메세지의 서명에 사용된 비트코인 주소</translation>
+        <translation>메시지의 서명에 사용된 도지코인 주소</translation>
     </message>
     <message>
         <source>The signed message to verify</source>
-        <translation>검증할 서명된 메세지</translation>
+        <translation>검증할 서명된 메시지</translation>
     </message>
     <message>
         <source>The signature given when the message was signed</source>
-        <translation>메세지의 서명되었을 때의 시그니처</translation>
+        <translation>메시지에 서명할 때 제공된 서명</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>입력된 비트코인 주소로 메시지가 서명되었는지 검증합니다</translation>
+        <translation>메시지가 지정된 도지코인 주소로 서명되었는지 확인</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -2852,11 +2852,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation>모든 입력 항목을 초기화합니다</translation>
+        <translation>모든 입력 항목 초기화</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation>서명을 만들려면 "메시지 서명"을 클릭하세요</translation>
+        <translation>서명을 생성하기 위해 "메시지 서명" 클릭</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
@@ -2864,11 +2864,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation>주소를 확인하고 다시 시도하십시오.</translation>
+        <translation>주소를 확인하고 다시 시도하세요.</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation>입력한 주소는 지갑내 키를 참조하지 않습니다.</translation>
+        <translation>입력한 주소는 지갑 내 키를 참조하지 않습니다.</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
@@ -2880,7 +2880,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation>입력한 주소에 대한 개인키가 없습니다.</translation>
+        <translation>입력한 주소에 대한 개인 키가 없습니다.</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
@@ -2896,7 +2896,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation>서명을 확인하고 다시 시도하십시오.</translation>
+        <translation>서명을 확인하고 다시 시도하세요.</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
@@ -2922,7 +2922,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     <name>TransactionDesc</name>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
-        <translation><numerusform>%n개의 더 많은 블록 열기</numerusform></translation>
+        <translation><numerusform>%n 개의 더 많은 블록 열기</numerusform></translation>
     </message>
     <message>
         <source>Open until %1</source>
@@ -3002,7 +3002,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message numerus="yes">
         <source>matures in %n more block(s)</source>
-        <translation><numerusform>%n개의 블록검증이 더 필요함</numerusform></translation>
+        <translation><numerusform>%n 개의 블록 검증이 더 필요함</numerusform></translation>
     </message>
     <message>
         <source>not accepted</source>
@@ -3054,7 +3054,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source> (Certificate was not verified)</source>
-        <translation>(인증서가 확인되지 않았습니다)</translation>
+        <translation> (인증서가 확인되지 않았습니다)</translation>
     </message>
     <message>
         <source>Merchant</source>
@@ -3062,7 +3062,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation>신규 채굴된 코인이 사용되기 위해서는 %1 개의 블록이 경과되어야 합니다. 블록을 생성할 때 블록체인에 추가되도록 네트워크에 전파되는 과정을 거치는데, 블록체인에 포함되지 못하고 실패한다면 해당 블록의 상태는 '미승인'으로 표현되고 비트코인 또한 사용될 수 없습니다. 이 현상은 다른 노드가 비슷한 시간대에 동시에 블록을 생성할 때 종종 발생할 수 있습니다.</translation>
+        <translation>신규 채굴된 코인이 사용되기 위해서는 %1 개의 블록이 경과되어야 합니다. 블록을 생성할 때 블록 체인에 추가되도록 네트워크에 전파되는 과정을 거치는데, 블록 체인에 포함되지 못하고 실패한다면, 해당 블록의 상태는 '미승인'으로 표현되고 도지코인 또한 사용될 수 없습니다. 이 현상은 다른 노드가 비슷한 시간대에 동시에 블록을 생성할 때 종종 발생할 수 있습니다.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -3093,11 +3093,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     <name>TransactionDescDialog</name>
     <message>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation>이 창은 거래의 세부내역을 보여줍니다</translation>
+        <translation>이 창은 거래의 세부 내역을 보여줌</translation>
     </message>
     <message>
         <source>Details for %1</source>
-        <translation>%1에 대한 세부 정보</translation>
+        <translation>%1 에 대한 세부 정보</translation>
     </message>
 </context>
 <context>
@@ -3116,7 +3116,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message numerus="yes">
         <source>Open for %n more block(s)</source>
-        <translation><numerusform>%n개의 더 많은 블록 열기</numerusform></translation>
+        <translation><numerusform>%n 개의 더 많은 블록 열기</numerusform></translation>
     </message>
     <message>
         <source>Open until %1</source>
@@ -3132,11 +3132,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation>승인 중 (권장되는 승인 회수 %2 대비 현재 승인 수 %1)</translation>
+        <translation>승인 중(권장되는 승인 회수 %2 대비 현재 승인 수 %1)</translation>
     </message>
     <message>
         <source>Confirmed (%1 confirmations)</source>
-        <translation>승인됨 (%1 확인됨)</translation>
+        <translation>승인됨(%1 확인됨)</translation>
     </message>
     <message>
         <source>Conflicted</source>
@@ -3144,7 +3144,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation>충분히 숙성되지 않은 상태 (%1 승인, %2 후에 사용 가능합니다)</translation>
+        <translation>충분히 숙성되지 않은 상태(%1 승인, %2 후에 사용할 수 있음)</translation>
     </message>
     <message>
         <source>Generated but not accepted</source>
@@ -3152,15 +3152,15 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Received with</source>
-        <translation>받은 주소 :</translation>
+        <translation>받은 주소:</translation>
     </message>
     <message>
         <source>Received from</source>
-        <translation>보낸 주소 :</translation>
+        <translation>보낸 주소:</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation>받는 주소 :</translation>
+        <translation>받는 주소:</translation>
     </message>
     <message>
         <source>Payment to yourself</source>
@@ -3184,15 +3184,15 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation>거래 상황. 마우스를 올리면 검증횟수가 표시됩니다.</translation>
+        <translation>거래 상황입니다. 마우스를 올리면 검증 횟수가 표시됩니다.</translation>
     </message>
     <message>
         <source>Date and time that the transaction was received.</source>
-        <translation>거래가 이루어진 날짜와 시각.</translation>
+        <translation>거래가 이루어진 날짜와 시각입니다.</translation>
     </message>
     <message>
         <source>Type of transaction.</source>
-        <translation>거래의 종류.</translation>
+        <translation>거래의 종류입니다.</translation>
     </message>
     <message>
         <source>Whether or not a watch-only address is involved in this transaction.</source>
@@ -3200,11 +3200,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>User-defined intent/purpose of the transaction.</source>
-        <translation>거래에 대해 사용자가 정의한 의도나 목적.</translation>
+        <translation>거래에 대해 사용자가 정의한 의도나 목적입니다.</translation>
     </message>
     <message>
         <source>Amount removed from or added to balance.</source>
-        <translation>늘어나거나 줄어든 액수.</translation>
+        <translation>늘어나거나 줄어든 액수입니다.</translation>
     </message>
 </context>
 <context>
@@ -3219,7 +3219,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>This week</source>
-        <translation>이번주</translation>
+        <translation>이번 주</translation>
     </message>
     <message>
         <source>This month</source>
@@ -3231,19 +3231,19 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>This year</source>
-        <translation>올 해</translation>
+        <translation>올해</translation>
     </message>
     <message>
         <source>Range...</source>
-        <translation>범위...</translation>
+        <translation>조회 기간...</translation>
     </message>
     <message>
         <source>Received with</source>
-        <translation>받은 주소 :</translation>
+        <translation>받은 주소:</translation>
     </message>
     <message>
         <source>Sent to</source>
-        <translation>보낸 주소 :</translation>
+        <translation>보낸 주소:</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3259,7 +3259,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Enter address, transaction id, or label to search</source>
-        <translation>검색하기 위한 주소, 거래 아이디 또는 라벨을 입력하십시오.</translation>
+        <translation>검색하기 위한 주소, 거래 ID 또는 라벨을 입력하세요.</translation>
     </message>
     <message>
         <source>Min amount</source>
@@ -3287,7 +3287,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Copy transaction ID</source>
-        <translation>거래 아이디 복사</translation>
+        <translation>거래 ID 복사</translation>
     </message>
     <message>
         <source>Copy raw transaction</source>
@@ -3311,7 +3311,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Comma separated file (*.csv)</source>
-        <translation>쉼표로 구분된 파일 (*.csv)</translation>
+        <translation>쉼표로 구분된 파일(*.csv)</translation>
     </message>
     <message>
         <source>Confirmed</source>
@@ -3339,7 +3339,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>ID</source>
-        <translation>아이디</translation>
+        <translation>ID</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
@@ -3347,7 +3347,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation>%1으로 거래 기록을 저장하는데 에러가 있었습니다.</translation>
+        <translation>%1 (으)로 거래 기록을 저장하는데 오류가 있었습니다.</translation>
     </message>
     <message>
         <source>Exporting Successful</source>
@@ -3355,22 +3355,22 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation>거래 기록이 성공적으로 %1에 저장되었습니다.</translation>
+        <translation>거래 기록이 성공적으로 %1 에 저장되었습니다.</translation>
     </message>
     <message>
         <source>Range:</source>
-        <translation>범위:</translation>
+        <translation>조회 기간:</translation>
     </message>
     <message>
         <source>to</source>
-        <translation>수신인</translation>
+        <translation>~</translation>
     </message>
 </context>
 <context>
     <name>UnitDisplayStatusBarControl</name>
     <message>
         <source>Unit to show amounts in. Click to select another unit.</source>
-        <translation>거래액을 표시하는 단위. 클릭해서 다른 단위를 선택할 수 있습니다.</translation>
+        <translation>거래액을 표시하는 단위입니다. 클릭해서 다른 단위를 선택할 수 있습니다.</translation>
     </message>
 </context>
 <context>
@@ -3385,7 +3385,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     <message>
         <source>Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled.</source>
-        <translation>지갑을 너무 오랫동안 닫는 것은 블록 축소가 적용될 경우 체인 전체 재 동기화로 이어질 수 있습니다.</translation>
+        <translation>지갑을 너무 오랫동안 닫는 것은 블록 축소가 적용될 경우 체인 전체 재동기화로 이어질 수 있습니다.</translation>
     </message>
     <message>
         <source>Close all wallets</source>
@@ -3404,7 +3404,7 @@ Go to File &gt; Open Wallet to load a wallet.
 - OR -</source>
         <translation>지갑이 로드되지 않았습니다.
 '파일 &gt; 지갑 열기'로 이동하여 지갑을 로드합니다.
--또는-</translation>
+- 또는 -</translation>
     </message>
     <message>
         <source>Create a new wallet</source>
@@ -3431,7 +3431,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Do you want to draft a transaction with fee increase?</source>
-        <translation>수수료가 인상 된 거래를 작성 하시겠습니까?</translation>
+        <translation>수수료가 인상된 거래를 작성하시겠습니까?</translation>
     </message>
     <message>
         <source>Current fee:</source>
@@ -3459,11 +3459,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Can't sign transaction.</source>
-        <translation>거래에 서명 할 수 없습니다.</translation>
+        <translation>거래에 서명할 수 없습니다.</translation>
     </message>
     <message>
         <source>Could not commit transaction</source>
-        <translation>거래를 커밋 할 수 없습니다.</translation>
+        <translation>거래를 커밋할 수 없습니다.</translation>
     </message>
     <message>
         <source>default wallet</source>
@@ -3474,7 +3474,7 @@ Go to File &gt; Open Wallet to load a wallet.
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation>내보내기 (&amp;E)</translation>
+        <translation>내보내기(&amp;E)</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
@@ -3486,23 +3486,23 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unable to decode PSBT from clipboard (invalid base64)</source>
-        <translation>클립 보드에서 PSBT를 디코딩 할 수 없습니다 (잘못된 base64).</translation>
+        <translation>클립 보드에서 PSBT를 디코딩할 수 없습니다(잘못된 base64).</translation>
     </message>
     <message>
         <source>Load Transaction Data</source>
-        <translation>트랜젝션 데이터 불러오기</translation>
+        <translation>거래 데이터 불러오기</translation>
     </message>
     <message>
         <source>Partially Signed Transaction (*.psbt)</source>
-        <translation>부분적으로 서명된 비트코인 트랜잭션 (* .psbt)</translation>
+        <translation>부분적으로 서명된 도지코인 거래(* .psbt)</translation>
     </message>
     <message>
         <source>PSBT file must be smaller than 100 MiB</source>
-        <translation>PSBT 파일은 100MiB보다 작아야합니다.</translation>
+        <translation>PSBT 파일은 100 MiB 보다 작아야 합니다.</translation>
     </message>
     <message>
         <source>Unable to decode PSBT</source>
-        <translation>PSBT를 디코드 할 수 없음</translation>
+        <translation>PSBT를 디코딩할 수 없음</translation>
     </message>
     <message>
         <source>Backup Wallet</source>
@@ -3510,7 +3510,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Wallet Data (*.dat)</source>
-        <translation>지갑 데이터 (*.dat)</translation>
+        <translation>지갑 데이터(*.dat)</translation>
     </message>
     <message>
         <source>Backup Failed</source>
@@ -3518,7 +3518,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation>지갑 데이터를 %1 폴더에 저장하는 동안 오류가 발생 하였습니다.</translation>
+        <translation>지갑 데이터를 %1 폴더에 저장하는 동안 오류가 발생하였습니다.</translation>
     </message>
     <message>
         <source>Backup Successful</source>
@@ -3526,7 +3526,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation>지갑 정보가 %1에 성공적으로 저장되었습니다.</translation>
+        <translation>지갑 정보가 %1 에 성공적으로 저장되었습니다.</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -3537,23 +3537,23 @@ Go to File &gt; Open Wallet to load a wallet.
     <name>bitcoin-core</name>
     <message>
         <source>Distributed under the MIT software license, see the accompanying file %s or %s</source>
-        <translation>MIT 소프트웨어 라이센스에 따라 배포되었습니다. 첨부 파일 %s 또는 %s을 참조하십시오.</translation>
+        <translation>MIT 소프트웨어 라이선스에 따라 배포되었습니다. 첨부 파일 %s 또는 %s 을/를 참고하세요.</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
-        <translation>블록 축소가 최소치인 %d MiB 밑으로 설정되어 있습니다. 더 높은 값을 사용해 주십시오.</translation>
+        <translation>블록 축소가 최소치인 %d MiB 밑으로 설정되어 있습니다. 더 높은 값을 사용해주세요.</translation>
     </message>
     <message>
         <source>Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)</source>
-        <translation>블록 축소: 마지막 지갑 동기화 지점이 축소된 데이터보다 과거의 것 입니다. -reindex가 필요합니다 (축소된 노드의 경우 모든 블록체인을 재다운로드합니다)</translation>
+        <translation>블록 축소: 마지막 지갑 동기화 지점이 축소된 데이터보다 과거의 것입니다. -reindex가 필요합니다(축소된 노드의 경우 모든 블록 체인을 다시 다운로드합니다).</translation>
     </message>
     <message>
         <source>Pruning blockstore...</source>
-        <translation>블록 데이터를 축소 중입니다..</translation>
+        <translation>블록 데이터 축소 중...</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
-        <translation>HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인 하세요.</translation>
+        <translation>HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인하세요.</translation>
     </message>
     <message>
         <source>The %s developers</source>
@@ -3561,75 +3561,75 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
-        <translation>데이터 디렉토리 %s 에 락을 걸 수 없었습니다. %s가 이미 실행 중인 것으로 보입니다.</translation>
+        <translation>데이터 폴더 %s 에 락을 걸 수 없었습니다. %s 이/가 이미 실행 중인 것으로 보입니다.</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
-        <translation>특정 연결을 제공 할 수없고 어드맨이 나가는 연결을 찾을 수 없습니다.</translation>
+        <translation>특정 연결을 제공할 수 없고 어드맨(addrman)이 나가는 연결을 찾을 수 없습니다.</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation>%s 불러오기 오류! 주소 키는 모두 정확하게 로드되었으나 거래 데이터와 주소록 필드에서 누락이나 오류가 존재할 수 있습니다.</translation>
+        <translation>%s 불러오기 오류! 주소 키는 모두 정확하게 로드되었으나, 거래 데이터와 주소록 필드에서 누락이나 오류가 존재할 수 있습니다.</translation>
     </message>
     <message>
         <source>More than one onion bind address is provided. Using %s for the automatically created Tor onion service.</source>
-        <translation>하나 이상의 양파 바인딩 주소가 제공됩니다. 자동으로 생성 된 Tor onion 서비스에 %s 사용.</translation>
+        <translation>하나 이상의 onion 바인딩 주소가 제공됩니다. 자동으로 생성된 Tor onion 서비스에 %s 사용합니다.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
-        <translation>컴퓨터의 날짜와 시간이 올바른지 확인하십시오! 시간이 잘못되면 %s은 제대로 동작하지 않습니다.</translation>
+        <translation>컴퓨터의 날짜와 시간이 올바른지 확인하세요! 시간이 잘못되면, %s 은/는 제대로 동작하지 않습니다.</translation>
     </message>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
-        <translation>%s가 유용하다고 생각한다면 프로젝트에 공헌해주세요. 이 소프트웨어에 대한 보다 자세한 정보는 %s를 방문해 주십시오.</translation>
+        <translation>%s 이/가 유용하다고 생각한다면 프로젝트에 기여해주세요. 이 소프트웨어에 대한 보다 자세한 정보는 %s 을/를 방문해주세요.</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare the statement to fetch sqlite wallet schema version: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 에스큐엘라이트 지갑 스키마 버전을 가져오는 실행문 준비에 실패하였습니다 : %s</translation>
+        <translation>SQLiteDatabase: sqlite 지갑 스키마 버전을 가져오는 실행문 준비 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare the statement to fetch the application id: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 응용 프로그램 ID를 가져오는 실행문 준비에 실패하였습니다 : %s</translation>
+        <translation>SQLiteDatabase: 애플리케이션 ID를 가져오는 실행문 준비 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unknown sqlite wallet schema version %d. Only version %d is supported</source>
-        <translation>에스큐엘라이트 데이터베이스 : 알 수 없는 에스큐엘라이트 지갑 스키마 버전 %d. %d 버전만 지원합니다.</translation>
+        <translation>SQLiteDatabase: 알 수 없는 sqlite 지갑 스키마 버전 %d. %d 버전만 지원</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
-        <translation>블록 데이터베이스에 미래의 블록이 포함되어 있습니다. 이것은 사용자의 컴퓨터의 날짜와 시간이 올바르게 설정되어 있지 않을때 나타날 수 있습니다. 블록 데이터 베이스의 재구성은 사용자의 컴퓨터의 날짜와 시간이 올바르다고 확신할 때에만 하십시오.</translation>
+        <translation>블록 데이터베이스에 미래의 블록이 포함되어 있습니다. 이것은 사용자의 컴퓨터의 날짜와 시간이 올바르게 설정되어 있지 않을 때 나타날 수 있습니다. 블록 데이터베이스의 재구성은 사용자의 컴퓨터의 날짜와 시간이 올바르다고 확신할 때에만 수행하세요.</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation>출시 전의 테스트 빌드 입니다. - 스스로의 책임하에 사용하십시오. - 채굴이나 상업적 용도로 사용하지 마십시오.</translation>
+        <translation>출시 전의 테스트 빌드입니다. - 스스로의 책임하에 사용하세요 - 채굴이나 상업적 용도로 사용하지 마세요.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
-        <translation>이것은 거스름돈이 현재 레벨의 더스트보다 적은 경우 버릴 수 있는 수수료입니다.</translation>
+        <translation>잔돈이 현재 레벨의 더스트보다 적은 경우 버릴 수 있는 수수료임</translation>
     </message>
     <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
-        <translation>블록을 재생할 수 없습니다. -reindex-chainstate를 사용하여 데이터베이스를 다시 빌드 해야 합니다.</translation>
+        <translation>블록을 재생할 수 없습니다. -reindex-chainstate를 사용하여 데이터베이스를 다시 빌드해야 합니다.</translation>
     </message>
     <message>
         <source>Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain</source>
-        <translation>데이터베이스를 포크 전 상태로 돌리지 못했습니다. 블록체인을 다시 다운로드 해주십시오.</translation>
+        <translation>데이터베이스를 포크 전 상태로 돌리지 못했습니다. 블록 체인을 다시 다운로드해주세요.</translation>
     </message>
     <message>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation>경고 : 모든 네트워크가 동의해야 하나, 일부 채굴자들에게 문제가 있는 것으로 보입니다.</translation>
+        <translation>경고: 모든 네트워크가 동의해야 합니다! 일부 채굴자들에게 문제가 있는 것으로 보입니다.</translation>
     </message>
     <message>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation>경고: 현재 비트코인 버전이 다른 네트워크 참여자들과 동일하지 않은 것 같습니다. 당신 또는 다른 참여자들이 동일한 비트코인 버전으로 업그레이드 할 필요가 있습니다.</translation>
+        <translation>경고: 현재 도지코인 버전이 다른 네트워크 참여자들과 동일하지 않은 것 같습니다. 당신 또는 다른 참여자들이 동일한 도지코인 버전으로 업그레이드할 필요가 있습니다.</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
-        <translation>-maxmempool은 최소한 %d MB 이어야 합니다</translation>
+        <translation>-maxmempool은 최소한 %d MB 이어야 함</translation>
     </message>
     <message>
         <source>Cannot resolve -%s address: '%s'</source>
-        <translation>%s 주소를 확인할 수 없습니다: '%s'</translation>
+        <translation>%s 주소를 확인할 수 없음: '%s'</translation>
     </message>
     <message>
         <source>Change index out of range</source>
@@ -3637,7 +3637,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Config setting for %s only applied on %s network when in [%s] section.</source>
-        <translation>%s의 설정은 %s 네트워크에만 적용되는 데, 이는 [%s] 항목에 있을 경우 뿐 입니다.</translation>
+        <translation>%s 의 설정은 %s 네트워크에만 적용되는 데, 이는 [%s] 항목에 있을 경우 뿐입니다.</translation>
     </message>
     <message>
         <source>Copyright (C) %i-%i</source>
@@ -3645,15 +3645,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Corrupted block database detected</source>
-        <translation>손상된 블록 데이터베이스가 감지되었습니다</translation>
+        <translation>손상된 블록 데이터베이스 감지됨</translation>
     </message>
     <message>
         <source>Could not find asmap file %s</source>
-        <translation>asmap file %s 을 찾을 수 없습니다</translation>
+        <translation>asmap 파일 %s 을/를 찾을 수 없음</translation>
     </message>
     <message>
         <source>Could not parse asmap file %s</source>
-        <translation>asmap file %s 을 파싱할 수 없습니다</translation>
+        <translation>asmap 파일 %s 을/를 파싱할 수 없음</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -3673,7 +3673,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Error loading %s: Private keys can only be disabled during creation</source>
-        <translation>%s 로딩 실패: 개인키는 생성할때만 비활성화 할 수 있습니다</translation>
+        <translation>%s 로딩 실패: 개인 키는 생성할 때만 비활성화할 수 있음</translation>
     </message>
     <message>
         <source>Error loading %s: Wallet corrupted</source>
@@ -3681,7 +3681,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Error loading %s: Wallet requires newer version of %s</source>
-        <translation>%s 불러오기 오류: 지갑은 새 버전의 %s이 필요합니다</translation>
+        <translation>%s 불러오기 오류: 지갑은 새 버전의 %s 이/가 필요함</translation>
     </message>
     <message>
         <source>Error loading block database</source>
@@ -3693,15 +3693,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation>포트 연결에 실패하였습니다. 필요하다면 -리슨=0 옵션을 사용하십시오.</translation>
+        <translation>포트 연결에 실패하였습니다. 필요하다면 -listen=0 옵션을 사용하세요.</translation>
     </message>
     <message>
         <source>Failed to rescan the wallet during initialization</source>
-        <translation>지갑 스캔 오류</translation>
+        <translation>초기화 중 지갑 재검색 실패</translation>
     </message>
     <message>
         <source>Failed to verify database</source>
-        <translation>데이터베이스를 검증 실패</translation>
+        <translation>데이터베이스 검증 실패</translation>
     </message>
     <message>
         <source>Importing...</source>
@@ -3709,11 +3709,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation>제네시스 블록이 없거나 잘 못 되었습니다. 네트워크의 datadir을 확인해 주십시오.</translation>
+        <translation>제네시스 블록이 없거나 잘못 되었습니다. 네트워크의 데이터 폴더를 확인해주세요.</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
-        <translation>무결성 확인 초기화에 실패하였습니다. %s가 곧 종료됩니다.</translation>
+        <translation>무결성 확인 초기화에 실패하였습니다. %s 이/가 곧 종료됩니다.</translation>
     </message>
     <message>
         <source>Invalid P2P permission: '%s'</source>
@@ -3721,39 +3721,39 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Invalid amount for -%s=&lt;amount&gt;: '%s'</source>
-        <translation>유효하지 않은 금액 -%s=&lt;amount&gt;: '%s'</translation>
+        <translation>-%s=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -discardfee=&lt;amount&gt;: '%s'</source>
-        <translation>유효하지 않은 금액 -discardfee=&lt;amount&gt;: '%s'</translation>
+        <translation>-discardfee=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s'</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
-        <translation>유효하지 않은 금액 -fallbackfee=&lt;amount&gt;: '%s'</translation>
+        <translation>-fallbackfee=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s'</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to execute statement to verify database: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 데이터베이스를 확인하는 실행문 출력을 실패하였습니다 : %s.</translation>
+        <translation>SQLiteDatabase: 데이터베이스를 확인하는 실행문 출력 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to fetch sqlite wallet schema version: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 에스큐엘라이트 지갑 스키마 버전 가져오기를 실패하였습니다 : %s</translation>
+        <translation>SQLiteDatabase: sqlite 지갑 스키마 버전 가져오기 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to fetch the application id: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 어플리케이션 아이디 가져오기를 실패하였습니다 : %s</translation>
+        <translation>SQLiteDatabase: 애플리케이션 아이디 가져오기 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Failed to prepare statement to verify database: %s</source>
-        <translation>에스큐엘라이트 데이터베이스 : 데이터베이스를 확인하는 실행문 준비에 실패하였습니다 : %s.</translation>
+        <translation>SQLiteDatabase: 데이터베이스를 확인하는 실행문 준비 실패: %s</translation>
     </message>
     <message>
         <source>SQLiteDatabase: Unexpected application id. Expected %u, got %u</source>
-        <translation>에스큐엘라이트 데이터베이스 : 예상 못한 어플리케이션 아이디. 예정: %u, 받음: %u</translation>
+        <translation>SQLiteDatabase: 예상치 못한 애플리케이션 아이디. 예정: %u, 받음: %u</translation>
     </message>
     <message>
         <source>Specified blocks directory "%s" does not exist.</source>
-        <translation>지정한 블록 디렉토리 "%s" 가 존재하지 않습니다.</translation>
+        <translation>지정한 블록 폴더 "%s" 이/가 존재하지 않습니다.</translation>
     </message>
     <message>
         <source>Unknown change type '%s'</source>
@@ -3761,7 +3761,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Upgrading txindex database</source>
-        <translation>txindex 데이터베이스 업테이트중</translation>
+        <translation>txindex 데이터베이스 업데이트 중</translation>
     </message>
     <message>
         <source>Loading P2P addresses...</source>
@@ -3769,7 +3769,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Loading banlist...</source>
-        <translation>추방리스트를 불러오는 중...</translation>
+        <translation>차단리스트를 불러오는 중...</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
@@ -3793,15 +3793,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>The source code is available from %s.</source>
-        <translation>소스코드는 %s 에서 확인하실 수 있습니다.</translation>
+        <translation>소스 코드는 %s 에서 확인하실 수 있습니다.</translation>
     </message>
     <message>
         <source>Transaction fee and change calculation failed</source>
-        <translation>거래 수수료 및 잔돈 계산에 실패했습니다.</translation>
+        <translation>거래 수수료 및 잔돈 계산 실패</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer. %s is probably already running.</source>
-        <translation>이 컴퓨터의 %s에 바인딩 할 수 없습니다. 아마도 %s이 실행중인 것 같습니다.</translation>
+        <translation>이 컴퓨터의 %s 에 바인딩할 수 없습니다. 아마도 %s 이/가 실행 중인 것 같습니다.</translation>
     </message>
     <message>
         <source>Unable to generate keys</source>
@@ -3809,7 +3809,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Unsupported logging category %s=%s.</source>
-        <translation>지원되지 않는 로깅 카테고리 %s = %s.</translation>
+        <translation>지원되지 않는 로깅 카테고리 %s=%s.</translation>
     </message>
     <message>
         <source>Upgrading UTXO database</source>
@@ -3817,7 +3817,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
-        <translation>사용자 정의 코멘트 (%s)에 안전하지 못한 글자가 포함되어 있습니다.</translation>
+        <translation>사용자 정의 코멘트(%s)에 안전하지 않은 글자가 포함되어 있습니다.</translation>
     </message>
     <message>
         <source>Verifying blocks...</source>
@@ -3825,47 +3825,47 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
-        <translation>지갑을 새로 써야 합니다:  진행을 위해 %s 를 다시 시작하십시오</translation>
+        <translation>지갑을 새로 써야 합니다. 완료를 위해 %s 을/를 다시 시작하세요</translation>
     </message>
     <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
-        <translation>오류: 들어오는 연결을 허용하는데 실패했습니다 (리슨 오류: %s)</translation>
+        <translation>오류: 들어오는 연결 허용 실패(리슨 반환 오류: %s)</translation>
     </message>
     <message>
         <source>%s corrupt. Try using the wallet tool bitcoin-wallet to salvage or restoring a backup.</source>
-        <translation>%s가 손상되었습니다. '비트 코인-지갑'을 사용하여 백업을 구제하거나 복원하십시오.</translation>
+        <translation>%s 이/가 손상되었습니다. 지갑 도구인 '도지코인-지갑'을 사용하여 백업을 복구하거나 복원하세요.</translation>
     </message>
     <message>
         <source>Cannot upgrade a non HD split wallet without upgrading to support pre split keypool. Please use version 169900 or no version specified.</source>
-        <translation>HD 분할을 하지 않은 지갑은 pre split keypool로 업그레이드 하지 않고는 업그레이드를 진행할 수 없습니다. 버전 169900나 버전을 지정하지 않는 것을 사용해주십시오.</translation>
+        <translation>HD 분할을 하지 않은 지갑은 분할 전 키 풀로 업그레이드하지 않고는 업그레이드를 진행할 수 없습니다. 버전 169900나 버전을 지정하지 마세요.</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
-        <translation>유효하지 않은 금액 -maxtxfee=&lt;amount&gt;: '%s' (거래가 막히는 상황을 방지하게 위해 적어도 %s 의 중계 수수료를 지정해야 합니다)</translation>
+        <translation>-maxtxfee=&lt;amount&gt;에 대한 유효하지 않은 금액: '%s' (거래가 막히는 상황을 방지하게 위해 적어도 %s 의 중계 수수료를 지정해야 함)</translation>
     </message>
     <message>
         <source>The transaction amount is too small to send after the fee has been deducted</source>
-        <translation>거래액이 수수료를 지불하기엔 너무 작습니다</translation>
+        <translation>거래액이 수수료를 지불하기에 너무 적음</translation>
     </message>
     <message>
         <source>This error could occur if this wallet was not shutdown cleanly and was last loaded using a build with a newer version of Berkeley DB. If so, please use the software that last loaded this wallet</source>
-        <translation>지갑이 완전히 종료되지 않고 최신 버전의 Berkeley DB 빌드를 사용하여 마지막으로 로드된 경우 오류가 발생할 수 있습니다. 이 지갑을 마지막으로 로드한 소프트웨어를 사용하십시오.</translation>
+        <translation>지갑이 완전히 종료되지 않고 최신 버전의 Berkeley DB 빌드를 사용하여 마지막으로 로드된 경우 오류가 발생할 수 있습니다. 이 지갑을 마지막으로 로드한 소프트웨어를 사용하세요.</translation>
     </message>
     <message>
         <source>This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection.</source>
-        <translation>이것은 일반 코인 선택보다 부분적 지출 회피를 우선시하기 위해 지불하는 최대 거래 수수료 (일반 수수료에 추가)입니다.</translation>
+        <translation>이는 일반 코인 선택보다 부분적 지출 회피를 우선시하기 위해 지불하는 최대 거래 수수료(일반 수수료에 추가)입니다.</translation>
     </message>
     <message>
         <source>Transaction needs a change address, but we can't generate it. Please call keypoolrefill first.</source>
-        <translation>거래에 변경 주소가 필요하지만 생성 할 수 없습니다. 먼저 keypoolrefill에 전화하십시오.</translation>
+        <translation>거래에 변경 주소가 필요하지만, 생성할 수 없습니다. 먼저 keypoolrefill을 호출하세요.</translation>
     </message>
     <message>
         <source>You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain</source>
-        <translation>블록 축소 모드를 해제하려면 데이터베이스를 재구성하기 위해 -reindex를 사용해야 합니다. 이 명령은 전체 블록체인을 다시 다운로드합니다.</translation>
+        <translation>블록 축소 모드를 해제하려면 데이터베이스를 재구성하기 위해 -reindex를 사용해야 합니다. 이 명령은 전체 블록 체인을 다시 다운로드합니다.</translation>
     </message>
     <message>
         <source>A fatal internal error occurred, see debug.log for details</source>
-        <translation>치명적 내부 오류 발생. 상세한 내용을 debug.log 에서 확인하십시오</translation>
+        <translation>치명적 내부 오류 발생. 상세한 내용은 debug.log 확인</translation>
     </message>
     <message>
         <source>Cannot set -peerblockfilters without -blockfilterindex.</source>
@@ -3877,7 +3877,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
-        <translation>블록 데이터베이스를 불러오는데 오류가 발생하였습니다, 곧 종료됩니다.</translation>
+        <translation>블록 데이터베이스를 불러오는데 오류가 발생하였습니다. 곧 종료됩니다.</translation>
     </message>
     <message>
         <source>Error upgrading chainstate database</source>
@@ -3885,11 +3885,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Error: Disk space is low for %s</source>
-        <translation>오류: %s 하기엔 저장공간이 부족합니다</translation>
+        <translation>오류: %s 하기엔 저장 공간 부족</translation>
     </message>
     <message>
         <source>Error: Keypool ran out, please call keypoolrefill first</source>
-        <translation>오류: 키풀이 바닥남, 키풀 리필을 먼저 호출할 하십시오</translation>
+        <translation>오류: 키풀이 바닥남. 먼저 keypoolrefill을 호출하세요.</translation>
     </message>
     <message>
         <source>Invalid -onion address or hostname: '%s'</source>
@@ -3901,19 +3901,19 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: '%s' (must be at least %s)</source>
-        <translation>유효하지 않은 금액 -paytxfee=&lt;amount&gt;: "%s" (최소 %s 이상이어야 합니다)</translation>
+        <translation>-paytxfee=&lt;amount&gt;에 대해 유효하지 않은 금액: '%s' (최소 %s 이상이어야 함)</translation>
     </message>
     <message>
         <source>Invalid netmask specified in -whitelist: '%s'</source>
-        <translation>유효하지 않은 넷마스크가 -whitelist: '%s" 를 통해 지정됨</translation>
+        <translation>-whitelist에 지정된 유효하지 않은 넷마스크: '%s'</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
-        <translation>-whitebind: '%s' 를 이용하여 포트를 지정해야 합니다</translation>
+        <translation>-whitebind: '%s' 을/를 이용하여 포트를 지정해야 함</translation>
     </message>
     <message>
         <source>No proxy server specified. Use -proxy=&lt;ip&gt; or -proxy=&lt;ip:port&gt;.</source>
-        <translation>프록시 서버가 지정되지 않았습니다. -proxy =&lt;ip&gt; 또는 -proxy =&lt;ip:port&gt;를 사용하십시오.</translation>
+        <translation>프록시 서버가 지정되지 않았습니다. -proxy =&lt;ip&gt; 또는 -proxy=&lt;ip:port&gt;를 사용하세요.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -blockfilterindex.</source>
@@ -3921,7 +3921,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
-        <translation>시스템 한계로 인하여 -maxconnections를 %d 에서 %d로 줄였습니다.</translation>
+        <translation>시스템 한계로 인하여 -maxconnections를 %d 에서 %d (으)로 줄였습니다.</translation>
     </message>
     <message>
         <source>Section [%s] is not recognized.</source>
@@ -3929,29 +3929,29 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Signing transaction failed</source>
-        <translation>거래 서명에 실패했습니다</translation>
+        <translation>거래 서명 실패</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" does not exist</source>
-        <translation>지정한 -walletdir "%s"은 존재하지 않습니다</translation>
+        <translation>지정한 -walletdir "%s" 은/는 존재하지 않음</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" is a relative path</source>
-        <translation>지정한 -walletdir "%s"은 상대 경로입니다</translation>
+        <translation>지정한 -walletdir "%s" 은/는 상대 경로임</translation>
     </message>
     <message>
         <source>Specified -walletdir "%s" is not a directory</source>
-        <translation>지정한 -walletdir "%s"은 디렉토리가 아닙니다</translation>
+        <translation>지정한 -walletdir "%s" 은/는 폴더가 아님</translation>
     </message>
     <message>
         <source>The specified config file %s does not exist
 </source>
-        <translation>지정한 설정 파일 "%s"는 존재하지 않습니다
+        <translation>지정한 설정 파일 "%s" 은/는 존재하지 않음
 </translation>
     </message>
     <message>
         <source>The transaction amount is too small to pay the fee</source>
-        <translation>거래액이 수수료를 지불하기엔 너무 작습니다</translation>
+        <translation>거래액이 수수료를 지불하기엔 너무 적음</translation>
     </message>
     <message>
         <source>This is experimental software.</source>
@@ -3959,15 +3959,15 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Transaction amount too small</source>
-        <translation>거래액이 너무 적습니다</translation>
+        <translation>거래액이 너무 적음</translation>
     </message>
     <message>
         <source>Transaction too large</source>
-        <translation>거래가 너무 큽니다</translation>
+        <translation>거래가 너무 큼</translation>
     </message>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
-        <translation>이 컴퓨터의 %s 에 바인딩할 수 없습니다 (바인딩 과정에 %s 오류 발생)</translation>
+        <translation>이 컴퓨터의 %s 에 바인딩할 수 없음(바인딩 과정에 %s 오류 발생)</translation>
     </message>
     <message>
         <source>Unable to create the PID file '%s': %s</source>
@@ -3987,11 +3987,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Warning: unknown new rules activated (versionbit %i)</source>
-        <translation>경고: 알려지지 않은 새로운 규칙이 활성화되었습니다. (버전비트 %i)</translation>
+        <translation>경고: 알려지지 않은 새로운 규칙이 활성화됨(버전비트 %i)</translation>
     </message>
     <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
-        <translation>-maxtxfee 값이 너무 큽니다!  하나의 거래에 너무 큰 수수료가 지불 됩니다.</translation>
+        <translation>-maxtxfee 값이 너무 큽니다! 하나의 거래에 너무 큰 수수료가 지불됩니다.</translation>
     </message>
     <message>
         <source>This is the transaction fee you may pay when fee estimates are not available.</source>
@@ -3999,19 +3999,19 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments.</source>
-        <translation>네트워크 버전 문자 (%i)의 길이가 최대길이 (%i)를 초과합니다. uacomments의 갯수나 길이를 줄이세요.</translation>
+        <translation>네트워크 버전 문자열(%i)의 길이가 최대 길이(%i)을/를 초과합니다. uacomments의 개수나 길이를 줄이세요.</translation>
     </message>
     <message>
         <source>%s is set very high!</source>
-        <translation>%s가 매우 높게 설정되었습니다!</translation>
+        <translation>%s 이/가 매우 높게 설정되었습니다!</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
-        <translation>네트워크 스레드 시작중...</translation>
+        <translation>네트워크 쓰레드 시작 중...</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
-        <translation>지갑은 최소 중계 수수료보다 적은 금액을 지불하는 것을 피할 것입니다.</translation>
+        <translation>지갑은 최소 중계 수수료보다 적은 금액 지불을 회피합니다.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
@@ -4019,7 +4019,7 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>This is the transaction fee you will pay if you send a transaction.</source>
-        <translation>이것은 거래를 보낼 경우 지불 할 거래 수수료입니다.</translation>
+        <translation>이것은 거래를 보낼 경우 지불할 거래 수수료입니다.</translation>
     </message>
     <message>
         <source>Transaction amounts must not be negative</source>
@@ -4027,31 +4027,31 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Transaction has too long of a mempool chain</source>
-        <translation>거래가 너무 긴 메모리 풀 체인을 갖고 있습니다</translation>
+        <translation>거래가 너무 긴 메모리 풀 체인을 갖고 있음</translation>
     </message>
     <message>
         <source>Transaction must have at least one recipient</source>
-        <translation>거래에는 최소한 한명의 수령인이 있어야 합니다.</translation>
+        <translation>거래에는 최소한 한 명의 수령인이 있어야 함</translation>
     </message>
     <message>
         <source>Unknown network specified in -onlynet: '%s'</source>
-        <translation>-onlynet: '%s' 에 알수없는 네트워크가 지정되었습니다</translation>
+        <translation>-onlynet: '%s' 에 알 수 없는 네트워크가 지정됨</translation>
     </message>
     <message>
         <source>Insufficient funds</source>
-        <translation>잔액이 부족합니다</translation>
+        <translation>잔액 부족</translation>
     </message>
     <message>
         <source>Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.</source>
-        <translation>수수료 추정이 실패했습니다. 고장 대체 수수료가 비활성화 상태입니다. 몇 블록을 기다리거나 -fallbackfee를 활성화 하십시오.</translation>
+        <translation>수수료 추정이 실패했습니다. 장애 대체 수수료가 비활성화 상태입니다. 몇 블록을 기다리거나 -fallbackfee를 활성화하세요.</translation>
     </message>
     <message>
         <source>Warning: Private keys detected in wallet {%s} with disabled private keys</source>
-        <translation>경고: 비활성화된 개인키 지갑 {%s} 에서 개인키들이 발견되었습니다</translation>
+        <translation>경고: 비활성화된 개인 키 지갑 {%s} 에서 개인 키들이 발견됨</translation>
     </message>
     <message>
         <source>Cannot write to data directory '%s'; check permissions.</source>
-        <translation>"%s" 데이터 폴더에 기록하지 못했습니다. 접근권한을 확인하십시오.</translation>
+        <translation>"%s" 데이터 폴더에 기록하지 못했습니다. 접근 권한을 확인하세요.</translation>
     </message>
     <message>
         <source>Loading block index...</source>
@@ -4063,11 +4063,11 @@ Go to File &gt; Open Wallet to load a wallet.
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
-        <translation>지갑을 다운그레이드 할 수 없습니다</translation>
+        <translation>지갑을 다운그레이드할 수 없음</translation>
     </message>
     <message>
         <source>Rescanning...</source>
-        <translation>재스캔 중...</translation>
+        <translation>재검색 중...</translation>
     </message>
     <message>
         <source>Done loading</source>


### PR DESCRIPTION
Fixes #2218 

The Korean translation has the following errors and needs to be fixed.
This PR contains corrections the following errors for 1.21-dev:
- Typos
- Incorrect translation
- 'Bitcoin' instead of 'Dogecoin' in Korean translation
- 'Satoshi' instead of 'Koinu' in Korean translation
- etc.

File: src/qt/locale/bitcoin_ko.ts