### PR TITLE
fees: Reduce minimum relay fee to 0.001 DOGE

### DIFF
--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -58,6 +58,7 @@ class BumpFeeTest(BitcoinTestFramework):
 
         print("Running tests")
         dest_address = peer_node.getnewaddress()
+        test_bumpfee_metadata(rbf_node, dest_address)
         test_small_output_fails(rbf_node, dest_address)
         test_dust_to_fee(rbf_node, dest_address)
         test_simple_bumpfee_succeeds(rbf_node, peer_node, dest_address)
@@ -69,7 +70,6 @@ class BumpFeeTest(BitcoinTestFramework):
         test_rebumping(rbf_node, dest_address)
         test_rebumping_not_replaceable(rbf_node, dest_address)
         test_unconfirmed_not_spendable(rbf_node, rbf_node_address)
-        test_bumpfee_metadata(rbf_node, dest_address)
         test_locked_wallet_fails(rbf_node, dest_address)
         print("Success")
 

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -639,8 +639,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         outputs = {self.nodes[3].getnewaddress() : 1}
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
         result = self.nodes[3].fundrawtransaction(rawtx) # uses min_relay_tx_fee (set by settxfee)
-        result2 = self.nodes[3].fundrawtransaction(rawtx, {"feeRate": 2*min_relay_tx_fee})
-        result3 = self.nodes[3].fundrawtransaction(rawtx, {"feeRate": 10*min_relay_tx_fee})
+        # TODO: We massively scale up min_relay_tx_fee here as it's not the recommended fee in 1.14.4,
+        # but must be scaled back for 1.14.5
+        result2 = self.nodes[3].fundrawtransaction(rawtx, {"feeRate": 2000*min_relay_tx_fee})
+        result3 = self.nodes[3].fundrawtransaction(rawtx, {"feeRate": 10000*min_relay_tx_fee})
         result_fee_rate = result['fee'] * 1000 / round_tx_size(count_bytes(result['hex']))
         assert_fee_amount(result2['fee'], count_bytes(result2['hex']), 2 * result_fee_rate)
         assert_fee_amount(result3['fee'], count_bytes(result3['hex']), 10 * result_fee_rate)

--- a/qa/rpc-tests/harddustlimit.py
+++ b/qa/rpc-tests/harddustlimit.py
@@ -33,7 +33,7 @@ class HardDustLimitTest(BitcoinTestFramework):
 
     def run_test(self):
 
-        self.fee = Decimal("1")
+        self.fee = Decimal("0.001")
         self.seed = 1000
         self.coinselector = {'minimumAmount': self.fee * 10, 'maximumAmount': self.seed}
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -40,7 +40,8 @@ class MempoolLimitTest(BitcoinTestFramework):
         txid = self.nodes[0].sendrawtransaction(txFS['hex'])
 
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-        base_fee = relayfee*100
+        # TODO: Remove "* 1000" in 1.14.5 when relayfee and minimum fee are close to each other again.
+        base_fee = relayfee*100 * 1000
         for i in range (6):
             txids.append([])
             txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -33,7 +33,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
     def run_test(self):
         utxo_count = 90
         utxos = create_confirmed_utxos(self.relayfee, self.nodes[0], utxo_count)
-        base_fee = self.relayfee*100 # our transactions are smaller than 100kb
+        base_fee = self.relayfee*100 * 1000 # our transactions are smaller than 100kb
         txids = []
 
         # Create 3 batches of transactions at 3 different fee rate levels

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -21,7 +21,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = COIN / 100;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/validation.h
+++ b/src/validation.h
@@ -54,7 +54,7 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const CAmount DEFAULT_MIN_RELAY_TX_FEE = COIN;
+static const CAmount DEFAULT_MIN_RELAY_TX_FEE = COIN / 1000;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 400 * COIN;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB


### PR DESCRIPTION
This loosens the minimum set of fee values for 1.14.4 to enable the rest in 1.14.5. Please review the figures, they should match the proposal, if not do let us know. If any values need to change for 1.14.4 and have been missed, equally let us know. Otherwise we'll raise the second set as a follow-on PR.