### PR TITLE
Correct #2342 - "added requirements to dependencies build README"

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -1,3 +1,51 @@
+### Prerequisites
+
+The depends system is maintained and tested using Ubuntu Trusty. Both generic
+apt packages, and packages specific to the target architecture are required to
+successfully compile all dependencies. Listed packages are tested and known to
+work.
+
+#### Generic packages
+
+```
+sudo apt-get install autoconf automake binutils-gold ca-certificates curl \
+                     faketime git-core libtool pkg-config python
+```
+
+#### Generic linux: i686-pc-linux-gnu and x86_64-linux-gnu
+
+```
+sudo apt-get install g++-4.8-multilib gcc-4.8-multilib
+```
+
+#### ARM7 32bit: arm-linux-gnueabihf
+
+```
+sudo apt-get install g++-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf \
+                     gcc-4.8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+```
+
+#### ARM 64bit: aarch64-linux-gnu
+
+```
+sudo apt-get install g++-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu \
+                     gcc-4.8-aarch64-linux-gnu binutils-aarch64-linux-gnu
+```
+
+#### Windows: i686-w64-mingw32 and x86_64-w64-mingw32
+
+```
+sudo apt-get install g++ g++-mingw-w64 mingw-w64 nsis zip
+```
+
+#### macOS (Intel): x86_64-apple-darwin11
+
+```
+sudo apt-get install g++ cmake imagemagick fonts-tuffy libz-dev libbz2-dev \
+                     libcap-dev librsvg2-bin libtiff-tools python python-dev \
+                     python-setuptools
+```
+
 ### Usage
 
 To build dependencies for the current arch+OS:
@@ -56,4 +104,3 @@ Additional targets:
 
 - [description.md](description.md): General description of the depends system
 - [packages.md](packages.md): Steps for adding packages
-

--- a/depends/README.md
+++ b/depends/README.md
@@ -1,17 +1,5 @@
 ### Usage
 
-## Requirements
-
-Before attempting to build these dependencies you should first follow the build instructions for your operating system, under the root folder:
-
-* `doc/build-unix.md`
-* `doc/build-osx.md`
-* `doc/build-windows.md`
-
-These contain up to date lists for each operating system.
-
-## Build
-
 To build dependencies for the current arch+OS:
 
     make
@@ -68,3 +56,4 @@ Additional targets:
 
 - [description.md](description.md): General description of the depends system
 - [packages.md](packages.md): Steps for adding packages
+


### PR DESCRIPTION
Reverts #2342 and adds the actual requirements.

The original PR inadvertently caused a policy change instead of adding the requirements to building with the tested set of dependencies, see post-merge discussion in said PR.


