### PR TITLE
[qa] Make GH Actions CI less trigger happy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: Continuous Integration
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'contrib/**'
+      - '**/*.md'
 
 jobs:
   build:


### PR DESCRIPTION
Do not run CI if all updated paths in a PR match:

- 'doc/**'
- 'contrib/**'
- '**/*.md'

and on push, if all updated paths match: '**/*.md'

I kept the "on push" trigger to not exclude any of the contrib and doc for now, in case this bugs out in any way. 