### PR TITLE
Add build and setup instructions for NixOS

### DIFF
--- a/contrib/nixos/shell.nix
+++ b/contrib/nixos/shell.nix
@@ -1,0 +1,18 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+mkShell {
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+    openssl
+    db5
+    util-linux
+    boost
+    zlib
+    libevent
+    miniupnpc
+    qt4
+    protobuf
+    qrencode
+  ];
+}

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -285,6 +285,50 @@ or building and depending on a local version of Berkeley DB 4.8. The readily ava
 As mentioned above, when maintaining portability of the wallet between the standard Dogecoin Core distributions and independently built
 node software is desired, Berkeley DB 4.8 must be used.
 
+Setup and Build Example: NixOS
+------------------------------
+This example lists the steps necessary to setup and build a full GUI distribution of the latest changes on NixOS.
+
+Clone and enter the repo:
+
+    $ git clone https://github.com/dogecoin/dogecoin
+    $ cd dogecoin
+
+Creating a file in the root of the repository called `shell.nix` with the following contents:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+  with pkgs; mkShell {
+    nativeBuildInputs = [
+      pkg-config
+      autoreconfHook
+      openssl
+      db5
+      util-linux
+      boost
+      zlib
+      libevent
+      miniupnpc
+      qt4
+      protobuf
+      qrencode
+    ];
+}
+```
+
+Enter the `nix-shell` environment with all the Dogecoin dependencies present:
+
+    $ nix-shell
+
+Run the build steps with flags necessary for NixOS:
+
+    $ ./autogen.sh
+    $ ./configure --with-incompatible-bdb --with-boost-libdir="$(nix eval --raw nixpkgs.boost.out)/lib" --with-gui
+    $ make
+
+Start the GUI!
+
+    $ ./src/qt/dogecoin-qt
 
 ARM Cross-compilation
 -------------------

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -294,31 +294,9 @@ Clone and enter the repo:
     $ git clone https://github.com/dogecoin/dogecoin
     $ cd dogecoin
 
-Creating a file in the root of the repository called `shell.nix` with the following contents:
-
-```nix
-{ pkgs ? import <nixpkgs> {} }:
-  with pkgs; mkShell {
-    nativeBuildInputs = [
-      pkg-config
-      autoreconfHook
-      openssl
-      db5
-      util-linux
-      boost
-      zlib
-      libevent
-      miniupnpc
-      qt4
-      protobuf
-      qrencode
-    ];
-}
-```
-
 Enter the `nix-shell` environment with all the Dogecoin dependencies present:
 
-    $ nix-shell
+    $ nix-shell ./contrib/nixos/shell.nix
 
 Run the build steps with flags necessary for NixOS:
 


### PR DESCRIPTION
This PR adds build and setup instructions for compiling Dogecoin on NixOS.

It took me a while to figure out what the different dependency packages were called in NixOS and how to get `./configure` to run without failing. This mirrors the release dependencies and flags in `nixpkgs`.

I hope this is helpful!