### PR TITLE
[qa] reduce CodeQL triggers to exclude non-compiled code

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,10 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
+      - 'contrib'
+      - 'doc'
+      - 'share'
+      - 'qa'
 
 jobs:
   analyze:


### PR DESCRIPTION
I noticed that CodeQL was triggering unnecessarily on `qa/*`-only PRs, this fixes that by excluding all dirs that do not create production code that needs to be analyzed:

- contrib
- doc
- share
- qa
