### PR TITLE
Introduce AuxPoW chain parameters

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -101,7 +101,7 @@ public:
 
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
-        consensus.nLegacyBlocksBefore = 371337;
+        consensus.nAuxPowHeight = 371337;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -222,7 +222,7 @@ public:
 
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = false;
-        consensus.nLegacyBlocksBefore = 158100;
+        consensus.nAuxPowHeight = 158100;
 
         pchMessageStart[0] = 0xfc;
         pchMessageStart[1] = 0xc1;
@@ -355,7 +355,7 @@ public:
 
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
-        consensus.nLegacyBlocksBefore = 0;
+        consensus.nAuxPowHeight = 0;
 
         // message start is defined as the first 4 bytes of the sha256d of the block script
         CHashWriter h(SER_DISK, 0);
@@ -431,7 +431,7 @@ public:
 
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
         consensus.fStrictChainId = true;
-        consensus.nLegacyBlocksBefore = 0;
+        consensus.nAuxPowHeight = 0;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -99,6 +99,10 @@ public:
         consensus.fSimplifiedRewards = false;
         consensus.fShortEarlyCoinbase = true;
 
+        consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
+        consensus.fStrictChainId = true;
+        consensus.nLegacyBlocksBefore = 371337;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -215,6 +219,10 @@ public:
 
         consensus.fSimplifiedRewards = false;
         consensus.fShortEarlyCoinbase = true;
+
+        consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
+        consensus.fStrictChainId = false;
+        consensus.nLegacyBlocksBefore = 158100;
 
         pchMessageStart[0] = 0xfc;
         pchMessageStart[1] = 0xc1;
@@ -345,6 +353,10 @@ public:
         consensus.fSimplifiedRewards = true;
         consensus.fShortEarlyCoinbase = true;
 
+        consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
+        consensus.fStrictChainId = true;
+        consensus.nLegacyBlocksBefore = 0;
+
         // message start is defined as the first 4 bytes of the sha256d of the block script
         CHashWriter h(SER_DISK, 0);
         h << consensus.signet_challenge;
@@ -416,6 +428,10 @@ public:
 
         consensus.fSimplifiedRewards = true;
         consensus.fShortEarlyCoinbase = false;
+
+        consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
+        consensus.fStrictChainId = true;
+        consensus.nLegacyBlocksBefore = 0;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -99,19 +99,7 @@ struct Params {
     /** Auxpow parameters */
     int32_t nAuxpowChainId;
     bool fStrictChainId;
-    int nLegacyBlocksBefore; // -1 for "always allow"
-
-    /**
-     * Check whether or not to allow legacy blocks at the given height.
-     * @param nHeight Height of the block to check.
-     * @return True if it is allowed to have a legacy version.
-     */
-    bool AllowLegacyBlocks(unsigned nHeight) const
-    {
-        if (nLegacyBlocksBefore < 0)
-            return true;
-        return static_cast<int> (nHeight) < nLegacyBlocksBefore;
-    }
+    int nAuxPowHeight; // 0 for "always on"
 };
 } // namespace Consensus
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -95,6 +95,23 @@ struct Params {
 
     bool fSimplifiedRewards;
     bool fShortEarlyCoinbase;
+
+    /** Auxpow parameters */
+    int32_t nAuxpowChainId;
+    bool fStrictChainId;
+    int nLegacyBlocksBefore; // -1 for "always allow"
+
+    /**
+     * Check whether or not to allow legacy blocks at the given height.
+     * @param nHeight Height of the block to check.
+     * @return True if it is allowed to have a legacy version.
+     */
+    bool AllowLegacyBlocks(unsigned nHeight) const
+    {
+        if (nLegacyBlocksBefore < 0)
+            return true;
+        return static_cast<int> (nHeight) < nLegacyBlocksBefore;
+    }
 };
 } // namespace Consensus
 


### PR DESCRIPTION
Introduce AuxPoW chain parameters. These are not yet used, splitting these out to make validation easier.