### PR TITLE
Rewrite subsidy limit tests (1.14)

### DIFF
--- a/src/test/dogecoin_tests.cpp
+++ b/src/test/dogecoin_tests.cpp
@@ -58,50 +58,65 @@ uint64_t expectedMinSubsidy(int height) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(subsidy_limit_test)
+BOOST_AUTO_TEST_CASE(subsidy_first_100k_test)
 {
-    int nHeight = 0;
-    int nStepSize= 1;
     const CChainParams& mainParams = Params(CBaseChainParams::MAIN);
     CAmount nSum = 0;
-    uint256 prevHash = uint256S("0");
+    arith_uint256 prevHash = UintToArith256(uint256S("0"));
 
-    for (nHeight = 0; nHeight <= 100000; nHeight++) {
+    for (int nHeight = 0; nHeight <= 100000; nHeight++) {
         const Consensus::Params& params = mainParams.GetConsensus(nHeight);
-        CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, prevHash);
+        CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, ArithToUint256(prevHash));
         BOOST_CHECK(MoneyRange(nSubsidy));
         BOOST_CHECK(nSubsidy <= 1000000 * COIN);
-        nSum += nSubsidy * nStepSize;
+        nSum += nSubsidy;
+        // Use nSubsidy to give us some variation in previous block hash, without requiring full block templates
+        prevHash += nSubsidy;
     }
-    for (; nHeight <= 145000; nHeight++) {
+
+    const CAmount expected = 54894174438 * COIN;
+    BOOST_CHECK_EQUAL(expected, nSum);
+}
+
+BOOST_AUTO_TEST_CASE(subsidy_100k_145k_test)
+{
+    const CChainParams& mainParams = Params(CBaseChainParams::MAIN);
+    CAmount nSum = 0;
+    arith_uint256 prevHash = UintToArith256(uint256S("0"));
+
+    for (int nHeight = 100000; nHeight <= 145000; nHeight++) {
         const Consensus::Params& params = mainParams.GetConsensus(nHeight);
-        CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, prevHash);
+        CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, ArithToUint256(prevHash));
         BOOST_CHECK(MoneyRange(nSubsidy));
         BOOST_CHECK(nSubsidy <= 500000 * COIN);
-        nSum += nSubsidy * nStepSize;
+        nSum += nSubsidy;
+        // Use nSubsidy to give us some variation in previous block hash, without requiring full block templates
+        prevHash += nSubsidy;
     }
-    for (; nHeight < 600000; nHeight++) {
+
+    const CAmount expected = 12349960000 * COIN;
+    BOOST_CHECK_EQUAL(expected, nSum);
+}
+
+// Check the simplified rewards after block 145,000
+BOOST_AUTO_TEST_CASE(subsidy_post_145k_test)
+{
+    const CChainParams& mainParams = Params(CBaseChainParams::MAIN);
+    const uint256 prevHash = uint256S("0");
+
+    for (int nHeight = 145000; nHeight < 600000; nHeight++) {
         const Consensus::Params& params = mainParams.GetConsensus(nHeight);
         CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, prevHash);
         CAmount nExpectedSubsidy = (500000 >> (nHeight / 100000)) * COIN;
         BOOST_CHECK(MoneyRange(nSubsidy));
         BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
-        nSum += nSubsidy * nStepSize;
     }
 
-    //test sum +- ~10billion
-    arith_uint256 upperlimit = arith_uint256("95e14ec776380000"); //108 billion doge
-    BOOST_CHECK(nSum <= upperlimit);
-
-    arith_uint256 lowerlimit = arith_uint256("7a1fe16027700000"); //88 billion doge
-    BOOST_CHECK(nSum >= lowerlimit);
-
     // Test reward at 600k+ is constant
-    const Consensus::Params& params = mainParams.GetConsensus(nHeight);
-    CAmount nConstantSubsidy = GetDogecoinBlockSubsidy(nHeight, params, prevHash);
+    CAmount nConstantSubsidy = GetDogecoinBlockSubsidy(600000, mainParams.GetConsensus(600000), prevHash);
     BOOST_CHECK_EQUAL(nConstantSubsidy, 10000 * COIN);
 
-    nConstantSubsidy = GetDogecoinBlockSubsidy(700000, params, prevHash);
+    nConstantSubsidy = GetDogecoinBlockSubsidy(700000, mainParams.GetConsensus(700000), prevHash);
     BOOST_CHECK_EQUAL(nConstantSubsidy, 10000 * COIN);
 }
 


### PR DESCRIPTION
Rebuild subsidy limit tests:

* Subsidy values are deterministic even if pseudo-random, so test against the expected value rather than a range.
* Break block heights into ranges so total fits into CAmount rather than overflows.
* Use previous susidy values to vary the previous hash value on each calculation, rather than always using zero.

Pairs with #2311