### PR TITLE
qa: fix p2p-acceptblock

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -116,6 +116,7 @@ testScripts = [
     'wallet-dump.py',
     'listtransactions.py',
     # vv Tests less than 60s vv
+    'p2p-acceptblock.py',
     'sendheaders.py',
     'zapwallettxes.py',
     'importmulti.py',
@@ -191,7 +192,6 @@ testScriptsExt = [
     'forknotify.py',
     'invalidateblock.py',
     'maxblocksinflight.py',
-    'p2p-acceptblock.py',
 ]
 
 

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -39,7 +39,7 @@ The test:
    it's missing an intermediate block.
    Node1 should reorg to this longer chain.
 
-4b.Send 288 more blocks on the longer chain.
+4b.Send 1440 more blocks on the longer chain.
    Node0 should process all but the last block (too far ahead in height).
    Send all headers to Node1, and then send the last block in that chain.
    Node1 should accept the block because it's coming from a whitelisted peer.
@@ -206,14 +206,14 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 3)
         print("Successfully reorged to length 3 chain from whitelisted peer")
 
-        # 4b. Now mine 288 more blocks and deliver; all should be processed but
+        # 4b. Now mine 1440 more blocks and deliver; all should be processed but
         # the last (height-too-high) on node0.  Node1 should process the tip if
         # we give it the headers chain leading to the tip.
         tips = blocks_h3
         headers_message = msg_headers()
         all_blocks = []   # node0's blocks
         for j in range(2):
-            for i in range(288):
+            for i in range(1440):
                 next_block = create_block(tips[j].sha256, create_coinbase(i + 4), tips[j].nTime+1)
                 next_block.solve()
                 if j==0:
@@ -224,7 +224,7 @@ class AcceptBlockTest(BitcoinTestFramework):
                 tips[j] = next_block
 
         time.sleep(2)
-        # Blocks 1-287 should be accepted, block 288 should be ignored because it's too far ahead
+        # Blocks 1-1439 should be accepted, block 1440 should be ignored because it's too far ahead
         for x in all_blocks[:-1]:
             self.nodes[0].getblock(x.hash)
         assert_raises_jsonrpc(-1, "Block not found on disk", self.nodes[0].getblock, all_blocks[-1].hash)
@@ -270,7 +270,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(msg_block(blocks_h2f[0]))
 
         test_node.sync_with_ping()
-        assert_equal(self.nodes[0].getblockcount(), 290)
+        assert_equal(self.nodes[0].getblockcount(), 1442)
         print("Successfully reorged to longer chain from non-whitelisted peer")
 
         [ c.disconnect_node() for c in connections ]

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -11,7 +11,7 @@ from .script import CScript, OP_TRUE, OP_CHECKSIG, OP_RETURN
 def create_block(hashprev, coinbase, nTime=None):
     block = CBlock()
     # Dogecoin: Create a non-AuxPoW block but include chain ID
-    block.nVersion = 0x620003
+    block.nVersion = 0x620004
     if nTime is None:
         import time
         block.nTime = int(time.time()+600)


### PR DESCRIPTION
This test failed because the sheer number of blocks required to trigger the max length of a fork we'd keep, exceed the v4 fork height on regtest.

- Adapted the blocktools.py miner to mine 0x00620004 blocks as done elsewhere too (be it suboptimal, but at least consistent)
- Adapted the test to work with 1440 blocks (Dogecoin limit) instead of 288 (Bitcoin limit)
- Made p2p-acceptblock a standard test instead of an extended test

Alternative to #2412 