### PR TITLE
depends: libevent 2.1.12-stable

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,8 +1,8 @@
 package=libevent
-$(package)_version=2.1.11-stable
-$(package)_download_path=https://github.com/libevent/libevent/archive/
-$(package)_file_name=release-$($(package)_version).tar.gz
-$(package)_sha256_hash=229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e
+$(package)_version=2.1.12-stable
+$(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
 
 define $(package)_preprocess_cmds
   ./autogen.sh

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,6 +3,7 @@ $(package)_version=2.1.12-stable
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+$(package)_patches = glibc_compatibility.patch
 
 define $(package)_preprocess_cmds
   ./autogen.sh
@@ -12,6 +13,10 @@ define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 -i $($(package)_patch_dir)/glibc_compatibility.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/glibc_compatibility.patch
+++ b/depends/patches/libevent/glibc_compatibility.patch
@@ -1,0 +1,14 @@
+Avoid getrandom@GLIBC_2.25 symbol.
+
+--- old/config.h.in
++++ new/config.h.in
+@@ -101,9 +101,6 @@
+ /* Define to 1 if you have the `getprotobynumber' function. */
+ #undef HAVE_GETPROTOBYNUMBER
+ 
+-/* Define to 1 if you have the `getrandom' function. */
+-#undef HAVE_GETRANDOM
+-
+ /* Define to 1 if you have the `getservbyname' function. */
+ #undef HAVE_GETSERVBYNAME
+ 


### PR DESCRIPTION
Cherry-picked from 1.21-dev (to avoid needing a windows patch from upstream bitcoin/bitcoin)