### PR TITLE
Add node context to wallet RPC request object

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -7,6 +7,7 @@
 #include <amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <node/context.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
@@ -489,8 +490,9 @@ public:
 class WalletClientImpl : public WalletClient
 {
 public:
-    WalletClientImpl(Chain& chain, ArgsManager& args)
+    WalletClientImpl(NodeContext& node, Chain& chain, ArgsManager& args)
     {
+        m_context.nodeContext = &node;
         m_context.chain = &chain;
         m_context.args = &args;
     }
@@ -566,9 +568,9 @@ public:
 
 std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet) { return wallet ? MakeUnique<WalletImpl>(wallet) : nullptr; }
 
-std::unique_ptr<WalletClient> MakeWalletClient(Chain& chain, ArgsManager& args)
+std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, Chain& chain, ArgsManager& args)
 {
-    return MakeUnique<WalletClientImpl>(chain, args);
+    return MakeUnique<WalletClientImpl>(node, chain, args);
 }
 
 } // namespace interfaces

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -568,9 +568,9 @@ public:
 
 std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet) { return wallet ? MakeUnique<WalletImpl>(wallet) : nullptr; }
 
-std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, Chain& chain, ArgsManager& args)
+std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, ArgsManager& args)
 {
-    return MakeUnique<WalletClientImpl>(node, chain, args);
+    return MakeUnique<WalletClientImpl>(node, *node.chain, args);
 }
 
 } // namespace interfaces

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -411,7 +411,7 @@ std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet);
 
 //! Return implementation of ChainClient interface for a wallet client. This
 //! function will be undefined in builds where ENABLE_WALLET is false.
-std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, Chain& chain, ArgsManager& args);
+std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, ArgsManager& args);
 
 } // namespace interfaces
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -411,7 +411,7 @@ std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet);
 
 //! Return implementation of ChainClient interface for a wallet client. This
 //! function will be undefined in builds where ENABLE_WALLET is false.
-std::unique_ptr<WalletClient> MakeWalletClient(Chain& chain, ArgsManager& args);
+std::unique_ptr<WalletClient> MakeWalletClient(NodeContext& node, Chain& chain, ArgsManager& args);
 
 } // namespace interfaces
 

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -10,6 +10,8 @@ namespace interfaces {
 class Chain;
 } // namespace interfaces
 
+struct NodeContext;
+
 //! WalletContext struct containing references to state shared between CWallet
 //! instances, like the reference to the chain interface, and the list of opened
 //! wallets.
@@ -23,6 +25,9 @@ class Chain;
 struct WalletContext {
     interfaces::Chain* chain{nullptr};
     ArgsManager* args{nullptr};
+
+    //! Dogecoin: getauxwork is a wallet RPC but actually needs the NodeContext.
+    NodeContext* nodeContext{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the WalletContext struct doesn't need to #include class

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -5,12 +5,12 @@
 #ifndef BITCOIN_WALLET_CONTEXT_H
 #define BITCOIN_WALLET_CONTEXT_H
 
+#include <node/context.h>
+
 class ArgsManager;
 namespace interfaces {
 class Chain;
 } // namespace interfaces
-
-struct NodeContext;
 
 //! WalletContext struct containing references to state shared between CWallet
 //! instances, like the reference to the chain interface, and the list of opened

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -107,7 +107,7 @@ void WalletInit::Construct(NodeContext& node) const
         LogPrintf("Wallet disabled!\n");
         return;
     }
-    auto wallet_client = interfaces::MakeWalletClient(node, *node.chain, args);
+    auto wallet_client = interfaces::MakeWalletClient(node, args);
     node.wallet_client = wallet_client.get();
     node.chain_clients.emplace_back(std::move(wallet_client));
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -107,7 +107,7 @@ void WalletInit::Construct(NodeContext& node) const
         LogPrintf("Wallet disabled!\n");
         return;
     }
-    auto wallet_client = interfaces::MakeWalletClient(*node.chain, args);
+    auto wallet_client = interfaces::MakeWalletClient(node, *node.chain, args);
     node.wallet_client = wallet_client.get();
     node.chain_clients.emplace_back(std::move(wallet_client));
 }

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -10,7 +10,7 @@
 
 InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
-    m_wallet_client = MakeWalletClient(*m_chain, *Assert(m_node.args));
+    m_wallet_client = MakeWalletClient(m_node, *m_chain, *Assert(m_node.args));
 
     std::string sep;
     sep += fs::path::preferred_separator;

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -10,7 +10,7 @@
 
 InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
-    m_wallet_client = MakeWalletClient(m_node, *m_chain, *Assert(m_node.args));
+    m_wallet_client = interfaces::MakeWalletClient(m_node, *Assert(m_node.args));
 
     std::string sep;
     sep += fs::path::preferred_separator;

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -21,7 +21,7 @@ struct WalletTestingSetup : public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
 
     std::unique_ptr<interfaces::Chain> m_chain = interfaces::MakeChain(m_node);
-    std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(m_node, *m_chain, *Assert(m_node.args));
+    std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(m_node, *Assert(m_node.args));
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -21,7 +21,7 @@ struct WalletTestingSetup : public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
 
     std::unique_ptr<interfaces::Chain> m_chain = interfaces::MakeChain(m_node);
-    std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_chain, *Assert(m_node.args));
+    std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(m_node, *m_chain, *Assert(m_node.args));
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };


### PR DESCRIPTION
Add node context to wallet RPC request object, as `getauxblock` needs access to the node to determine if it is in initial block download, and requires access to the wallet to get an address to pay to.