### PR TITLE
Cache qa-assets directory on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/depends/built
     - $TRAVIS_BUILD_DIR/depends/sdk-sources
+    - $TRAVIS_BUILD_DIR/ci/scratch/qa-assets
     - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
     - $TRAVIS_BUILD_DIR/releases/$HOST
 stages:


### PR DESCRIPTION
### Issue: 

Everytime a build run, the CI will clone https://github.com/bitcoin-core/qa-assets which is a very large Dataset: 10Go

### Fix

Cache directory ci/scratch/qa-assets

### Expected Result

Decrease the build time

### Result

Decrease the build time by 33%