### PR TITLE
[qa] Retain binary artifacts on CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,10 @@ jobs:
           make check $MAKEJOBS VERBOSE=1
           qa/pull-tester/install-deps.sh
           qa/pull-tester/rpc-tests.py --coverage
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dogecoin-${{ github.sha }}-${{ matrix.name }}
+          path: |
+            depends/${{ matrix.host }}/bin/dogecoin*


### PR DESCRIPTION
Retain the binaries we build on GH actions so that if something needs visual inspection (qt) or testnet checks, that we don't all have to build this again.

Binaries will be retained for a limited time (bound by GH's artifact cache size policy)
