### PR TITLE
Fix boost 1.63 MACOS Big Sur

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_63_0
 $(package)_download_path=https://sourceforge.net/projects/boost/files/boost/1.63.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
+$(package)_patches=execcmd.patch execnt.patch filent.patch filesys.patch fileunix.patch jam.patch make.patch path.patch darwin.patch fpclassify.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,7 +26,17 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
+  patch -p1 < $($(package)_patch_dir)/execcmd.patch && \
+  patch -p1 < $($(package)_patch_dir)/execnt.patch && \
+  patch -p1 < $($(package)_patch_dir)/filent.patch && \
+  patch -p1 < $($(package)_patch_dir)/filesys.patch && \
+  patch -p1 < $($(package)_patch_dir)/fileunix.patch && \
+  patch -p1 < $($(package)_patch_dir)/jam.patch && \
+  patch -p1 < $($(package)_patch_dir)/make.patch && \
+  patch -p1 < $($(package)_patch_dir)/path.patch && \
+  patch -p1 < $($(package)_patch_dir)/darwin.patch && \
+  patch -p1 < $($(package)_patch_dir)/fpclassify.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/darwin.patch
+++ b/depends/patches/boost/darwin.patch
@@ -1,0 +1,19 @@
+--- old-boost/tools/build/src/tools/darwin.jam	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/tools/darwin.jam	2021-07-14 14:05:00.000000000 -0400
+@@ -137,13 +137,14 @@
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/depends/patches/boost/execcmd.patch
+++ b/depends/patches/boost/execcmd.patch
@@ -1,0 +1,10 @@
+--- old-boost/tools/build/src/engine/execcmd.c	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/execcmd.c	2021-07-14 12:48:06.000000000 -0400
+@@ -10,6 +10,7 @@
+
+ #include "jam.h"
+ #include "execcmd.h"
++#include "output.h"
+
+ #include <assert.h>
+ #include <stdio.h>

--- a/depends/patches/boost/execnt.patch
+++ b/depends/patches/boost/execnt.patch
@@ -1,0 +1,11 @@
+--- old-boost/tools/build/src/engine/execnt.c	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/execnt.c	2021-07-14 14:10:37.000000000 -0400
+@@ -521,7 +521,7 @@
+ 
+ static int maxline()
+ {
+-    static result;
++    static int result;
+     if ( !result ) result = raw_maxline();
+     return result;
+ }

--- a/depends/patches/boost/filent.patch
+++ b/depends/patches/boost/filent.patch
@@ -1,0 +1,10 @@
+--- old-boost/tools/build/src/engine/filent.c	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/filent.c	2021-07-14 12:49:14.000000000 -0400
+@@ -49,6 +49,7 @@
+ #include <direct.h>
+ #include <io.h>
+
++int file_collect_archive_content_( file_archive_info_t * const archive );
+
+ /*
+  * file_collect_dir_content_() - collects directory content information

--- a/depends/patches/boost/filesys.patch
+++ b/depends/patches/boost/filesys.patch
@@ -1,0 +1,11 @@
+--- old-boost/tools/build/src/engine/filesys.h	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/filesys.h	2021-07-14 12:49:33.000000000 -0400
+@@ -96,6 +96,8 @@
+ file_info_t * filelist_front(  FILELIST * list );
+ file_info_t * filelist_back(  FILELIST * list );
+
++int filelist_empty( FILELIST * list );
++
+ #define FL0 ((FILELIST *)0)
+
+

--- a/depends/patches/boost/fileunix.patch
+++ b/depends/patches/boost/fileunix.patch
@@ -1,0 +1,10 @@
+--- old-boost/tools/build/src/engine/fileunix.c	2021-07-14 13:41:40.000000000 -0400
++++ new-boost/tools/build/src/engine/fileunix.c	2021-07-14 13:53:24.000000000 -0400
+@@ -219,6 +219,7 @@
+     timestamp_init( t, 1, 0 );
+ }
+
++int file_collect_archive_content_( file_archive_info_t * const archive );
+
+ /*
+  * file_archscan() - scan an archive for files

--- a/depends/patches/boost/fpclassify.patch
+++ b/depends/patches/boost/fpclassify.patch
@@ -1,0 +1,13 @@
+--- old-boost/boost/math/special_functions/fpclassify.hpp	2016-12-22 07:33:17.000000000 -0500
++++ new-boost/boost/math/special_functions/fpclassify.hpp	2021-07-14 14:20:24.000000000 -0400
+@@ -137,6 +137,10 @@
+       _GLIBCXX_USE_C99_MATH && !_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC
+ inline bool is_nan_helper(__float128 f, const boost::true_type&) { return std::isnan(static_cast<double>(f)); }
+ inline bool is_nan_helper(__float128 f, const boost::false_type&) { return std::isnan(static_cast<double>(f)); }
++#elif defined(BOOST_GNU_STDLIB) && BOOST_GNU_STDLIB && \
++      _GLIBCXX_USE_C99_MATH && !_GLIBCXX_USE_C99_FP_MACROS_DYNAMIC
++inline bool is_nan_helper(__float128 f, const boost::true_type&) { return std::isnan(static_cast<double>(f)); }
++inline bool is_nan_helper(__float128 f, const boost::false_type&) { return std::isnan(static_cast<double>(f)); }
+ #else
+ inline bool is_nan_helper(__float128 f, const boost::true_type&) { return ::isnan(static_cast<double>(f)); }
+ inline bool is_nan_helper(__float128 f, const boost::false_type&) { return ::isnan(static_cast<double>(f)); }

--- a/depends/patches/boost/jam.patch
+++ b/depends/patches/boost/jam.patch
@@ -1,0 +1,10 @@
+--- old-boost/tools/build/src/engine/jam.c	2021-07-14 12:57:33.000000000 -0400
++++ new-boost/tools/build/src/engine/jam.c	2021-07-14 12:49:56.000000000 -0400
+@@ -120,6 +120,7 @@
+ #include "strings.h"
+ #include "timestamp.h"
+ #include "variable.h"
++#include "execcmd.h"
+
+ /* Macintosh is "special" */
+ #ifdef OS_MAC

