### PR TITLE
1.14.4 outbound peers disconnect implement #2283

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1189,8 +1189,7 @@ inline void static SendBlockTransactions(const CBlock& block, const BlockTransac
     connman.PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCKTXN, resp));
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman& connman, const std::atomic<bool>& interruptMsgProc)
-{
+bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman& connman, const std::atomic<bool>& interruptMsgProc, bool punish_duplicate_invalid = false ){
     LogPrint("net", "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->id);
     if (IsArgSet("-dropmessagestest") && GetRand(GetArg("-dropmessagestest", 0)) == 0)
     {
@@ -1995,13 +1994,58 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         const CBlockIndex *pindex = NULL;
         CValidationState state;
-        if (!ProcessNewBlockHeaders({cmpctblock.header}, state, chainparams, &pindex)) {
+        CBlockHeader first_invalid_header;
+        if (!ProcessNewBlockHeaders({cmpctblock.header}, state, chainparams, &pindex, &first_invalid_header)) {
             int nDoS;
             if (state.IsInvalid(nDoS)) {
                 if (nDoS > 0) {
                     LOCK(cs_main);
                     Misbehaving(pfrom->GetId(), nDoS);
                 }
+
+                if ( mapBlockIndex.find(first_invalid_header.GetHash()) != mapBlockIndex.end()) {
+                      // TODO: The documentation below is from bitcoin's commit 37886d5e2f. 
+                      //       This implementation will disconnect outbound connections on invalid
+                      //       headers even when the blocks are compact, which under BIP 152 they
+                      //       are allowed to be invalid under some scenarios. The implementation
+                      //       that disconnects on all the right scenarios under the right conditions
+                      //       needs to written and is a significant amount of work.
+
+
+                      // Goal: don't allow outbound peers to use up our outbound
+                      // connection slots if they are on incompatible chains.
+                      //
+                      // We ask the caller to set punish_invalid appropriately based
+                      // on the peer and the method of header delivery (compact
+                      // blocks are allowed to be invalid in some circumstances,
+                      // under BIP 152).
+                      // Here, we try to detect the narrow situation that we have a
+                      // valid block header (ie it was valid at the time the header
+                      // was received, and hence stored in mapBlockIndex) but know the
+                      // block is invalid, and that a peer has announced that same
+                      // block as being on its active chain.
+                      // Disconnect the peer in such a situation.
+                      //
+                      // Note: if the header that is invalid was not accepted to our
+                      // mapBlockIndex at all, that may also be grounds for
+                      // disconnecting the peer, as the chain they are on is likely
+                      // to be incompatible. However, there is a circumstance where
+                      // that does not hold: if the header's timestamp is more than
+                      // 2 hours ahead of our current time. In that case, the header
+                      // may become valid in the future, and we don't want to
+                      // disconnect a peer merely for serving us one too-far-ahead
+                      // block header, to prevent an attacker from splitting the
+                      // network by mining a block right at the 2 hour boundary.
+                      //
+                      // TODO: update the DoS logic (or, rather, rewrite the
+                      // DoS-interface between validation and net_processing) so that
+                      // the interface is cleaner, and so that we disconnect on all the
+                      // reasons that a peer's headers chain is incompatible
+                      // with ours (eg block->nVersion softforks, MTP violations,
+                      // etc), and not just the duplicate-invalid case.
+                      pfrom->fDisconnect = true;
+                }
+
                 LogPrintf("Peer %d sent us invalid header via cmpctblock\n", pfrom->id);
                 return true;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3192,21 +3192,24 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
     return true;
 }
 
+
 // Exposed wrapper for AcceptBlockHeader
-bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex)
+bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex, CBlockHeader *first_invalid )
 {
-    {
+    if (first_invalid != NULL) first_invalid->SetNull();
+    {    
         LOCK(cs_main);
         for (const CBlockHeader& header : headers) {
-            CBlockIndex *pindex = NULL; // Use a temp pindex instead of ppindex to avoid a const_cast
+            CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
             if (!AcceptBlockHeader(header, state, chainparams, &pindex)) {
+                if (first_invalid) *first_invalid = header;
                 return false;
             }
             if (ppindex) {
                 *ppindex = pindex;
             }
         }
-    }
+    }    
     NotifyHeaderTip();
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -247,9 +247,10 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
  * @param[in]  block The block headers themselves
  * @param[out] state This may be set to an Error state if any error occurred processing them
  * @param[in]  chainparams The params for the chain we want to connect to
+ * @param[out] store the invalid block here if there is one. 
  * @param[out] ppindex If set, the pointer will be set to point to the last new block index object for the given headers
  */
-bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex=NULL);
+bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex=NULL, CBlockHeader *first_invalid = NULL);
 
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);


### PR DESCRIPTION
#2283 Suggested fix. However, it will disconnect outbound connection even if the invalid header comes from a compact block, which under BIP 152 there are scenarios where that is allowed.

We need a test for this. I would write it, but don't know how to. If someone can take care of that, or teach me how to do it, that would be great.

@rnicoll @patricklodder @michilumin 