### PR TITLE
Fix RPC port documentation in RPC help

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -529,7 +529,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:22555/\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)


### PR DESCRIPTION
Changed RPC port from 8332 (BTC) to 22555 (Dogecoin)