### PR TITLE
Change key derivation path to be correct for Dogecoin

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1908,11 +1908,11 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     } // no default case, so the compiler can warn about missing cases
     assert(!desc_prefix.empty());
 
-    // Mainnet derives at 0', testnet and regtest derive at 1'
+    // Mainnet derives at 3', testnet and regtest derive at 1'
     if (Params().IsTestChain()) {
         desc_prefix += "/1'";
     } else {
-        desc_prefix += "/0'";
+        desc_prefix += "/3'";
     }
 
     std::string internal_path = m_internal ? "/1" : "/0";

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -57,7 +57,7 @@ class WalletHDTest(BitcoinTestFramework):
             if self.options.descriptors:
                 assert_equal(hd_info["hdkeypath"], "m/44'/1'/0'/0/" + str(i))
             else:
-                assert_equal(hd_info["hdkeypath"], "m/0'/0'/" + str(i) + "'")
+                assert_equal(hd_info["hdkeypath"], "m/0'/3'/" + str(i) + "'")
             assert_equal(hd_info["hdmasterfingerprint"], hd_fingerprint)
             self.nodes[0].sendtoaddress(hd_add, 1)
             self.nodes[0].generate(1)
@@ -95,7 +95,7 @@ class WalletHDTest(BitcoinTestFramework):
             if self.options.descriptors:
                 assert_equal(hd_info_2["hdkeypath"], "m/44'/1'/0'/0/" + str(i))
             else:
-                assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/" + str(i) + "'")
+                assert_equal(hd_info_2["hdkeypath"], "m/0'/3'/" + str(i) + "'")
             assert_equal(hd_info_2["hdmasterfingerprint"], hd_fingerprint)
         assert_equal(hd_add, hd_add_2)
         self.connect_nodes(0, 1)
@@ -159,7 +159,7 @@ class WalletHDTest(BitcoinTestFramework):
             addr = self.nodes[1].getnewaddress()
             assert_equal(orig_masterkeyid, self.nodes[1].getaddressinfo(addr)['hdseedid'])
             # Make sure the new address continues previous keypool
-            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/1\'')
+            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/3\'/1\'')
 
             # Check that the next address is from the new seed
             self.nodes[1].keypoolrefill(1)


### PR DESCRIPTION
Needs tests updated and needs to handle pre-1.14.4 wallets having the wrong derivation path.
