### PR TITLE
rpc: add feefilter to peers from getpeerinfo

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -658,6 +658,7 @@ void CNode::copyStats(CNodeStats &stats)
         X(nRecvBytes);
     }
     X(fWhitelisted);
+    X(minFeeFilter);
 
     // It is common for nodes with good ping times to suddenly become lagged,
     // due to a new block arriving or other large transfer.

--- a/src/net.h
+++ b/src/net.h
@@ -510,6 +510,7 @@ public:
     double dMinPing;
     std::string addrLocal;
     CAddress addr;
+    CAmount minFeeFilter;
 };
 
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,6 +16,7 @@
 #include "timedata.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "version.h"
 
@@ -95,6 +96,7 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
             "    \"inbound\": true|false,     (boolean) Inbound (true) or Outbound (false)\n"
             "    \"addnode\": true|false,     (boolean) Whether connection was due to addnode and is using an addnode slot\n"
             "    \"startingheight\": n,       (numeric) The starting height (block) of the peer\n"
+            "    \"feefilter\": \"decimal\",  (string)  The value of the last feefilter set by this peer, in DOGE\n"
             "    \"banscore\": n,             (numeric) The ban score\n"
             "    \"synced_headers\": n,       (numeric) The last header we have in common with this peer\n"
             "    \"synced_blocks\": n,        (numeric) The last block we have in common with this peer\n"
@@ -157,6 +159,7 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("addnode", stats.fAddnode));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
+        obj.push_back(Pair("feefilter", FormatMoney(stats.minFeeFilter)));
         if (fStateStats) {
             obj.push_back(Pair("banscore", statestats.nMisbehavior));
             obj.push_back(Pair("synced_headers", statestats.nSyncHeight));


### PR DESCRIPTION
Exposes information about the feefilter the peer sets to us, so that we can make better informed decisions when a transaction does not get relayed.