### PR TITLE
Docs4Doge : Update unix build instructions

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,35 +1,22 @@
-UNIX BUILD NOTES
-====================
-Some notes on how to build Dogecoin Core in Unix.
+# Unix Build Notes
+1. [Install dependencies](#dependencies)
+ - [Ubuntu & Debian](#ubuntu)
+ - [Fedora](#Fedora)
+ - [FreeBSD](#FreeBSD)
+2. [Build steps](#build-steps)
+3. [Build configuration](#configure-build)
+ - [Enable Qt Gui](#enable-qt-gui)
+ - [Incompatible BerkeleyDB](#incompatible-berkleydb)
+ - [Disable Wallet](#diable-wallet)
+ - [Miniupnpc](#miniupnpc)
+ - [Security](#security)
 
-(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+## Install dependencies
 
-Note
----------------------
-Always use absolute paths to configure and compile Dogecoin and the dependencies,
-for example, when specifying the path of the dependency:
+You must install required dependencies to run a basic Dogecoin daemon.  
+Optional dependencies may vary depending on your build specifications.
 
-	../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
-
-Here BDB_PREFIX must be an absolute path - it is defined using $(pwd) which ensures
-the usage of the absolute path.
-
-To Build
----------------------
-
-```bash
-./autogen.sh
-./configure
-make
-make install # optional
-```
-
-This will build Dogecoin-Qt as well if the dependencies are met.
-
-Dependencies
----------------------
-
-These dependencies are required:
+**Required dependencies :**
 
  Library     | Purpose          | Description
  ------------|------------------|----------------------
@@ -37,7 +24,7 @@ These dependencies are required:
  libboost    | Utility          | Library for threading, data structures, etc
  libevent    | Networking       | OS independent asynchronous networking
 
-Optional dependencies:
+**Optional dependencies:**
 
  Library     | Purpose          | Description
  ------------|------------------|----------------------
@@ -60,147 +47,107 @@ tuned to conserve memory with additional CXXFLAGS:
 
     ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
 
-Dependency Build Instructions: Ubuntu & Debian
-----------------------------------------------
-Build requirements:
+### Ubuntu & Debian
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
+**Required dependencies** :
+```
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
+```
 
-Options when installing required Boost library files:
+**Optional dependencies** :  
+```
+# Qt (required for dogecoin-qt GUI)
+sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
 
-1. On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
-individual boost development packages, so the following can be used to only
-install necessary parts of boost:
+# BerkeleyDB
+sudo apt-get install libdb5.1-dev libdb5.1++-dev
 
-        sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+# Boost
+sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
 
-2. If that doesn't work, you can install all boost development packages with:
+# ZMQ (provides ZMQ API 4.x)
+sudo apt-get install libzmq3-dev
 
-        sudo apt-get install libboost-all-dev
+# Miniupnpc
+sudo apt-get install libminiupnpc-dev
+```
 
-BerkeleyDB is required for the wallet.
+### Fedora
 
-    sudo apt-get install libdb5.1-dev libdb5.1++-dev
+**Required dependencies :**
+```
+sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
+```
+**Optional dependencies :**
+```
+# Qt (required for dogecoin-qt GUI)
+sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel qrencode-devel
 
-       Note that if you have Berkeley DB 4.8 packages installed (i.e. for other
-       wallet software), they are incompatible with the packages for 5.1. You
-       will have to manually download 5.1 from
-       http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz and compile
-       it, install it to /usr/local where the configure script should locate it
-       automatically.
+# Miniupnpc
+sudo dnf install miniupnpc-devel
+```
 
+## FreeBSD
 
-See the section "Disable-wallet mode" to build Dogecoin Core without wallet.
+**Required dependencies :**
+```
+sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
+```
+**Optional dependencies :**
+```
+# BerkeleyDB
+pkg install db5
+```
+## Build steps
 
-Optional (see --with-miniupnpc and --enable-upnp-default):
+According to installed dependencies, the following steps will compile `dogecoind`, `dogecoin-cli` and `dogecoin-qt`.
 
-    sudo apt-get install libminiupnpc-dev
+```bash
+./autogen.sh
+./configure
+make
+make install # optional
+```
+See [Build configuration](#build-configuration) section for extra settings.
 
-ZMQ dependencies (provides ZMQ API 4.x):
+## Build configuration
+You can see all available options with `./configure --help`
 
-    sudo apt-get install libzmq3-dev
+#### Enable Qt GUI
+Create `dogecoin-qt`, the core wallet GUI.
+```
+./configure --with-gui
+```
 
-Dependencies for the GUI: Ubuntu & Debian
------------------------------------------
+#### Incompatible BerkeleyDB
+If you're using any other BerkeleyDB version than 4.8 :
+```
+./configure --with-incompatible-bdb
+```
+#### Disable-wallet mode
+When the intention is to run only a P2P node without a wallet, Dogecoin may be compiled in
+disable-wallet mode with:
 
-If you want to build Dogecoin-Qt, make sure that the required packages for Qt development
-are installed. Either Qt 5 or Qt 4 are necessary to build the GUI.
-If both Qt 4 and Qt 5 are installed, Qt 5 will be used. Pass `--with-gui=qt4` to configure to choose Qt4.
-To build without GUI pass `--without-gui`.
+```
+./configure --disable-wallet
+```
 
-To build with Qt 5 (recommended) you need the following:
+Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
+call, not `getwork`.
 
-    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
-
-Alternatively, to build with Qt 4 you need the following:
-
-    sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler
-
-libqrencode (optional) can be installed with:
-
-    sudo apt-get install libqrencode-dev
-
-Once these are installed, they will be found by configure and a dogecoin-qt executable will be
-built by default.
-
-Dependency Build Instructions: Fedora
--------------------------------------
-Build requirements:
-
-    sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
-
-Optional:
-
-    sudo dnf install miniupnpc-devel
-
-To build with Qt 5 (recommended) you need the following:
-
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
-
-libqrencode (optional) can be installed with:
-
-    sudo dnf install qrencode-devel
-
-Notes
------
-The release is built with GCC and then "strip dogecoind" to strip the debug
-symbols, which reduces the executable size by about 90%.
-
-
-miniupnpc
----------
+#### Miniupnpc
 
 [miniupnpc](http://miniupnp.free.fr/) may be used for UPnP port mapping.  It can be downloaded from [here](
 http://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
 turned off by default.  See the configure options for upnp behavior desired:
 
-	--without-miniupnpc      No UPnP support miniupnp not required
-	--disable-upnp-default   (the default) UPnP support turned off by default at runtime
-	--enable-upnp-default    UPnP support turned on by default at runtime
-
-
-Berkeley DB
------------
-It is recommended to use Berkeley DB 5.1. If you have to build it yourself:
-
-```bash
-BITCOIN_ROOT=$(pwd)
-
-# Pick some path to install BDB to, here we create a directory within the dogecoin directory
-BDB_PREFIX="${BITCOIN_ROOT}/db5"
-mkdir -p $BDB_PREFIX
-
-# Fetch the source and verify that it is not tampered with
-wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
-echo '08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c db-5.1.29.NC.tar.gz' | sha256sum -c
-# -> db-5.1.29.NC.tar.gz: OK
-tar -xzvf db-5.1.29.NC.tar.gz
-
-# Build the library and install to our prefix
-cd db-5.1.29.NC/build_unix/
-#  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
-make install
-
-# Configure Dogecoin Core to use our own-built instance of BDB
-cd $BITCOIN_ROOT
-./autogen.sh
-./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)
+```
+--without-miniupnpc      No UPnP support miniupnp not required
+--disable-upnp-default   (the default) UPnP support turned off by default at runtime
+--enable-upnp-default    UPnP support turned on by default at runtime
 ```
 
-**Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).
-
-Boost
------
-If you need to build Boost yourself:
-
-	sudo su
-	./bootstrap.sh
-	./bjam install
-
-
-Security
---------
+#### Security
 To help make your Dogecoin installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, binaries are hardened by default.
 This can be disabled with:
@@ -248,42 +195,7 @@ Hardening enables the following features:
 
     The STK RW- means that the stack is readable and writeable, but not executable.
 
-Disable-wallet mode
---------------------
-When the intention is to run only a P2P node without a wallet, Dogecoin may be compiled in
-disable-wallet mode with:
 
-    ./configure --disable-wallet
-
-In this case there is no dependency on Berkeley DB 4.8.
-
-Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
-call, not `getwork`.
-
-Additional Configure Flags
---------------------------
-A list of additional configure flags can be displayed with:
-
-    ./configure --help
-
-
-Setup and Build Example: Arch Linux
------------------------------------
-This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
-
-    pacman -S git base-devel boost libevent python
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin/
-    ./autogen.sh
-    ./configure --disable-wallet --without-gui --without-miniupnpc
-    make check
-
-Note:
-Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
-or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
-`--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
-As mentioned above, when maintaining portability of the wallet between the standard Dogecoin Core distributions and independently built
-node software is desired, Berkeley DB 4.8 must be used.
 
 
 ARM Cross-compilation
@@ -305,39 +217,4 @@ To build executables for ARM:
     ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
     make
 
-
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-
-Building on FreeBSD
---------------------
-
-(Updated as of FreeBSD 11.0)
-
-Clang is installed by default as `cc` compiler, this makes it easier to get
-started than on [OpenBSD](build-openbsd.md). Installing dependencies:
-
-    pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent
-    pkg install gmake
-
-You need to use GNU make (`gmake`) instead of `make`.
-(`libressl` instead of `openssl` will also work)
-
-For the wallet (optional):
-
-    pkg install db5
-
-This will give a warning "configure: WARNING: Found Berkeley DB other
-than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
-had a binary release, this may not matter. If backwards compatibility
-with 4.8-built Dogecoin Core is needed follow the steps under "Berkeley DB" above.
-
-Then build using:
-
-    ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
-    gmake
-
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command e.g. `gdb7111`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -84,7 +84,7 @@ sudo dnf install miniupnpc-devel
 
 **Required dependencies :**
 ```bash
-sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
+pkg install autoconf automake libtool pkgconf boost-libs openssl libevent gmake
 ```
 **Optional dependencies :**
 ```bash


### PR DESCRIPTION
Starting to dive into installation instructions for [docs4doge](https://github.com/dogecoin/dogecoin/issues/2271), focus only on unix.

The goal is to reduce entry barrier for users, make it easier to getting started with Dogecoin core.

I reorganized the content as follows to be more logical : *Dependencies install > Build Steps > build Configuration*.

## Dependencies

I made some choice for dependencies, need feedback/check : 
- Use only qt5 and remove qt4 (#2316)
- For BerkeleyDB, recommend 5.3 with package manager (5.1 not available [on debian/ubuntu/[gentoo/fedora](https://github.com/dogecoin/dogecoin/pull/2221#issuecomment-851028567)]), but suggest 5.1 for source install. (See #2245)
- For boost, install package separately only (`libboost-system-dev libboost-filesystem-dev [...] libboost-thread-dev`) instead of `libboost-all-dev`

## Removed notes
I removed a couple of notes, like the first one who explain that you must use a right path.
Also I removed `The release is built with GCC and then "strip dogecoind" to strip the debug symbols, which reduces the executable size by about 90%.`, I thought it wasn't an important info for compilation, idk if we should keep it.

PS. : ARM compilation is not at the right place in my mind, at the end because still WIP.
**[Tested only with debian]**