--- a/depends/patches/boost/make.patch
+++ b/depends/patches/boost/make.patch
@@ -1,0 +1,11 @@
+--- old-boost/tools/build/src/engine/make.c	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/make.c	2021-07-14 12:50:18.000000000 -0400
+@@ -44,6 +44,8 @@
+ #include "search.h"
+ #include "timestamp.h"
+ #include "variable.h"
++#include "execcmd.h"
++#include "output.h"
+
+ #include <assert.h>
+

--- a/depends/patches/boost/path.patch
+++ b/depends/patches/boost/path.patch
@@ -1,0 +1,11 @@
+--- old-boost/tools/build/src/engine/modules/path.c	2016-12-22 07:33:21.000000000 -0500
++++ new-boost/tools/build/src/engine/modules/path.c	2021-07-14 12:50:27.000000000 -0400
+@@ -8,7 +8,7 @@
+ #include "../frames.h"
+ #include "../lists.h"
+ #include "../native.h"
+-#include "../timestamp.h"
++#include "../filesys.h"
+
+
+ LIST * path_exists( FRAME * frame, int flags )

--- a/doc/Building-Dogecoin-1.14-for-Mac.md
+++ b/doc/Building-Dogecoin-1.14-for-Mac.md
@@ -31,14 +31,11 @@ Install Brew. (If you already have Brew installed, perform a 'brew update'.)
 
 Install dependencies via Brew.
 
-    $brew install autoconf automake libtool miniupnpc openssl pkg-config protobuf qt5 zeromq qrencode librsvg boost
+    $brew install autoconf automake libtool miniupnpc openssl pkg-config protobuf qt5 zeromq qrencode librsvg
 
-Install Boost lib via Brew from source, and link it to be sure:
+### Compile BOOST 1.63.0 ###
 
-**note** Boost version may have changed by the time you're reading this, from 167.
-
-    $brew install boost --build-from-source --HEAD
-    $brew link boost167
+    $make -C depends boost
 
 ### Get, Patch And Compile BDB 5.1 ###
 


### PR DESCRIPTION
`make -C depends` is failing on MACOS Big Sur

**Current behavior:**
```
Extracting boost...
Preprocessing boost...
Configuring boost...
Building Boost.Build engine with toolset darwin... 
Failed to build Boost.Build build engine
Consult 'bootstrap.log' for more details
make: *** [./depends/work/build/x86_64-apple-darwin20.5.0/boost/1_63_0-368f0866e9f/./.stamp_configured] Error 1
```

**bootstrap.log**
```
 error: implicit declaration of function 'out_flush' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

**Expected behavior**
Success build

**Steps to reproduce:**
make -C depends boost