### PR TITLE
depends: Update libevent to 2.1.11

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,8 +1,8 @@
 package=libevent
-$(package)_version=2.1.7
+$(package)_version=2.1.8-stable
 $(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_file_name=release-$($(package)_version)-rc.tar.gz
-$(package)_sha256_hash=548362d202e22fe24d4c3fad38287b4f6d683e6c21503341373b89785fa6f991
+$(package)_file_name=release-$($(package)_version).tar.gz
+$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
 
 define $(package)_preprocess_cmds
   ./autogen.sh

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -9,7 +9,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress
+  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
 endef

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,8 +1,8 @@
 package=libevent
-$(package)_version=2.1.8-stable
+$(package)_version=2.1.11-stable
 $(package)_download_path=https://github.com/libevent/libevent/archive/
 $(package)_file_name=release-$($(package)_version).tar.gz
-$(package)_sha256_hash=316ddb401745ac5d222d7c529ef1eada12f58f6376a66c1118eee803cb70f83d
+$(package)_sha256_hash=229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e
 
 define $(package)_preprocess_cmds
   ./autogen.sh


### PR DESCRIPTION
Tested locally with test and main nets, along with unit test suite. Going to push this to a long running node to soak before we merge, but raising so others are aware the work is done.

This is an item for #2321