### PR TITLE
Use CAmount for amounts

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -209,7 +209,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
 CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
-unsigned int nDustLimit = DEFAULT_DUST_LIMIT;
+CAmount nDustLimit = DEFAULT_DUST_LIMIT;
 
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost)
 {

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -103,7 +103,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 extern CFeeRate incrementalRelayFee;
 extern CFeeRate dustRelayFee;
 extern unsigned int nBytesPerSigOp;
-extern unsigned int nDustLimit;
+extern CAmount nDustLimit;
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -15,7 +15,8 @@ static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 
-extern unsigned int nDustLimit;
+/** An amount smaller than this is considered dust */
+extern CAmount nDustLimit;
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -36,7 +36,7 @@ std::vector<std::unique_ptr<CWalletTx>> wtxn;
 
 typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
 
-extern unsigned int nDustLimit;
+extern CAmount nDustLimit;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 


### PR DESCRIPTION
Use CAmount rather than unsigned int for amounts for consistency with other fee rate amounts.

This does change the type from unsigned int to unsigned int64, and while it is unlikely anyone would need a dust limit higher than
unsigned int, again this ensures the theoretical maximum is in line with other rates.