### PR TITLE
fix: macos qt build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -80,6 +80,9 @@ extern double NSAppKitVersionNumber;
 #if !defined(NSAppKitVersionNumber10_9)
 #define NSAppKitVersionNumber10_9 1265
 #endif
+#include <QProcess>
+
+void ForceActivation();
 #endif
 
 namespace GUIUtil {
@@ -403,6 +406,23 @@ bool isObscured(QWidget *w)
         && checkPoint(QPoint(0, w->height() - 1), w)
         && checkPoint(QPoint(w->width() - 1, w->height() - 1), w)
         && checkPoint(QPoint(w->width() / 2, w->height() / 2), w));
+}
+
+void bringToFront(QWidget* w)
+{
+    #ifdef Q_OS_MAC
+        ForceActivation();
+    #endif
+    if (w) {
+        // activateWindow() (sometimes) helps with keyboard focus on Windows
+        if (w->isMinimized()) {
+            w->showNormal();
+        } else {
+            w->show();
+        }
+        w->activateWindow();
+        w->raise();
+    }
 }
 
 void openDebugLogfile()

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -9,10 +9,9 @@
 #include <QBuffer>
 #include <QWidget>
 
-#undef slots
 #include <Cocoa/Cocoa.h>
-#include <objc/objc.h>
-#include <objc/message.h>
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
 
 #if QT_VERSION < 0x050000
 extern void qt_mac_set_dock_menu(QMenu *);
@@ -23,26 +22,20 @@ static MacDockIconHandler *s_instance = NULL;
 bool dockClickHandler(id self,SEL _cmd,...) {
     Q_UNUSED(self)
     Q_UNUSED(_cmd)
-    
+
     s_instance->handleDockIconClickEvent();
-    
+
     // Return NO (false) to suppress the default OS X actions
     return false;
 }
 
 void setupDockClickHandler() {
-    Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
-    
-    if (appInst != NULL) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
-        SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-        if (class_getInstanceMethod(delClass, shouldHandle))
-            class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
-        else
-            class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
+    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
+    SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+    if (class_getInstanceMethod(delClass, shouldHandle))
+        class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
+    else
+        class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
 }
 
 
@@ -132,3 +125,14 @@ void MacDockIconHandler::handleDockIconClickEvent()
 
     Q_EMIT this->dockIconClicked();
 }
+
+/**
+ * Force application activation on macOS. With Qt 5.5.1 this is required when
+ * an action in the Dock menu is triggered.
+ * TODO: Define a Qt version where it's no-longer necessary.
+ */
+void ForceActivation()
+{
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+}
+


### PR DESCRIPTION
### ISSUE

Impossible to compile MAC OS locally with GUI

### ERROR MESSAGE

```
qt/macdockiconhandler.mm:35:18: error: no matching function for call to 'objc_msgSend'
    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
                 ^~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note: candidate function not viable: requires 0 arguments, but 2 were provided
objc_msgSend(void /* id self, SEL op, ... */ )
^
qt/macdockiconhandler.mm:38:23: error: no matching function for call to 'objc_msgSend'
        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
                      ^~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note: candidate function not viable: requires 0 arguments, but 2 were provided
objc_msgSend(void /* id self, SEL op, ... */ )
^
qt/macdockiconhandler.mm:39:33: error: no matching function for call to 'objc_msgSend'
        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
                                ^~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note: candidate function not viable: requires 0 arguments, but 2 were provided
objc_msgSend(void /* id self, SEL op, ... */ )
^
3 errors generated.

```

### FIX

https://github.com/hebasto/bitcoin/commit/0bb33b5348dbddd65b88a7f00449c965562355d3