### PR TITLE
qt: translate all user-exposed strings

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -517,7 +517,7 @@ void BitcoinApplication::shutdownResult(int retval)
 
 void BitcoinApplication::handleRunawayException(const QString &message)
 {
-    QMessageBox::critical(0, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. Dogecoin can no longer continue safely and will quit.") + QString("\n\n") + message);
+    QMessageBox::critical(0, BitcoinGUI::tr("Runaway exception"), BitcoinGUI::tr("A fatal error occurred. Dogecoin can no longer continue safely and will quit.") + QString("\n\n") + message);
     ::exit(EXIT_FAILURE);
 }
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -261,7 +261,7 @@ void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
 
 void Intro::on_ellipsisButton_clicked()
 {
-    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(0, "Choose data directory", ui->dataDirectory->text()));
+    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(0, tr("Choose data directory"), ui->dataDirectory->text()));
     if(!dir.isEmpty())
         ui->dataDirectory->setText(dir);
 }

--- a/src/qt/peerdialog.cpp
+++ b/src/qt/peerdialog.cpp
@@ -118,7 +118,7 @@ void AddPeerDialog::on_addPeer_clicked()
 
     if(!PeerTools::CheckPeerAddress(address))
     {
-        QMessageBox::critical(this, tr("Add Peer"), tr("Please enter a vaild peer address."), QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Add Peer"), tr("Please enter a valid peer address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 
@@ -165,7 +165,7 @@ void TestPeerDialog::on_testPeer_clicked()
 
     if(!PeerTools::CheckPeerAddress(address))
     {
-        QMessageBox::critical(this, tr("Test Peer"), tr("Please enter a vaild peer address."), QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Test Peer"), tr("Please enter a valid peer address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 

--- a/src/qt/peerdialog.cpp
+++ b/src/qt/peerdialog.cpp
@@ -35,37 +35,37 @@ QString PeerTools::ManagePeer(QString type, QString peer)
     std::string peerAddress = peer.toStdString();
 
     if(!g_connman)
-        return "Error: Peer-to-peer functionality missing or disabled";
+        return tr("Error: Peer-to-peer functionality missing or disabled");
 
     if (type == "onetry")
     {
         CAddress addr;
         g_connman->OpenNetworkConnection(addr, false, NULL, peerAddress.c_str());
-        return "Attempted to one try node.";
+        return tr("Attempted to one try node.");
     }
 
     if (type == "add")
     {
         if(!g_connman->AddNode(peerAddress))
-            return "Error: Node already added";
+            return tr("Error: Node already added");
     }
     else if(type == "remove")
     {
         if(!g_connman->RemoveAddedNode(peerAddress))
         {
             if(!g_connman->DisconnectNode(peerAddress))
-                return "Node not found in connected nodes";
+                return tr("Node not found in connected nodes");
 
-            return "Disconnected the node: " + peer;
+            return tr("Disconnected the node: ") + peer;
         }
         else
         {
             if(!g_connman->DisconnectNode(peerAddress))
-                return "Node not found in connected nodes";
+                return tr("Node not found in connected nodes");
         }
     }
 
-    return "Returned OK.";
+    return tr("Returned OK.");
 }
 
 /** Check if Peer is valid */
@@ -106,7 +106,7 @@ void AddPeerDialog::on_addPeer_clicked()
 
     if(address.isEmpty()) 
     {
-        QMessageBox::critical(this, "Add Peer", "Please enter an address.", QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Add Peer"), tr("Please enter an address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 
@@ -118,13 +118,13 @@ void AddPeerDialog::on_addPeer_clicked()
 
     if(!PeerTools::CheckPeerAddress(address))
     {
-        QMessageBox::critical(this, "Add Peer", "Please enter a vaild peer address.", QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Add Peer"), tr("Please enter a vaild peer address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 
     data = address + ":" + port;
 
-    if(QMessageBox::Ok == QMessageBox::information(this, "Add Peer", PeerTools::ManagePeer("add", data), QMessageBox::Ok, QMessageBox::Ok))
+    if(QMessageBox::Ok == QMessageBox::information(this, tr("Add Peer"), PeerTools::ManagePeer("add", data), QMessageBox::Ok, QMessageBox::Ok))
         this->close();
 }
 
@@ -153,7 +153,7 @@ void TestPeerDialog::on_testPeer_clicked()
 
     if(address.isEmpty()) 
     {
-        QMessageBox::critical(this, "Test Peer", "Please enter an address.", QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Test Peer"), tr("Please enter an address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 
@@ -165,12 +165,12 @@ void TestPeerDialog::on_testPeer_clicked()
 
     if(!PeerTools::CheckPeerAddress(address))
     {
-        QMessageBox::critical(this, "Test Peer", "Please enter a vaild peer address.", QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Test Peer"), tr("Please enter a vaild peer address."), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 
     data = address + ":" + port;
 
-    if(QMessageBox::Ok == QMessageBox::information(this, "Try Peer", PeerTools::ManagePeer("onetry", data), QMessageBox::Ok, QMessageBox::Ok))
+    if(QMessageBox::Ok == QMessageBox::information(this, tr("Try Peer"), PeerTools::ManagePeer("onetry", data), QMessageBox::Ok, QMessageBox::Ok))
         this->close();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -840,7 +840,7 @@ void RPCConsole::on_lineEdit_returnPressed()
                 throw std::runtime_error("Invalid command line");
             }
         } catch (const std::exception& e) {
-            QMessageBox::critical(this, "Error", QString("Error: ") + QString::fromStdString(e.what()));
+            QMessageBox::critical(this, tr("Error"), QString("Error: ") + QString::fromStdString(e.what()));
             return;
         }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -946,14 +946,14 @@ void RPCConsole::on_removePeer_clicked()
     {
         QString address = ips[0].data().toString();
 
-        if(QMessageBox::Yes == QMessageBox::question(this, "Remove Peer", "Are you sure you want to remove the peer: " + address + "?", QMessageBox::Yes | QMessageBox::No))
+        if(QMessageBox::Yes == QMessageBox::question(this, tr("Remove Peer"), tr("Are you sure you want to remove the peer: ") + address + "?", QMessageBox::Yes | QMessageBox::No))
         {
-            QMessageBox::information(this, "Remove Peer", PeerTools::ManagePeer("remove", address), QMessageBox::Ok, QMessageBox::Ok);
+            QMessageBox::information(this, tr("Remove Peer"), PeerTools::ManagePeer("remove", address), QMessageBox::Ok, QMessageBox::Ok);
         }
 
     } else 
     {
-        QMessageBox::information(this, "Remove Peer", "No peer was selected.", QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::information(this, tr("Remove Peer"), tr("No peer was selected."), QMessageBox::Ok, QMessageBox::Ok);
     }
 }
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -192,9 +192,9 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
                             strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
                         strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(address).ToString());
                         if(toSelf == ISMINE_SPENDABLE)
-                            strHTML += " (own address)";
+                            strHTML += " (" + tr("own address") + ")";
                         else if(toSelf & ISMINE_WATCH_ONLY)
-                            strHTML += " (watch-only)";
+                            strHTML += " (" + tr("watch-only") + ")";
                         strHTML += "<br>";
                     }
                 }

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -217,7 +217,7 @@ void PaperWalletDialog::setClientModel(ClientModel *_clientModel)
 
     // FIXME: This cannot be the right way of doing something on open
     if (_clientModel && _clientModel->getNetworkActive()) {
-        QMessageBox::critical(this, "Warning: Network Activity Detected", tr("It is recommended to disconnect from the internet before printing paper wallets. Even though paper wallets are generated on your local computer, it is still possible to unknowingly have malware that transmits your screen to a remote location. It is also recommended to print to a local printer vs a network printer since that network traffic can be monitored. Some advanced printers also store copies of each printed document. Proceed with caution relative to the amount of value you plan to store on each address."), QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Warning: Network Activity Detected"), tr("It is recommended to disconnect from the internet before printing paper wallets. Even though paper wallets are generated on your local computer, it is still possible to unknowingly have malware that transmits your screen to a remote location. It is also recommended to print to a local printer vs a network printer since that network traffic can be monitored. Some advanced printers also store copies of each printed document. Proceed with caution relative to the amount of value you plan to store on each address."), QMessageBox::Ok, QMessageBox::Ok);
     }
 }
 
@@ -361,7 +361,7 @@ void PaperWalletDialog::on_printButton_clicked()
 
     QPainter painter;
     if (!painter.begin(&printer)) { // failed to open file
-        QMessageBox::critical(this, "Printing Error", tr("failed to open file, is it writable?"), QMessageBox::Ok, QMessageBox::Ok);
+        QMessageBox::critical(this, tr("Printing Error"), tr("failed to open file, is it writable?"), QMessageBox::Ok, QMessageBox::Ok);
         return;
     }
 


### PR DESCRIPTION
fixes some missed `tr()` wrappings from the newly created peer management dialogs and debug console screens. Needed to do a fresh set of translations. I haven't found anything else that is not translated in a diff from bitcoin 0.14.1 to current 1.14.4-dev.