### PR TITLE
bugfix: break ActivateBestChain() differently on shutdown

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2504,9 +2504,6 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
     do {
-        boost::this_thread::interruption_point();
-        if (ShutdownRequested())
-            break;
 
         const CBlockIndex *pindexFork;
         ConnectTrace connectTrace;
@@ -2566,6 +2563,15 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
         if (pindexFork != pindexNewTip) {
             uiInterface.NotifyBlockTip(fInitialDownload, pindexNewTip);
         }
+
+        // Perform the shutdown detection to the end of the loop to prevent
+        // pindexNewTip being nil
+        boost::this_thread::interruption_point();
+        if (ShutdownRequested()) {
+            LogPrintf("ActivateBestChain: shutdown requested, breaking loop\n");
+            break;
+        }
+
     } while (pindexNewTip != pindexMostWork);
     CheckBlockIndex(chainparams.GetConsensus(pindexNewTip->nHeight));
 


### PR DESCRIPTION
Moves the break in ActivateBestChain() when a node is being shut down from the beginning of the loop block to the end, allowing `pindexNewTip` to be populated with at the very least `chainActive.Tip()` rather than its initial `NULL` value. Solves issues when shutting down nodes while inside the ActivateBestChain loop, which is most visible whenever qa tests are getting into a condition where shutdown is triggered while processing a new block, but this also happens on mainnet, causing unclean shutdown.

Original function was introduced with 07398e8, patched upstream with dd2de47 for a different edge-case, which is currently already ported into `1.21-dev` - so this fix applies to 1.14 only.

This fixes #2406 and is a prerequisite for 69e0b93 from #2415

Tested by running `auxpow.py` and `bumpfee.py` 100x each and verifying that at no time, `pindexNewTip` equals `NULL` when the loop ends or breaks.