### PR TITLE
1.21 default address type

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -96,6 +96,9 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
             ui->useBech32->setCheckState(Qt::Checked);
         } else {
             ui->useBech32->setCheckState(Qt::Unchecked);
+            // Dogecoin: Don't allow the user to generate BECH32 addresses as we don't support them except for test networks.
+            // If you need to test, override the default on the command line.
+            ui->useBech32->setEnabled(false);
         }
 
         // Set the button to be enabled or disabled based on whether the wallet can give out new addresses.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -108,7 +108,7 @@ enum class FeeEstimateMode;
 class ReserveDestination;
 
 //! Default for -addresstype
-constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::BECH32};
+constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::LEGACY};
 
 static constexpr uint64_t KNOWN_WALLET_FLAGS =
         WALLET_FLAG_AVOID_REUSE

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -96,7 +96,7 @@ class TestBitcoinCli(BitcoinTestFramework):
 
             # Setup to test -getinfo, -generate, and -rpcwallet= with multiple wallets.
             wallets = [self.default_wallet_name, 'Encrypted', 'secret']
-            amounts = [BALANCE + Decimal('90000.999928'), Decimal(99999), Decimal(310000)]
+            amounts = [BALANCE + Decimal('90000.99991'), Decimal(99999), Decimal(310000)]
             self.nodes[0].createwallet(wallet_name=wallets[1])
             self.nodes[0].createwallet(wallet_name=wallets[2])
             w1 = self.nodes[0].get_wallet_rpc(wallets[0])

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -246,7 +246,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Generate a bunch of transactions.
         node.generate(241)
         num_transactions = 25
-        address = node.getnewaddress()
+        if use_witness_address:
+            address = node.getnewaddress(address_type="bech32")
+        else:
+            address = node.getnewaddress()
 
         segwit_tx_generated = False
         for _ in range(num_transactions):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -31,7 +31,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # This test isn't testing tx relay. Set whitelist on the peers for
         # instant tx relay.
-        self.extra_args = [['-whitelist=noban@127.0.0.1']] * self.num_nodes
+        # Dogecoin: Force BECH32 addresses so descriptors work
+        self.extra_args = [['-whitelist=noban@127.0.0.1', '-addresstype=bech32']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -374,8 +374,9 @@ class PSBTTest(BitcoinTestFramework):
 
         # Make sure the wallet's change type is respected by default
         small_output = {self.nodes[0].getnewaddress():0.1}
-        psbtx_native = self.nodes[0].walletcreatefundedpsbt([], [small_output])
-        self.assert_change_type(psbtx_native, "witness_v0_keyhash")
+        psbtx_default = self.nodes[0].walletcreatefundedpsbt([], [small_output])
+        # Dogecoin: Default is pubkeyhash, so both nodes generate pubkeyhash change
+        self.assert_change_type(psbtx_default, "pubkeyhash")
         psbtx_legacy = self.nodes[1].walletcreatefundedpsbt([], [small_output])
         self.assert_change_type(psbtx_legacy, "pubkeyhash")
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -416,7 +416,7 @@ class WalletTest(BitcoinTestFramework):
             self.log.info("Test sendtoaddress with fee_rate param (explicit fee rate in koinu/vB)")
             prebalance = self.nodes[2].getbalance()
             assert prebalance > 2
-            address = self.nodes[1].getnewaddress()
+            address = self.nodes[1].getnewaddress(address_type="bech32")
             amount = 3
             fee_rate_sat_vb = 2
             fee_rate_btc_kvb = fee_rate_sat_vb * 1e3 / 1e8

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -19,6 +19,8 @@ class CreateWalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = False
         self.num_nodes = 1
+        # Dogecoin: Force BECH32 addresses so descriptors work
+        self.extra_args = [['-addresstype=bech32']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -105,24 +105,24 @@ class WalletGroupTest(BitcoinTestFramework):
         # Node 2 enforces avoidpartialspends so needs no checking here
 
         # Test wallet option maxapsfee with Node 3
-        addr_aps = self.nodes[3].getnewaddress()
+        addr_aps = self.nodes[3].getnewaddress(address_type="bech32")
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].generate(1)
         self.sync_all()
-        with self.nodes[3].assert_debug_log(['Fee non-grouped = 2820, grouped = 4160, using grouped']):
-            txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
+        with self.nodes[3].assert_debug_log(['Fee non-grouped = 2880, grouped = 4220, using grouped']):
+            txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(address_type="bech32"), 0.1)
         tx4 = self.nodes[3].getrawtransaction(txid4, True)
         # tx4 should have 2 inputs and 2 outputs although one output would
         # have been enough and the transaction caused higher fees
         assert_equal(2, len(tx4["vin"]))
         assert_equal(2, len(tx4["vout"]))
 
-        addr_aps2 = self.nodes[3].getnewaddress()
+        addr_aps2 = self.nodes[3].getnewaddress(address_type="bech32")
         [self.nodes[0].sendtoaddress(addr_aps2, 1.0) for _ in range(5)]
         self.nodes[0].generate(1)
         self.sync_all()
