### PR TITLE
[CI] Enable windows unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
               sudo update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
               sudo update-alternatives --set i686-w64-mingw32-g++  /usr/bin/i686-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
-            run-tests: false
+            run-tests: true
             dep-opts: ""
             config-opts: "--enable-reduce-exports"
             goal: install
@@ -82,7 +82,7 @@ jobs:
               sudo update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
-            run-tests: false
+            run-tests: true
             dep-opts: ""
             config-opts: "--enable-reduce-exports"
             goal: install


### PR DESCRIPTION
Enables unit testing for windows builds using GH Actions

In my dirty version of #2320, windows tests failed consistently, but it turns out on the clean version that we merged, they just work. So we can simply enable the tests in CI configuration :grin: