### PR TITLE
fix runtime for dogecoin on Alpine Linux (musl libc)

### DIFF
--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -254,7 +254,7 @@ void scrypt_detect_sse2()
 
 void scrypt_1024_1_1_256(const char *input, char *output)
 {
-    static char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
+    thread_local char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
     memset(scratchpad, 0, sizeof(scratchpad));
     scrypt_1024_1_1_256_sp(input, output, scratchpad);
 }

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -254,6 +254,7 @@ void scrypt_detect_sse2()
 
 void scrypt_1024_1_1_256(const char *input, char *output)
 {
-	char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
+    static char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
+    memset(scratchpad, 0, sizeof(scratchpad));
     scrypt_1024_1_1_256_sp(input, output, scratchpad);
 }


### PR DESCRIPTION
`dogecoind` built with musl libc will die unexpectedly giving a `Segmentation fault (core dumped)`.

This patch makes it so dogecoin will run successfully on Alpine Linux using the standard `musl` libc.