### PR TITLE
[vulnerability] Add unordered transaction inputs

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,7 +32,8 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
-
+#include <random>
+#include <chrono>
 using namespace std;
 
 CWallet* pwalletMain = NULL;
@@ -2726,7 +2727,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
         // Unordered transaction inputs
         txNew.vin.clear();
         std::vector<pair<const CWalletTx*,unsigned int>> selectedCoins(setCoins.begin(), setCoins.end());
-        random_shuffle(selectedCoins.begin(), selectedCoins.end(), GetRandInt);
+        unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+        std::shuffle(selectedCoins.begin(), selectedCoins.end(), std::default_random_engine(seed));
+
         for (const auto& coin : selectedCoins)
             txNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second,CScript(), std::numeric_limits<unsigned int>::max() - (fWalletRbf ? 2 : 1)));
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2723,12 +2723,18 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                 continue;
             }
         }
+        // Unordered transaction inputs
+        txNew.vin.clear();
+        std::vector<pair<const CWalletTx*,unsigned int>> selectedCoins(setCoins.begin(), setCoins.end());
+        random_shuffle(selectedCoins.begin(), selectedCoins.end(), GetRandInt);
+        for (const auto& coin : selectedCoins)
+            txNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second,CScript(), std::numeric_limits<unsigned int>::max() - (fWalletRbf ? 2 : 1)));
 
         if (sign)
         {
             CTransaction txNewConst(txNew);
             int nIn = 0;
-            for (const auto& coin : setCoins)
+            for (const auto& coin : selectedCoins)
             {
                 const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
                 SignatureData sigdata;


### PR DESCRIPTION
# Description 

From #2279, 

> The wallet uses ordered inputs of transactions (src/wallet/wallet.cpp, line 2628 - 2640), which may incur privacy risks like fingerprinting the wallet to observers.

This PR change the original order by shuffling the inputs. 