### PR TITLE
Replace HMAC_SHA256 with Bitcoin's version

### DIFF
--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256
@@ -21,6 +22,10 @@ public:
     static const size_t OUTPUT_SIZE = 32;
 
     CHMAC_SHA256(const unsigned char* key, size_t keylen);
+    void Copy(CHMAC_SHA256* dest)
+    {
+        memcpy(dest, this, sizeof(CHMAC_SHA256));
+    }
     CHMAC_SHA256& Write(const unsigned char* data, size_t len)
     {
         inner.Write(data, len);

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <crypto/scrypt.h>
+#include <crypto/hmac_sha256.h>
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -61,309 +62,6 @@ static inline void be32enc(void *pp, uint32_t x)
 
 #endif
 
-typedef struct SHA256_CTXContext {
-    uint32_t total[2];
-    uint32_t state[8];
-    uint8_t buffer[64];
-} SHA256_CTX;
-
-#define GET_UINT32(n, b, i)                  \
-    {                                        \
-        (n) = ((uint32_t)(b)[(i)] << 24)     \
-            | ((uint32_t)(b)[(i) + 1] << 16) \
-            | ((uint32_t)(b)[(i) + 2] << 8)  \
-            | ((uint32_t)(b)[(i) + 3]);      \
-    }
-
-#define PUT_UINT32(n, b, i)                  \
-    {                                        \
-        (b)[(i)] = (uint8_t)((n) >> 24);     \
-        (b)[(i) + 1] = (uint8_t)((n) >> 16); \
-        (b)[(i) + 2] = (uint8_t)((n) >> 8);  \
-        (b)[(i) + 3] = (uint8_t)((n));       \
-    }
-
-#define SHR(x, n) ((x & 0xFFFFFFFF) >> n)
-#define ROTR(x, n) (SHR(x, n) | (x << (32 - n)))
-#define S0(x) (ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3))
-#define S1(x) (ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10))
-#define S2(x) (ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
-#define S3(x) (ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
-#define F0(x, y, z) ((x & y) | (z & (x | y)))
-#define F1(x, y, z) (z ^ (x & (y ^ z)))
-#define R(t) (W[t] = S1(W[t - 2]) + W[t - 7] + S0(W[t - 15]) + W[t - 16])
-
-#define P(a, b, c, d, e, f, g, h, x, K)          \
-    {                                            \
-        temp1 = h + S3(e) + F1(e, f, g) + K + x; \
-        temp2 = S2(a) + F0(a, b, c);             \
-        d += temp1;                              \
-        h = temp1 + temp2;                       \
-    }
-
-static void
-SHA256_Init(SHA256_CTX* ctx)
-{
-    ctx->total[0] = 0;
-    ctx->total[1] = 0;
-
-    ctx->state[0] = 0x6A09E667;
-    ctx->state[1] = 0xBB67AE85;
-    ctx->state[2] = 0x3C6EF372;
-    ctx->state[3] = 0xA54FF53A;
-    ctx->state[4] = 0x510E527F;
-    ctx->state[5] = 0x9B05688C;
-    ctx->state[6] = 0x1F83D9AB;
-    ctx->state[7] = 0x5BE0CD19;
-}
-
-static void
-SHA256_Process(SHA256_CTX* ctx, uint8_t data[64])
-{
-    uint32_t temp1, temp2, W[64];
-    uint32_t A, B, C, D, E, F, G, H;
-
-    GET_UINT32(W[0], data, 0);
-    GET_UINT32(W[1], data, 4);
-    GET_UINT32(W[2], data, 8);
-    GET_UINT32(W[3], data, 12);
-    GET_UINT32(W[4], data, 16);
-    GET_UINT32(W[5], data, 20);
-    GET_UINT32(W[6], data, 24);
-    GET_UINT32(W[7], data, 28);
-    GET_UINT32(W[8], data, 32);
-    GET_UINT32(W[9], data, 36);
-    GET_UINT32(W[10], data, 40);
-    GET_UINT32(W[11], data, 44);
-    GET_UINT32(W[12], data, 48);
-    GET_UINT32(W[13], data, 52);
-    GET_UINT32(W[14], data, 56);
-    GET_UINT32(W[15], data, 60);
-
-    A = ctx->state[0];
-    B = ctx->state[1];
-    C = ctx->state[2];
-    D = ctx->state[3];
-    E = ctx->state[4];
-    F = ctx->state[5];
-    G = ctx->state[6];
-    H = ctx->state[7];
-
-    P(A, B, C, D, E, F, G, H, W[0], 0x428A2F98);
-    P(H, A, B, C, D, E, F, G, W[1], 0x71374491);
-    P(G, H, A, B, C, D, E, F, W[2], 0xB5C0FBCF);
-    P(F, G, H, A, B, C, D, E, W[3], 0xE9B5DBA5);
-    P(E, F, G, H, A, B, C, D, W[4], 0x3956C25B);
-    P(D, E, F, G, H, A, B, C, W[5], 0x59F111F1);
-    P(C, D, E, F, G, H, A, B, W[6], 0x923F82A4);
-    P(B, C, D, E, F, G, H, A, W[7], 0xAB1C5ED5);
-    P(A, B, C, D, E, F, G, H, W[8], 0xD807AA98);
-    P(H, A, B, C, D, E, F, G, W[9], 0x12835B01);
-    P(G, H, A, B, C, D, E, F, W[10], 0x243185BE);
-    P(F, G, H, A, B, C, D, E, W[11], 0x550C7DC3);
-    P(E, F, G, H, A, B, C, D, W[12], 0x72BE5D74);
-    P(D, E, F, G, H, A, B, C, W[13], 0x80DEB1FE);
-    P(C, D, E, F, G, H, A, B, W[14], 0x9BDC06A7);
-    P(B, C, D, E, F, G, H, A, W[15], 0xC19BF174);
-    P(A, B, C, D, E, F, G, H, R(16), 0xE49B69C1);
-    P(H, A, B, C, D, E, F, G, R(17), 0xEFBE4786);
-    P(G, H, A, B, C, D, E, F, R(18), 0x0FC19DC6);
-    P(F, G, H, A, B, C, D, E, R(19), 0x240CA1CC);
-    P(E, F, G, H, A, B, C, D, R(20), 0x2DE92C6F);
-    P(D, E, F, G, H, A, B, C, R(21), 0x4A7484AA);
-    P(C, D, E, F, G, H, A, B, R(22), 0x5CB0A9DC);
-    P(B, C, D, E, F, G, H, A, R(23), 0x76F988DA);
-    P(A, B, C, D, E, F, G, H, R(24), 0x983E5152);
-    P(H, A, B, C, D, E, F, G, R(25), 0xA831C66D);
-    P(G, H, A, B, C, D, E, F, R(26), 0xB00327C8);
-    P(F, G, H, A, B, C, D, E, R(27), 0xBF597FC7);
-    P(E, F, G, H, A, B, C, D, R(28), 0xC6E00BF3);
-    P(D, E, F, G, H, A, B, C, R(29), 0xD5A79147);
-    P(C, D, E, F, G, H, A, B, R(30), 0x06CA6351);
-    P(B, C, D, E, F, G, H, A, R(31), 0x14292967);
-    P(A, B, C, D, E, F, G, H, R(32), 0x27B70A85);
-    P(H, A, B, C, D, E, F, G, R(33), 0x2E1B2138);
-    P(G, H, A, B, C, D, E, F, R(34), 0x4D2C6DFC);
-    P(F, G, H, A, B, C, D, E, R(35), 0x53380D13);
-    P(E, F, G, H, A, B, C, D, R(36), 0x650A7354);
-    P(D, E, F, G, H, A, B, C, R(37), 0x766A0ABB);
-    P(C, D, E, F, G, H, A, B, R(38), 0x81C2C92E);
-    P(B, C, D, E, F, G, H, A, R(39), 0x92722C85);
-    P(A, B, C, D, E, F, G, H, R(40), 0xA2BFE8A1);
-    P(H, A, B, C, D, E, F, G, R(41), 0xA81A664B);
-    P(G, H, A, B, C, D, E, F, R(42), 0xC24B8B70);
-    P(F, G, H, A, B, C, D, E, R(43), 0xC76C51A3);
-    P(E, F, G, H, A, B, C, D, R(44), 0xD192E819);
-    P(D, E, F, G, H, A, B, C, R(45), 0xD6990624);
-    P(C, D, E, F, G, H, A, B, R(46), 0xF40E3585);
-    P(B, C, D, E, F, G, H, A, R(47), 0x106AA070);
-    P(A, B, C, D, E, F, G, H, R(48), 0x19A4C116);
-    P(H, A, B, C, D, E, F, G, R(49), 0x1E376C08);
-    P(G, H, A, B, C, D, E, F, R(50), 0x2748774C);
-    P(F, G, H, A, B, C, D, E, R(51), 0x34B0BCB5);
-    P(E, F, G, H, A, B, C, D, R(52), 0x391C0CB3);
-    P(D, E, F, G, H, A, B, C, R(53), 0x4ED8AA4A);
-    P(C, D, E, F, G, H, A, B, R(54), 0x5B9CCA4F);
-    P(B, C, D, E, F, G, H, A, R(55), 0x682E6FF3);
-    P(A, B, C, D, E, F, G, H, R(56), 0x748F82EE);
-    P(H, A, B, C, D, E, F, G, R(57), 0x78A5636F);
-    P(G, H, A, B, C, D, E, F, R(58), 0x84C87814);
-    P(F, G, H, A, B, C, D, E, R(59), 0x8CC70208);
-    P(E, F, G, H, A, B, C, D, R(60), 0x90BEFFFA);
-    P(D, E, F, G, H, A, B, C, R(61), 0xA4506CEB);
-    P(C, D, E, F, G, H, A, B, R(62), 0xBEF9A3F7);
-    P(B, C, D, E, F, G, H, A, R(63), 0xC67178F2);
-
-    ctx->state[0] += A;
-    ctx->state[1] += B;
-    ctx->state[2] += C;
-    ctx->state[3] += D;
-    ctx->state[4] += E;
-    ctx->state[5] += F;
-    ctx->state[6] += G;
-    ctx->state[7] += H;
-}
-
-static void
-SHA256_Update(SHA256_CTX* ctx, uint8_t* input, uint32_t length)
-{
-    uint32_t left, fill;
-
-    if (!length)
-        return;
-
-    left = ctx->total[0] & 0x3F;
-    fill = 64 - left;
-
-    ctx->total[0] += length;
-    ctx->total[0] &= 0xFFFFFFFF;
-
-    if (ctx->total[0] < length)
-        ctx->total[1]++;
-
-    if (left && length >= fill) {
-        memcpy((void*)(ctx->buffer + left),
-            (void*)input, fill);
-        SHA256_Process(ctx, ctx->buffer);
-        length -= fill;
-        input += fill;
-        left = 0;
-    }
-
-    while (length >= 64) {
-        SHA256_Process(ctx, input);
-        length -= 64;
-        input += 64;
-    }
-
-    if (length) {
-        memcpy((void*)(ctx->buffer + left),
-            (void*)input, length);
-    }
-}
-
-static void
-SHA256_Final(SHA256_CTX* ctx, uint8_t digest[32])
-{
-    uint32_t last, padn;
-    uint32_t high, low;
-    uint8_t msglen[8];
-
-    high = (ctx->total[0] >> 29)
-        | (ctx->total[1] << 3);
-    low = (ctx->total[0] << 3);
-
-    PUT_UINT32(high, msglen, 0);
-    PUT_UINT32(low, msglen, 4);
-
-    last = ctx->total[0] & 0x3F;
-    padn = (last < 56) ? (56 - last) : (120 - last);
-
-    uint8_t sha256_padding[64];
-    memset(sha256_padding, 0, 64);
-    memset(sha256_padding, 0x80, 1);
-
-    SHA256_Update(ctx, sha256_padding, padn);
-    SHA256_Update(ctx, msglen, 8);
-
-    PUT_UINT32(ctx->state[0], digest, 0);
-    PUT_UINT32(ctx->state[1], digest, 4);
-    PUT_UINT32(ctx->state[2], digest, 8);
-    PUT_UINT32(ctx->state[3], digest, 12);
-    PUT_UINT32(ctx->state[4], digest, 16);
-    PUT_UINT32(ctx->state[5], digest, 20);
-    PUT_UINT32(ctx->state[6], digest, 24);
-    PUT_UINT32(ctx->state[7], digest, 28);
-}
-
-typedef struct HMAC_SHA256Context {
-	SHA256_CTX ictx;
-	SHA256_CTX octx;
-} HMAC_SHA256_CTX;
-
-/* Initialize an HMAC-SHA256 operation with the given key. */
-static void
-HMAC_SHA256_Init(HMAC_SHA256_CTX *ctx, const void *_K, size_t Klen)
-{
-	unsigned char pad[64];
-	unsigned char khash[32];
-	const unsigned char *K = (const unsigned char *)_K;
-	size_t i;
-
-	/* If Klen > 64, the key is really SHA256(K). */
-	if (Klen > 64) {
-		SHA256_Init(&ctx->ictx);
-		SHA256_Update(&ctx->ictx, (uint8_t*)K, Klen);
-		SHA256_Final(&ctx->ictx, (uint8_t*)khash);
-		K = khash;
-		Klen = 32;
-	}
-
-	/* Inner SHA256 operation is SHA256(K xor [block of 0x36] || data). */
-	SHA256_Init(&ctx->ictx);
-	memset(pad, 0x36, 64);
-	for (i = 0; i < Klen; i++)
-		pad[i] ^= K[i];
-	SHA256_Update(&ctx->ictx, pad, 64);
-
-	/* Outer SHA256 operation is SHA256(K xor [block of 0x5c] || hash). */
-	SHA256_Init(&ctx->octx);
-	memset(pad, 0x5c, 64);
-	for (i = 0; i < Klen; i++)
-		pad[i] ^= K[i];
-	SHA256_Update(&ctx->octx, pad, 64);
-
-	/* Clean the stack. */
-	memset(khash, 0, 32);
-}
-
-/* Add bytes to the HMAC-SHA256 operation. */
-static void
-HMAC_SHA256_Update(HMAC_SHA256_CTX *ctx, const void *in, size_t len)
-{
-	/* Feed data to the inner SHA256 operation. */
-	SHA256_Update(&ctx->ictx, (uint8_t*)in, len);
-}
-
-/* Finish an HMAC-SHA256 operation. */
-static void
-HMAC_SHA256_Final(unsigned char digest[32], HMAC_SHA256_CTX *ctx)
-{
-	unsigned char ihash[32];
-
-	/* Finish the inner SHA256 operation. */
-	SHA256_Final(&ctx->ictx, ihash);
-
-	/* Feed the inner hash to the outer SHA256 operation. */
-	SHA256_Update(&ctx->octx, ihash, 32);
-
-	/* Finish the outer SHA256 operation. */
-	SHA256_Final(&ctx->octx, digest);
-
-	/* Clean the stack. */
-	memset(ihash, 0, 32);
-}
-
 /**
  * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
  * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-SHA256 as the PRF, and
@@ -373,18 +71,19 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen)
 {
-	HMAC_SHA256_CTX PShctx, hctx;
+	CHMAC_SHA256 baseCtx = CHMAC_SHA256(passwd, passwdlen);
+	CHMAC_SHA256 PShctx = CHMAC_SHA256(passwd, passwdlen);
+	CHMAC_SHA256 hctx = CHMAC_SHA256(passwd, passwdlen);
 	size_t i;
 	uint8_t ivec[4];
-	uint8_t U[32];
-	uint8_t T[32];
+	uint8_t U[CHMAC_SHA256::OUTPUT_SIZE];
+	uint8_t T[CHMAC_SHA256::OUTPUT_SIZE];
 	uint64_t j;
-	int k;
+	unsigned int k;
 	size_t clen;
 
 	/* Compute HMAC state after processing P and S. */
-	HMAC_SHA256_Init(&PShctx, passwd, passwdlen);
-	HMAC_SHA256_Update(&PShctx, salt, saltlen);
+	PShctx.Write(salt, saltlen);
 
 	/* Iterate through the blocks. */
 	for (i = 0; i * 32 < dkLen; i++) {
@@ -392,33 +91,30 @@ PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
 		be32enc(ivec, (uint32_t)(i + 1));
 
 		/* Compute U_1 = PRF(P, S || INT(i)). */
-		memcpy(&hctx, &PShctx, sizeof(HMAC_SHA256_CTX));
-		HMAC_SHA256_Update(&hctx, ivec, 4);
-		HMAC_SHA256_Final(U, &hctx);
+		PShctx.Copy(&hctx);
+		hctx.Write(ivec, 4);
+		hctx.Finalize(U);
 
 		/* T_i = U_1 ... */
-		memcpy(T, U, 32);
+		memcpy(T, U, CHMAC_SHA256::OUTPUT_SIZE);
 
 		for (j = 2; j <= c; j++) {
 			/* Compute U_j. */
-			HMAC_SHA256_Init(&hctx, passwd, passwdlen);
-			HMAC_SHA256_Update(&hctx, U, 32);
-			HMAC_SHA256_Final(U, &hctx);
+			baseCtx.Copy(&hctx);
+			hctx.Write(U, CHMAC_SHA256::OUTPUT_SIZE);
+			hctx.Finalize(U);
 
 			/* ... xor U_j ... */
-			for (k = 0; k < 32; k++)
+			for (k = 0; k < CHMAC_SHA256::OUTPUT_SIZE; k++)
 				T[k] ^= U[k];
 		}
 
 		/* Copy as many bytes as necessary into buf. */
-		clen = dkLen - i * 32;
-		if (clen > 32)
-			clen = 32;
-		memcpy(&buf[i * 32], T, clen);
+		clen = dkLen - i * CHMAC_SHA256::OUTPUT_SIZE;
+		if (clen > CHMAC_SHA256::OUTPUT_SIZE)
+			clen = CHMAC_SHA256::OUTPUT_SIZE;
+		memcpy(&buf[i * CHMAC_SHA256::OUTPUT_SIZE], T, clen);
 	}
-
-	/* Clean PShctx, since we never called _Final on it. */
-	memset(&PShctx, 0, sizeof(HMAC_SHA256_CTX));
 }
 
 #define ROTL(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
@@ -565,12 +261,3 @@ void scrypt_1024_1_1_256(const char *input, char *output)
     char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
     scrypt_1024_1_1_256_sp(input, output, scratchpad);
 }
-
-void SHA256(unsigned char* input, int len, unsigned char* output)
-{
-    SHA256_CTX ctx;
-    SHA256_Init(&ctx);
-    SHA256_Update(&ctx, (uint8_t*)input, len);
-    SHA256_Final(&ctx, (uint8_t*)output);
-}
-


### PR DESCRIPTION
Resolves an issue with integer overflow in the Scrypt provided SHA256 implementation, and also removes unneeded code.
