### PR TITLE
Upgrade ZeroMQ to libzmq 4.3.4

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,19 +1,21 @@
 package=zeromq
-$(package)_version=4.1.5
-$(package)_download_path=https://github.com/zeromq/zeromq4-1/releases/download/v$($(package)_version)/
+$(package)_version=4.3.4
+$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=04aac57f081ffa3a2ee5ed04887be9e205df3a7ddade0027460b8042432bdbcf
-$(package)_patches=9114d3957725acd34aa8b8d011585812f3369411.patch 9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
+$(package)_patches=remove_libstd_link.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared --without-libsodium --disable-curve
+  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf
+  $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
+  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
+  $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/9114d3957725acd34aa8b8d011585812f3369411.patch && \
-  patch -p1 < $($(package)_patch_dir)/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch && \
+  patch -p1 < $($(package)_patch_dir)/remove_libstd_link.patch && \
   ./autogen.sh
 endef
 
@@ -22,7 +24,7 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) libzmq.la
+  $(MAKE) src/libzmq.la
 endef
 
 define $(package)_stage_cmds
@@ -30,5 +32,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf bin share
+  rm -rf bin share lib/*.la
 endef

--- a/depends/patches/zeromq/remove_libstd_link.patch
+++ b/depends/patches/zeromq/remove_libstd_link.patch
@@ -1,0 +1,25 @@
+commit 47d4cd12a2c051815ddda78adebdb3923b260d8a
+Author: fanquake <fanquake@gmail.com>
+Date:   Tue Aug 18 14:45:40 2020 +0800
+
+    Remove needless linking against libstdc++
+
+    This is broken for a number of reasons, including:
+    - g++ understands "static-libstdc++ -lstdc++" to mean "link against
+      whatever libstdc++ exists, probably shared", which in itself is buggy.
+    - another stdlib (libc++ for example) may be in use
+
+    See #11981.
+
+diff --git a/src/libzmq.pc.in b/src/libzmq.pc.in
+index 233bc3a..3c2bf0d 100644
+--- a/src/libzmq.pc.in
++++ b/src/libzmq.pc.in
+@@ -7,6 +7,6 @@ Name: libzmq
+ Description: 0MQ c++ library
+ Version: @VERSION@
+ Libs: -L${libdir} -lzmq
+-Libs.private: -lstdc++ @pkg_config_libs_private@
++Libs.private: @pkg_config_libs_private@
+ Requires.private: @pkg_config_names_private@
+ Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
To fix #2149 issue
Replace zeromq4-1 with libzmq version 4.3.4
remove_libstd_link.patch to avoid error on libdogecoinqt build

There are some problem when build this lib using mingw 4.7 on Ubuntu Trusty. I think we should upgrade linux distro on travis-ci & gitian build to at least Ubuntu Xenial. What do you think?
