### PR TITLE
1.14.4 mempool packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,6 @@ linux-coverage-build
 linux-build
 win32-build
 qa/pull-tester/tests_config.py
-qa/pull-tester/ltc-scrypt-master/
 qa/cache/*
 
 !src/leveldb*/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/dogecoin
 src/dogecoind
 src/dogecoin-cli
 src/dogecoin-tx
+src/bench
 src/test/test_dogecoin
 src/test/test_dogecoin_fuzzy
 src/qt/test/test_dogecoin-qt
@@ -102,6 +103,7 @@ linux-coverage-build
 linux-build
 win32-build
 qa/pull-tester/tests_config.py
+qa/pull-tester/ltc-scrypt-master/
 qa/cache/*
 
 !src/leveldb*/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ src/dogecoin
 src/dogecoind
 src/dogecoin-cli
 src/dogecoin-tx
-src/bench
 src/test/test_dogecoin
 src/test/test_dogecoin_fuzzy
 src/qt/test/test_dogecoin-qt

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -49,7 +49,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         vout = utxo[0]['vout']
         value = utxo[0]['amount']
 
-        fee = Decimal("0.0001")
+        fee = Decimal("1.0000")
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
         for i in range(MAX_ANCESTORS):


### PR DESCRIPTION
i apologize this is not atomic, i can redo .gitignore in separate pr if need be, but if not i noticed after setting up qa dependencies, vs code was tracking files within `qa/pull-tester/ltc-scrypt-master/` and after forgetting to omit benchmark in `./configure`, vs code was also tracking `src/bench` binary so added those to .gitignore.

as for the mempool_packages.py test, i bumped the fee from .0001 to 1 to fix insufficient priority err.