-        with self.nodes[3].assert_debug_log(['Fee non-grouped = 5520, grouped = 8240, using non-grouped']):
+        with self.nodes[3].assert_debug_log(['Fee non-grouped = 5640, grouped = 8360, using non-grouped']):
             txid5 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
         tx5 = self.nodes[3].getrawtransaction(txid5, True)
         # tx5 should have 3 inputs (1.0, 1.0, 1.0) and 2 outputs
@@ -131,11 +131,11 @@ class WalletGroupTest(BitcoinTestFramework):
 
         # Test wallet option maxapsfee with node 4, which sets maxapsfee
         # 1 sat higher, crossing the threshold from non-grouped to grouped.
-        addr_aps3 = self.nodes[4].getnewaddress()
+        addr_aps3 = self.nodes[4].getnewaddress(address_type="bech32")
         [self.nodes[0].sendtoaddress(addr_aps3, 1.0) for _ in range(5)]
         self.nodes[0].generate(1)
         self.sync_all()
-        with self.nodes[4].assert_debug_log(['Fee non-grouped = 5520, grouped = 8240, using grouped']):
+        with self.nodes[4].assert_debug_log(['Fee non-grouped = 5640, grouped = 8360, using grouped']):
             txid6 = self.nodes[4].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
         tx6 = self.nodes[4].getrawtransaction(txid6, True)
         # tx6 should have 5 inputs and 2 outputs

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -33,7 +33,7 @@ class WalletHDTest(BitcoinTestFramework):
         change_addr = self.nodes[1].getrawchangeaddress()
         change_addrV = self.nodes[1].getaddressinfo(change_addr)
         if self.options.descriptors:
-            assert_equal(change_addrV["hdkeypath"], "m/84'/1'/0'/1/0")
+            assert_equal(change_addrV["hdkeypath"], "m/44'/1'/0'/1/0")
         else:
             assert_equal(change_addrV["hdkeypath"], "m/0'/1'/0'")  #first internal child key
 
@@ -55,7 +55,7 @@ class WalletHDTest(BitcoinTestFramework):
             hd_add = self.nodes[1].getnewaddress()
             hd_info = self.nodes[1].getaddressinfo(hd_add)
             if self.options.descriptors:
-                assert_equal(hd_info["hdkeypath"], "m/84'/1'/0'/0/" + str(i))
+                assert_equal(hd_info["hdkeypath"], "m/44'/1'/0'/0/" + str(i))
             else:
                 assert_equal(hd_info["hdkeypath"], "m/0'/0'/" + str(i) + "'")
             assert_equal(hd_info["hdmasterfingerprint"], hd_fingerprint)
@@ -68,7 +68,7 @@ class WalletHDTest(BitcoinTestFramework):
         change_addr = self.nodes[1].getrawchangeaddress()
         change_addrV = self.nodes[1].getaddressinfo(change_addr)
         if self.options.descriptors:
-            assert_equal(change_addrV["hdkeypath"], "m/84'/1'/0'/1/1")
+            assert_equal(change_addrV["hdkeypath"], "m/44'/1'/0'/1/1")
         else:
             assert_equal(change_addrV["hdkeypath"], "m/0'/1'/1'")  #second internal child key
 
@@ -93,7 +93,7 @@ class WalletHDTest(BitcoinTestFramework):
             hd_add_2 = self.nodes[1].getnewaddress()
             hd_info_2 = self.nodes[1].getaddressinfo(hd_add_2)
             if self.options.descriptors:
-                assert_equal(hd_info_2["hdkeypath"], "m/84'/1'/0'/0/" + str(i))
+                assert_equal(hd_info_2["hdkeypath"], "m/44'/1'/0'/0/" + str(i))
             else:
                 assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/" + str(i) + "'")
             assert_equal(hd_info_2["hdmasterfingerprint"], hd_fingerprint)
@@ -135,7 +135,7 @@ class WalletHDTest(BitcoinTestFramework):
                 keypath = self.nodes[1].getaddressinfo(out['scriptPubKey']['addresses'][0])['hdkeypath']
 
         if self.options.descriptors:
-            assert_equal(keypath[0:14], "m/84'/1'/0'/1/")
+            assert_equal(keypath[0:14], "m/44'/1'/0'/1/")
         else:
             assert_equal(keypath[0:7], "m/0'/1'")
 

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -13,6 +13,8 @@ from test_framework.util import assert_equal, assert_raises_rpc_error
 class KeyPoolTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        # Dogecoin: Force BECH32 addresses so descriptors work
+        self.extra_args = [['-addresstype=bech32']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Switch the default address type for 1.21 from BECH32 (SegWit) to pubkeyhash ("legacy") addresses. This is required as otherwise Dogecoin Core would create addresses by default which cannot be used.

The ability to produce BECH32 addresses is retained for forward compatibility and to reduce scale of changes.

Some RPC tests (especially those using descriptors) require SegWit addresses for them to function as-is, without significant change, and in those cases the address type is set via extra parameters.
