### PR TITLE
Refine Snap verification message

### DIFF
--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -37,10 +37,10 @@ parts:
       wget https://github.com/dogecoin/dogecoin/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
       wget https://github.com/dogecoin/gitian.sigs/archive/refs/heads/master.zip
       unzip master.zip
-      echo "Verifying signatures..."
+      echo "Verifying secure hash matches signed values..."
       checksum=$(sha256sum dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz)
       if ! grep -r $checksum *; then
-        echo "Signature not verified."
+        echo "Secure hash not verified."
         return
       fi
       tar -xvf dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz


### PR DESCRIPTION
Refine Snap verification message to accurately reflect it's checking secure hashes,
not signatures. Checking signature would entail verifying there is a signature from a
trusted person, not just that the hash matches a value in the known values list.