### PR TITLE
qa: txn_dblspend - fix arithmetic

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -128,7 +128,7 @@ testScripts = [
     'reindex.py',
     # vv Tests less than 30s vv
     'mempool_resurrect_test.py',
-    #'txn_doublespend.py --mineblock',
+    'txn_doublespend.py --mineblock',
     'txn_clone.py',
     'getchaintips.py',
     'rest.py',

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -34,40 +34,40 @@ class TxnMallTest(BitcoinTestFramework):
         
         # Assign coins to foo and bar accounts:
         node0_address_foo = self.nodes[0].getnewaddress("foo")
-        fund_foo_txid = self.nodes[0].sendfrom("", node0_address_foo, 7499970)
+        fund_foo_txid = self.nodes[0].sendfrom("", node0_address_foo, 7314000)
         fund_foo_tx = self.nodes[0].gettransaction(fund_foo_txid)
 
         node0_address_bar = self.nodes[0].getnewaddress("bar")
-        fund_bar_txid = self.nodes[0].sendfrom("", node0_address_bar, 30)
+        fund_bar_txid = self.nodes[0].sendfrom("", node0_address_bar, 174000)
         fund_bar_tx = self.nodes[0].gettransaction(fund_bar_txid)
 
         assert_equal(self.nodes[0].getbalance(""),
-                     starting_balance - 1219 - 29 + fund_foo_tx["fee"] + fund_bar_tx["fee"])
+                     starting_balance - 7314000 - 174000 + fund_foo_tx["fee"] + fund_bar_tx["fee"])
 
         # Coins are sent to node1_address
         node1_address = self.nodes[1].getnewaddress("from0")
 
-        # First: use raw transaction API to send 7499960 DOGE to node1_address,
+        # First: use raw transaction API to send 7440000 DOGE to node1_address,
         # but don't broadcast:
-        doublespend_fee = Decimal('-2')
+        doublespend_fee = Decimal('-120')
         rawtx_input_0 = {}
         rawtx_input_0["txid"] = fund_foo_txid
-        rawtx_input_0["vout"] = find_output(self.nodes[0], fund_foo_txid, 1219)
+        rawtx_input_0["vout"] = find_output(self.nodes[0], fund_foo_txid, 7314000)
         rawtx_input_1 = {}
         rawtx_input_1["txid"] = fund_bar_txid
-        rawtx_input_1["vout"] = find_output(self.nodes[0], fund_bar_txid, 29)
+        rawtx_input_1["vout"] = find_output(self.nodes[0], fund_bar_txid, 174000)
         inputs = [rawtx_input_0, rawtx_input_1]
         change_address = self.nodes[0].getnewaddress()
         outputs = {}
-        outputs[node1_address] = 7499960
-        outputs[change_address] = 7499998 - 1219 + doublespend_fee
+        outputs[node1_address] = 7440000
+        outputs[change_address] = 7488000 - 7440000 + doublespend_fee
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         doublespend = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(doublespend["complete"], True)
 
-        # Create two spends using 1 50 BTC coin each
-        txid1 = self.nodes[0].sendfrom("foo", node1_address, 7499960, 0)
-        txid2 = self.nodes[0].sendfrom("bar", node1_address, 20, 0)
+        # Create two spends
+        txid1 = self.nodes[0].sendfrom("foo", node1_address, 240000, 0)
+        txid2 = self.nodes[0].sendfrom("bar", node1_address, 120000, 0)
         
         # Have node0 mine a block:
         if (self.options.mine_block):
@@ -78,7 +78,7 @@ class TxnMallTest(BitcoinTestFramework):
         tx2 = self.nodes[0].gettransaction(txid2)
 
         # Node0's balance should be starting balance, plus 500,000 DOGE for another
-        # matured block, minus 7499960, minus 20, and minus transaction fees:
+        # matured block, minus 7499960, minus 120000, and minus transaction fees:
         expected = starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"]
         if self.options.mine_block: expected += 500000
         expected += tx1["amount"] + tx1["fee"]
@@ -86,8 +86,8 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), expected)
 
         # foo and bar accounts should be debited:
-        assert_equal(self.nodes[0].getbalance("foo", 0), 7499970+tx1["amount"]+tx1["fee"])
-        assert_equal(self.nodes[0].getbalance("bar", 0), 30+tx2["amount"]+tx2["fee"])
+        assert_equal(self.nodes[0].getbalance("foo", 0), 7314000+tx1["amount"]+tx1["fee"])
+        assert_equal(self.nodes[0].getbalance("bar", 0), 174000+tx2["amount"]+tx2["fee"])
 
         if self.options.mine_block:
             assert_equal(tx1["confirmations"], 1)
@@ -119,28 +119,28 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(tx1["confirmations"], -2)
         assert_equal(tx2["confirmations"], -2)
 
-        # Node0's total balance should be starting balance, plus 100BTC for 
-        # two more matured blocks, minus 1240 for the double-spend, plus fees (which are
+        # Node0's total balance should be starting balance, plus 1000000 DOGE for 
+        # two more matured blocks, minus 7440000 for the double-spend, plus fees (which are
         # negative):
-        expected = starting_balance + 1000000 - 7499960 + fund_foo_tx["fee"] + fund_bar_tx["fee"] + doublespend_fee
+        expected = starting_balance + 1000000 - 7440000 + fund_foo_tx["fee"] + fund_bar_tx["fee"] + doublespend_fee
         assert_equal(self.nodes[0].getbalance(), expected)
         assert_equal(self.nodes[0].getbalance("*"), expected)
 
         # Final "" balance is starting_balance - amount moved to accounts - doublespend + subsidies +
         # fees (which are negative)
-        assert_equal(self.nodes[0].getbalance("foo"), 7499970-7499960)
-        assert_equal(self.nodes[0].getbalance("bar"), 30)
+        assert_equal(self.nodes[0].getbalance("foo"), 7314000)
+        assert_equal(self.nodes[0].getbalance("bar"), 174000)
         assert_equal(self.nodes[0].getbalance(""), starting_balance
-                                                              -1219
-                                                              -  29
-                                                              -1240
-                                                              + 100
+                                                              -7314000
+                                                              - 174000
+                                                              -7440000
+                                                              + 1000000
                                                               + fund_foo_tx["fee"]
                                                               + fund_bar_tx["fee"]
                                                               + doublespend_fee)
 
         # Node1's "from0" account balance should be just the doublespend:
-        assert_equal(self.nodes[1].getbalance("from0"), 7499960)
+        assert_equal(self.nodes[1].getbalance("from0"), 7440000)
 
 if __name__ == '__main__':
     TxnMallTest().main()


### PR DESCRIPTION
as a starting point i compared 7,500,000 DOGE to the initially set value of 1250 BTC in https://github.com/bitcoin/bitcoin/blob/v0.14.3/qa/rpc-tests/txn_doublespend.py and found that 7500000 / 1250 = 6000 so with that i went down the line on the original test and multiplied the numbers by 6000 to make everything proportionally uniform with exception to the 100 on L137 which was multiplied by 10,000.