### PR TITLE
Reduce getheaders spam by serializing getheader requests per peer

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2704,6 +2704,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseRecv = false;
     fPauseSend = false;
     nProcessQueueSize = 0;
+    nPendingHeaderRequests = 0;
 
     BOOST_FOREACH(const std::string &msg, getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -681,6 +681,9 @@ public:
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 
+    // Counts getheaders requests sent to this peer
+    std::atomic<int64_t> nPendingHeaderRequests;
+
     // Alert relay
     std::vector<CAlert> vAlertToSend;
 


### PR DESCRIPTION
Introduces a counter for getheader requests that have been sent to a peer but are pending response, reducing the number of parallel requests a node pushes out to its peers when needing to sync large amounts of headers. All getheader requests are serialized during initial sync, except when a non-connecting header is received, allowing the node to resolve issues with peers sending faulty blocks using the DoS mechanism, and when we get an inv for a block that we do not know, because it's possible we're only connected to legacy nodes that do not implement header announcement properly.

I have tested testnet and mainnet headless sync on ubuntu 20.04, have not yet fully tested QT. Syncing a clean install went from avg 18h to avg 7h, beginning to end for me.

This needs to see some further field testing on different platforms, including the qt wallet.

_Note: further optimization can be done by implementing the `TODO` on line 2337 of src/net_processing.cpp_