### PR TITLE
Add python3-devel package to CentOS

### DIFF
--- a/ci/test/00_setup_env_i686_centos.sh
+++ b/ci/test/00_setup_env_i686_centos.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export HOST=i686-pc-linux-gnu
 export CONTAINER_NAME=ci_i686_centos_7
 export DOCKER_NAME_TAG=centos:7
-export DOCKER_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache libtool make git python3 python3-distutils python36-zmq which patch lbzip2 dash"
+export DOCKER_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache libtool make git python3 python36-devel python36-zmq which patch lbzip2 dash"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-reduce-exports --with-boost-process"
 export CONFIG_SHELL="/bin/dash"


### PR DESCRIPTION
* Add python3-devel package to CentOS as it is required for ltc_scrypt to build.
* Remove python3-distutils package from CentOS as they ship in the default Python 3 install.