### PR TITLE
Tune codeql-analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,24 +1,18 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+# CodeQL GH Actions file
+name: CodeQL
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '*-dev'
+      - '*-maint'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
-  schedule:
-    - cron: '16 12 * * 4'
+    branches:
+      - '*-dev'
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   analyze:
@@ -32,44 +26,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python' ]
+        language: [ 'cpp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Update system
+      run: |
+        sudo apt-get update --yes
+        sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils --yes
+
+    - name: Dependency cache
+      uses: actions/cache@v2
+      env:
+        cache-name: depends
+      with:
+        path: ./depends/built
+        key: codeql-${{ env.cache-name }}-${{ hashFiles('depends/packages/*') }}
+
+    - name: Build depends
+      run: |
+        pushd depends
+        make -j4 HOST=x86_64-pc-linux-gnu
+        popd
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    - run: |
-       sudo apt-get update --yes
-       sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils --yes
-       sudo apt-get install libboost-all-dev --yes
+    - name: Build Dogecoin
+      run: |
        ./autogen.sh
-       ./configure --disable-wallet --without-gui
-       make
-       
+       ./configure --prefix=`pwd`/depends/x86_64-pc-linux-gnu
+       make -j4
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Currently CodeQL is only triggered on the `master` branch. This is not useful for how we set up the Dogecoin Core repo.

Additionally changed the process to use the depends system (but not analyze that) and to skip over any doc changes.

- only audit production code (no python) 
- trigger on *-maint and *-dev push
- trigger on PR
- remove useless autogenerated comments
- skip doc changes
- use depends system without analyzing it
- cache depends