### PR TITLE
[depends] Update osslsigncode mirror consistently

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -11,7 +11,7 @@ remotes:
 - "url": "https://github.com/dogecoin/dogecoin-detached-sigs.git"
   "dir": "signature"
 files:
-- "osslsigncode-1.7.1.tar.gz"
+- "osslsigncode_1.7.1.orig.tar.gz"
 - "osslsigncode-Backports-to-1.7.1.patch"
 - "dogecoin-win-unsigned.tar.gz"
 script: |
@@ -19,13 +19,13 @@ script: |
   SIGDIR=${BUILD_DIR}/signature/win
   UNSIGNED_DIR=${BUILD_DIR}/unsigned
 
-  echo "f9a8cdb38b9c309326764ebc937cba1523a3a751a7ab05df3ecc99d18ae466c9  osslsigncode-1.7.1.tar.gz" | sha256sum -c
+  echo "f9a8cdb38b9c309326764ebc937cba1523a3a751a7ab05df3ecc99d18ae466c9  osslsigncode_1.7.1.orig.tar.gz" | sha256sum -c
   echo "a8c4e9cafba922f89de0df1f2152e7be286aba73f78505169bc351a7938dd911  osslsigncode-Backports-to-1.7.1.patch" | sha256sum -c
 
   mkdir -p ${UNSIGNED_DIR}
   tar -C ${UNSIGNED_DIR} -xf dogecoin-win-unsigned.tar.gz
 
-  tar xf osslsigncode-1.7.1.tar.gz
+  tar xf osslsigncode_1.7.1.orig.tar.gz
   cd osslsigncode-1.7.1
   patch -p1 < ${BUILD_DIR}/osslsigncode-Backports-to-1.7.1.patch
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -99,7 +99,7 @@ Ensure gitian-builder is up-to-date:
     pushd ./gitian-builder
     mkdir -p inputs
     wget -P inputs https://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
-    wget -P inputs http://downloads.sourceforge.net/project/osslsigncode/osslsigncode/osslsigncode-1.7.1.tar.gz
+    wget -P inputs https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/osslsigncode/1.7.1-1/osslsigncode_1.7.1.orig.tar.gz
     popd
 
 Create the OS X SDK tarball, see the [OS X readme](README_osx.md) for details, and copy it into the inputs directory.


### PR DESCRIPTION
Updates the osslsigncode 1.7.1 tarball mirror to launchpad consistently in all gitian descriptors and docs. 

Fixes #2369

