### PR TITLE
Docs4Doge : Improve README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,5 @@
 # Contributing to Dogecoin Core
 
-Dogecoin Core is open source software, and we would welcome contributions
-which improve the state of the software. For those wanting to discuss changes,
-or look for work that needs doing, please see:
-
-* [Help requests](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
-* [Projects](https://github.com/dogecoin/dogecoin/projects)
-* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
-
 ## Branch Strategy
 
 Dogecoin Core's default branch is intentionally a stable release, so that anyone

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,84 @@
-Building Dogecoin
-================
+## Building Dogecoin
 
-See doc/build-*.md for instructions on building the various
-elements of the Dogecoin Core reference implementation of Dogecoin.
+Development is ongoing, and the development team, as well as other volunteers,
+can freely work in their own trees and submit pull requests when features or
+bug fixes are ready.
+
+### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
+
+  The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+
+  - [OSX Build Notes](doc/build-osx.md)
+  - [Unix Build Notes](doc/build-unix.md)
+  - [Windows Build Notes](doc/build-windows.md)
+
+### Such ports
+
+- RPC 22555
+- P2P 22556
+
+#### Version strategy
+Version numbers are following ```major.minor.patch``` semantics.
+
+#### Branches
+There are 3 types of branches in this repository:
+
+- **master:** Stable, contains the latest version of the latest *major.minor* release.
+- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
+- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
+
+*Master and maintenance branches are exclusively mutable by release. Planned*
+*releases will always have a development branch and pull requests should be*
+*submitted against those. Maintenance branches are there for **bug fixes only,***
+*please submit new features against the development branch with the highest version.*
+
+#### Contributions ✍️
+
+Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
+submit new unit tests for old code. Unit tests can be compiled and run
+(assuming they weren't disabled in configure) with: `make check`. Further details on running
+and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
+
+There are also [regression and integration tests](/qa) of the RPC interface, written
+in Python, that are run automatically on the build server.
+These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
+
+Changes should be tested by somebody other than the developer who wrote the
+code. This is especially important for large or high-risk changes. It is useful
+to add a test plan to the pull request description if testing the changes is
+not straightforward.
+
+
+## Development tips and tricks
+
+**compiling for debugging**
+
+Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
+`CXXFLAGS="-g -ggdb -O0"` or whatever debug flags you need.
+
+**debug.log**
+
+If the code is behaving strangely, take a look in the debug.log file in the data directory;
+error and debugging messages are written there.
+
+The `-debug=...` command-line option controls debugging; running with just `-debug` will turn
+on all categories (and give you a very large debug.log file).
+
+The Qt code routes `qDebug()` output to debug.log under category "qt": run with `-debug=qt`
+to see it.
+
+**testnet and regtest modes**
+
+Run with the `-testnet` option to run with "play dogecoins" on the test network, if you
+are testing multi-machine code that needs to operate across the internet.
+
+If you are testing something that can run on one machine, run with the `-regtest` option.
+In regression test mode, blocks can be created on-demand; see qa/rpc-tests/ for tests
+that run in `-regtest` mode.
+
+**DEBUG_LOCKORDER**
+
+Dogecoin Core is a multithreaded application, and deadlocks or other multithreading bugs
+can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
+CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
+are held, and adds warnings to the debug.log file if inconsistencies are detected.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-## Building Dogecoin
+# Building Dogecoin Core
 
 Development is ongoing, and the development team, as well as other volunteers,
 can freely work in their own trees and submit pull requests when features or

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 - **Website:** [dogecoin.com.](https://dogecoin.com)
 
-## Ongoing development - Moon plan
+## Ongoing development - Moon plan 🌒
 
 For those wanting to discuss changes, or look for work that needs doing, please see:
 
@@ -23,7 +23,7 @@ To get information about current development, to discuss changes or look for wor
 * [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
 * [Discord](https://discord.gg/dogecoin) (in particular the #core-dev channel)
 
-## Contribute
+## Contribute 🤝
 
 Dogecoin Core is open source software, and we would welcome contributions
 which improve the state of the software.
@@ -36,7 +36,7 @@ Do not limitate yourself to guidelines, feel free to contribute in your own way 
 
 You have a question regarding dogecoin ? An answer is perhaps already in the [FAQ](doc/FAQ.md) !
 
-## Installation – omg developers
+## Installation – omg developers 👨‍💻
 
 To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 - **Website:** [dogecoin.com.](https://dogecoin.com)
 
-## License – Much license ⚖️
-Dogecoin Core is released under the terms of the MIT license. See
-[COPYING](COPYING) for more information or see
-[opensource.org](https://opensource.org/licenses/MIT)
 
 ## Development and contributions – omg developers
 Development is ongoing, and the development team, as well as other volunteers,
@@ -161,3 +157,8 @@ Dogecoin Core is a multithreaded application, and deadlocks or other multithread
 can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
 CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
 are held, and adds warnings to the debug.log file if inconsistencies are detected.
+
+## License – Much license ⚖️
+Dogecoin Core is released under the terms of the MIT license. See
+[COPYING](COPYING) for more information or see
+[opensource.org](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -13,15 +13,25 @@ Dogecoin currently employs a simplified variant of scrypt.
 
 ## Ongoing development - Moon plan 🌒
 
-For those wanting to discuss changes, or look for work that needs doing, please see:
+Dogecoin Core is an open source and community driven software.  
+Developement process is done publicly. Anyone can see, discuss and work on them.  
 
-* [Help requests](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
-* [Projects](https://github.com/dogecoin/dogecoin/projects)
-* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
-To get information about current development, to discuss changes or look for work that needs doing, please see :
-* [Projects](https://github.com/dogecoin/dogecoin/projects)
-* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
-* [Discord](https://discord.gg/dogecoin) (in particular the #core-dev channel)
+Main tools used for the core development :
+
+* [Github Projects](https://github.com/dogecoin/dogecoin/projects) to see all developments and [Github Discussion](https://github.com/dogecoin/dogecoin/discussions) to discuss them
+* [Dogecoin Improvement Proposals (DIPs)](https://github.com/dogecoin/dips) for major improvements
+* [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
+
+## Community 🚀🍾
+
+You can join the community on different social media !
+To see what's going on, meet people & discuss, find latest meme, learn about dogecoin,
+give or receive any kind of help or to share your projects... some places to visit !
+
+* [Discord](https://discord.gg/dogecoin)
+* [Dogecoin subreddit](https://www.reddit.com/r/dogecoin/)
+* [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
+* [Dogeducation subreddit](https://www.reddit.com/r/dogeducation/)
 
 ## Contribute 🤝
 

--- a/README.md
+++ b/README.md
@@ -95,22 +95,6 @@ lessen the impact of sudden increases and decreases of network hashing rate.
 
 600,000+: 10,000 Dogecoin
 
-**The original block reward schedule, with one-minute block targets and four-hour difficulty readjustment:**
-
-1–99,999: 0–1,000,000 Dogecoin
-
-100,000–199,999: 0–500,000 Dogecoin
-
-200,000–299,999: 0–250,000 Dogecoin
-
-300,000–399,999: 0–125,000 Dogecoin
-
-400,000–499,999: 0–62,500 Dogecoin
-
-500,000–599,999: 0–31,250 Dogecoin
-
-600,000+: 10,000 Dogecoin
-
 ### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
 
   The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dogecoin currently employs a simplified variant of scrypt.
 ## Ongoing development - Moon plan 🌒
 
 Dogecoin Core is an open source and community driven software.  
-Developement process is done publicly. Anyone can see, discuss and work on them.  
+Development process is done publicly. Anyone can see, discuss and work on them.  
 
 Main tools used for the core development :
 
@@ -22,10 +22,20 @@ Main tools used for the core development :
 * [Dogecoin Improvement Proposals (DIPs)](https://github.com/dogecoin/dips) for major improvements
 * [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
 
+## Installation – omg developers 👨‍💻
+
+To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
+
+## Contribute 🤝
+
+Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
+
+Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
+
 ## Community 🚀🍾
 
 You can join the community on different social media !
-To see what's going on, meet people & discuss, find latest meme, learn about dogecoin,
+To see what's going on, meet people & discuss, find the lastest meme, learn about dogecoin,
 give or receive any kind of help or to share your projects... some places to visit !
 
 * [Discord](https://discord.gg/dogecoin)
@@ -33,22 +43,9 @@ give or receive any kind of help or to share your projects... some places to vis
 * [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
 * [Dogeducation subreddit](https://www.reddit.com/r/dogeducation/)
 
-## Contribute 🤝
-
-Dogecoin Core is open source software, and we would welcome contributions
-which improve the state of the software.
-
-Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
-
-Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
-
 ## Very Much Frequently Asked Questions ❓
 
 You have a question regarding dogecoin ? An answer is perhaps already in the [FAQ](doc/FAQ.md) !
-
-## Installation – omg developers 👨‍💻
-
-To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
 
 ## License – Much license ⚖️
 Dogecoin Core is released under the terms of the MIT license. See

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Main tools used for the core development :
 
 * [Github Projects](https://github.com/dogecoin/dogecoin/projects) to see all developments and [Github Discussion](https://github.com/dogecoin/dogecoin/discussions) to discuss them
 * [Dogecoin Improvement Proposals (DIPs)](https://github.com/dogecoin/dips) for major improvements
-* [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
+* [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
 
 ## Installation – omg developers 👨‍💻
 
@@ -36,12 +36,12 @@ Do not limitate yourself to guidelines, feel free to contribute in your own way 
 
 You can join the community on different social media !
 To see what's going on, meet people & discuss, find the lastest meme, learn about dogecoin,
-give or receive any kind of help or to share your projects... some places to visit !
+give or ask different type of help, to share your project... some places to visit !
 
 * [Discord](https://discord.gg/dogecoin)
 * [Dogecoin subreddit](https://www.reddit.com/r/dogecoin/)
-* [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
 * [Dogeducation subreddit](https://www.reddit.com/r/dogeducation/)
+* [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
 
 ## Very Much Frequently Asked Questions ❓
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 - **Website:** [dogecoin.com.](https://dogecoin.com)
 
-## Ongoing development - Moon plan
+## Ongoing development - Moon plan
 
 For those wanting to discuss changes, or look for work that needs doing, please see:
 
@@ -23,7 +23,7 @@ To get information about current development, to discuss changes or look for wor
 * [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
 * [Discord](https://discord.gg/dogecoin) (in particular the #core-dev channel)
 
-## Contribute
+## Contribute
 
 Dogecoin Core is open source software, and we would welcome contributions
 which improve the state of the software.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 - **Website:** [dogecoin.com.](https://dogecoin.com)
 
+## Ongoing development - Moon plan
+
+For those wanting to discuss changes, or look for work that needs doing, please see:
+
+* [Help requests](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
+* [Projects](https://github.com/dogecoin/dogecoin/projects)
+* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
+To get information about current development, to discuss changes or look for work that needs doing, please see :
+* [Projects](https://github.com/dogecoin/dogecoin/projects)
+* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
+* [Discord](https://discord.gg/dogecoin) (in particular the #core-dev channel)
+
+## Contribute
+
+Dogecoin Core is open source software, and we would welcome contributions
+which improve the state of the software.
+
+Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
+
+Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
 
 ## Development and contributions – omg developers
 Development is ongoing, and the development team, as well as other volunteers,

--- a/README.md
+++ b/README.md
@@ -32,135 +32,13 @@ Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
 
 Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
 
-## Development and contributions – omg developers
-Development is ongoing, and the development team, as well as other volunteers,
-can freely work in their own trees and submit pull requests when features or
-bug fixes are ready.
-
-#### Version strategy
-Version numbers are following ```major.minor.patch``` semantics.
-
-#### Branches
-There are 3 types of branches in this repository:
-
-- **master:** Stable, contains the latest version of the latest *major.minor* release.
-- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
-- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
-
-*Master and maintenance branches are exclusively mutable by release. Planned*
-*releases will always have a development branch and pull requests should be*
-*submitted against those. Maintenance branches are there for **bug fixes only,***
-*please submit new features against the development branch with the highest version.*
-
-#### Contributions ✍️
-
-Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`. Further details on running
-and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
-
-There are also [regression and integration tests](/qa) of the RPC interface, written
-in Python, that are run automatically on the build server.
-These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
-
-Changes should be tested by somebody other than the developer who wrote the
-code. This is especially important for large or high-risk changes. It is useful
-to add a test plan to the pull request description if testing the changes is
-not straightforward.
-
 ## Very Much Frequently Asked Questions ❓
 
-### How much doge can exist? – So many puppies! 🐕
-Early 2015 (approximately a year and a half after release) there were
-approximately 100,000,000,000 coins.
-Each subsequent block will grant 10,000 coins to encourage miners to continue to
-secure the network and make up for lost wallets on hard drives/phones/lost
-encryption passwords/etc.
+You have a question regarding dogecoin ? An answer is perhaps already in the [FAQ](doc/FAQ.md) !
 
+## Installation – omg developers
 
-### Such mining information ⛏
-
-Dogecoin uses a simplified variant of the scrypt key derivation function as its
-proof of work with a target time of one minute per block and difficulty
-readjustment after every block. The block rewards are fixed and halve every
-100,000 blocks. Starting with the 600,000th block, a permanent reward of
-10,000 Dogecoin per block will be issued.  
-
-Originally, a different payout scheme was envisioned with block rewards being
-determined by taking the maximum reward as per the block schedule and applying
-the result of a Mersenne Twister pseudo-random number generator to arrive at a
-number between 0 and the maximum reward.
-
-This was changed starting with block 145,000, to prevent large pools from gaming
-the system and mining only high reward blocks. At the same time, the difficulty
-retargeting was also changed from four hours to once per block (every minute),
-implementing an algorithm courtesy of the DigiByte Coin development team, to
-lessen the impact of sudden increases and decreases of network hashing rate.
-
-**The current block reward schedule:**
-
-1–99,999: 0–1,000,000 Dogecoin
-
-100,000–144,999: 0–500,000 Dogecoin
-
-145,000–199,999: 250,000 Dogecoin
-
-200,000–299,999: 125,000 Dogecoin
-
-300,000–399,999: 62,500 Dogecoin
-
-400,000–499,999: 31,250 Dogecoin
-
-500,000–599,999: 15,625 Dogecoin
-
-600,000+: 10,000 Dogecoin
-
-### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
-
-  The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
-
-  - [OSX Build Notes](doc/build-osx.md)
-  - [Unix Build Notes](doc/build-unix.md)
-  - [Windows Build Notes](doc/build-windows.md)
-
-### Such ports
-
-- RPC 22555
-- P2P 22556
-
-## Development tips and tricks
-
-**compiling for debugging**
-
-Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
-`CXXFLAGS="-g -ggdb -O0"` or whatever debug flags you need.
-
-**debug.log**
-
-If the code is behaving strangely, take a look in the debug.log file in the data directory;
-error and debugging messages are written there.
-
-The `-debug=...` command-line option controls debugging; running with just `-debug` will turn
-on all categories (and give you a very large debug.log file).
-
-The Qt code routes `qDebug()` output to debug.log under category "qt": run with `-debug=qt`
-to see it.
-
-**testnet and regtest modes**
-
-Run with the `-testnet` option to run with "play dogecoins" on the test network, if you
-are testing multi-machine code that needs to operate across the internet.
-
-If you are testing something that can run on one machine, run with the `-regtest` option.
-In regression test mode, blocks can be created on-demand; see qa/rpc-tests/ for tests
-that run in `-regtest` mode.
-
-**DEBUG_LOCKORDER**
-
-Dogecoin Core is a multithreaded application, and deadlocks or other multithreading bugs
-can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
-CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
-are held, and adds warnings to the debug.log file if inconsistencies are detected.
+To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
 
 ## License – Much license ⚖️
 Dogecoin Core is released under the terms of the MIT license. See

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,0 +1,46 @@
+## Very Much Frequently Asked Questions ❓
+
+### How much doge can exist? – So many puppies! 🐕
+Early 2015 (approximately a year and a half after release) there were
+approximately 100,000,000,000 coins.
+Each subsequent block will grant 10,000 coins to encourage miners to continue to
+secure the network and make up for lost wallets on hard drives/phones/lost
+encryption passwords/etc.
+
+
+### Such mining information ⛏
+
+Dogecoin uses a simplified variant of the scrypt key derivation function as its
+proof of work with a target time of one minute per block and difficulty
+readjustment after every block. The block rewards are fixed and halve every
+100,000 blocks. Starting with the 600,000th block, a permanent reward of
+10,000 Dogecoin per block will be issued.  
+
+Originally, a different payout scheme was envisioned with block rewards being
+determined by taking the maximum reward as per the block schedule and applying
+the result of a Mersenne Twister pseudo-random number generator to arrive at a
+number between 0 and the maximum reward.
+
+This was changed starting with block 145,000, to prevent large pools from gaming
+the system and mining only high reward blocks. At the same time, the difficulty
+retargeting was also changed from four hours to once per block (every minute),
+implementing an algorithm courtesy of the DigiByte Coin development team, to
+lessen the impact of sudden increases and decreases of network hashing rate.
+
+**The current block reward schedule:**
+
+1–99,999: 0–1,000,000 Dogecoin
+
+100,000–144,999: 0–500,000 Dogecoin
+
+145,000–199,999: 250,000 Dogecoin
+
+200,000–299,999: 125,000 Dogecoin
+
+300,000–399,999: 62,500 Dogecoin
+
+400,000–499,999: 31,250 Dogecoin
+
+500,000–599,999: 15,625 Dogecoin
+
+600,000+: 10,000 Dogecoin


### PR DESCRIPTION
Starting to work on [Docs4Doge](https://github.com/dogecoin/dogecoin/issues/2271) initiative, it's a suggestion for refreshing the README.

This PR is mainly about organization of existing content, keeping important content on the front page and redirect for more specific content, reduce the information mix. It also groups used tools/social media.

I think one important point is that many type of user would come here, developer as well, but more regular user, and we have to get useful information for both. Developers need info to code, but regular user need also to (relatively) understand where they are and get some useful information regarding their situation.

#### Work done
- Try to get a nicer and more organized `README.md`
- Move all information related to installation & technical infos from `README.md` to in `INSTALL.md` [WIP]
- Remove FAQ questions from README and create `FAQ.md`
- Organize used tools and social media