### PR TITLE
 [ Improvement ] Backport from 1.21-dev. The entropy whence the priva…

### DIFF
--- a/src/random.h
+++ b/src/random.h
@@ -10,6 +10,13 @@
 
 #include <stdint.h>
 
+/* Number of random bytes returned by GetOSRand.
+ * When changing this constant make sure to change all call sites, and make
+ * sure that the underlying OS APIs for all platforms support the number.
+ * (many cap out at 256 bytes).
+ */
+static const int NUM_OS_RANDOM_BYTES = 32;
+
 /* Seed OpenSSL PRNG with additional entropy data */
 void RandAddSeed();
 


### PR DESCRIPTION
 Backport from 1.21-dev. The entropy whence the private keys for wallets are generated needs to be cryptographically secure not merely computationally secure.

Some distros handle RNGs differently, some of that is addressed in this backport from 1.21-dev. If all fails, fallback on /dev/urandom.

 

Call tree that leads to this function call:

![Screenshot from 2021-08-18 21-19-01](https://user-images.githubusercontent.com/6852543/129992648-5f162f49-3f6c-4fe7-8536-197897c92be7.png)

The function    GetOSRand( )  gets called here:
https://github.com/dogecoin/dogecoin/blob/f80bfe9068ac1a0619d48dad0d268894d926941e/src/random.cpp#L132-L151

Hashing SSL's RNG with GetOSRand( ) mitigates this some. But, this is an improvement nonetheless, per Linux docs:

https://github.com/torvalds/linux/blob/a4a78bc8ead44c3cdb470c6e1f37afcabdddfc14/drivers/char/random.c#L110-L121
. 


@patricklodder @rnicoll @michilumin