### PR TITLE
Update Unix build instructions

### DIFF
--- a/doc/build-archlinux.md
+++ b/doc/build-archlinux.md
@@ -1,5 +1,8 @@
 Arch Linux build guide
 -----------------------------------
+
+***NOTE: This documentation is outdated and needs to be updated***
+
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
     pacman -S git base-devel boost libevent python

--- a/doc/build-archlinux.md
+++ b/doc/build-archlinux.md
@@ -1,0 +1,17 @@
+Arch Linux build guide
+-----------------------------------
+This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
+
+    pacman -S git base-devel boost libevent python
+    git clone https://github.com/bitcoin/bitcoin.git
+    cd bitcoin/
+    ./autogen.sh
+    ./configure --disable-wallet --without-gui --without-miniupnpc
+    make check
+
+Note:
+Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
+or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
+`--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
+As mentioned above, when maintaining portability of the wallet between the standard Dogecoin Core distributions and independently built
+node software is desired, Berkeley DB 4.8 must be used.

--- a/doc/build-fedora.md
+++ b/doc/build-fedora.md
@@ -1,6 +1,8 @@
 Fedora build dependencies
 --------------------------
 
+***NOTE: This documentation is outdated and needs to be updated***
+
 Build requirements:
 
     sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel

--- a/doc/build-fedora.md
+++ b/doc/build-fedora.md
@@ -1,0 +1,18 @@
+Fedora build dependencies
+--------------------------
+
+Build requirements:
+
+    sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
+
+Optional:
+
+    sudo dnf install miniupnpc-devel
+
+To build with Qt 5 (recommended) you need the following:
+
+    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
+
+libqrencode (optional) can be installed with:
+
+    sudo dnf install qrencode-devel

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,6 +1,8 @@
 Building on FreeBSD
 --------------------
 
+***NOTE: This documentation is outdated and needs to be updated***
+
 (Updated as of FreeBSD 11.0)
 
 Clang is installed by default as `cc` compiler, this makes it easier to get

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,0 +1,33 @@
+Building on FreeBSD
+--------------------
+
+(Updated as of FreeBSD 11.0)
+
+Clang is installed by default as `cc` compiler, this makes it easier to get
+started than on [OpenBSD](build-openbsd.md). Installing dependencies:
+
+    pkg install autoconf automake libtool pkgconf
+    pkg install boost-libs openssl libevent
+    pkg install gmake
+
+You need to use GNU make (`gmake`) instead of `make`.
+(`libressl` instead of `openssl` will also work)
+
+For the wallet (optional):
+
+    pkg install db5
+
+This will give a warning "configure: WARNING: Found Berkeley DB other
+than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
+had a binary release, this may not matter. If backwards compatibility
+with 4.8-built Dogecoin Core is needed follow the steps under "Berkeley DB" above.
+
+Then build using:
+
+    ./autogen.sh
+    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
+    gmake
+
+*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
+It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
+use the versioned gdb command e.g. `gdb7111`.

--- a/doc/build-nixos.md
+++ b/doc/build-nixos.md
@@ -1,0 +1,23 @@
+NixOS build guide
+------------------------------
+This guide lists the steps necessary to setup and build a full GUI distribution
+of the latest changes on NixOS.
+
+Clone and enter the repo:
+
+    $ git clone https://github.com/dogecoin/dogecoin
+    $ cd dogecoin
+
+Enter the `nix-shell` environment with all the Dogecoin dependencies present:
+
+    $ nix-shell ./contrib/nixos/shell.nix
+
+Run the build steps with flags necessary for NixOS:
+
+    $ ./autogen.sh
+    $ ./configure --with-incompatible-bdb --with-boost-libdir="$(nix eval --raw nixpkgs.boost.out)/lib" --with-gui
+    $ make
+
+Start the GUI!
+
+    $ ./src/qt/dogecoin-qt

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,5 +1,8 @@
 OpenBSD build guide
 ======================
+
+***NOTE: This documentation is outdated and needs to be updated***
+
 (updated for OpenBSD 6.0)
 
 This guide describes how to build dogecoind and command-line utilities on OpenBSD.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,35 +1,26 @@
-UNIX BUILD NOTES
-====================
-Some notes on how to build Dogecoin Core in Unix.
+# Unix Build of Dogecoin Core
 
-(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+1. [Install dependencies](#install-dependencies)
+    * [Ubuntu & Debian](#ubuntu--debian)
+    * [Fedora](#Fedora)
+    * [FreeBSD](#FreeBSD)
+2. [Build steps](#build-steps)
+3. [Build configuration](#build-configuration)
+    * [Enable Qt GUI](#enable-qt-gui)
+    * [Wallet](#wallet)
+    * [Disable-wallet mode](#disable-wallet-mode)
+    * [Miniupnpc](#miniupnpc)
+    * [Security](#security)
+    * [Memory requirements](#memory-requirements)
+4. [ARM Cross-compilation](#arm-cross-compilation)
 
-Note
----------------------
-Always use absolute paths to configure and compile Dogecoin and the dependencies,
-for example, when specifying the path of the dependency:
+## Install dependencies
 
-	../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+You must install required dependencies to build a basic Dogecoin daemon, optional dependencies may vary according to your requirements.
 
-Here BDB_PREFIX must be an absolute path - it is defined using $(pwd) which ensures
-the usage of the absolute path.
+Wallet is optional to run a node, see [Wallet](#wallet) section to enable them.
 
-To Build
----------------------
-
-```bash
-./autogen.sh
-./configure
-make
-make install # optional
-```
-
-This will build Dogecoin-Qt as well if the dependencies are met.
-
-Dependencies
----------------------
-
-These dependencies are required:
+**Required dependencies :**
 
  Library     | Purpose          | Description
  ------------|------------------|----------------------
@@ -37,7 +28,7 @@ These dependencies are required:
  libboost    | Utility          | Library for threading, data structures, etc
  libevent    | Networking       | OS independent asynchronous networking
 
-Optional dependencies:
+**Optional dependencies:**
 
  Library     | Purpose          | Description
  ------------|------------------|----------------------
@@ -51,147 +42,120 @@ Optional dependencies:
 
 For the versions used in the release, see [release-process.md](release-process.md) under *Fetch and build inputs*.
 
-Memory Requirements
---------------------
 
-C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
-memory available when compiling Dogecoin Core. On systems with less, gcc can be
-tuned to conserve memory with additional CXXFLAGS:
+### Ubuntu & Debian
 
-    ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+**Required dependencies** :
+```bash
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
+sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+```
 
-Dependency Build Instructions: Ubuntu & Debian
-----------------------------------------------
-Build requirements:
+**Optional dependencies** :  
+```bash
+# Qt (required for dogecoin-qt GUI)
+sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
+# BerkeleyDB (version 5.3)
+sudo apt install libdb5.3++-dev libdb5.3++ libdb5.3-dev
 
-Options when installing required Boost library files:
+# ZMQ (provides ZMQ API 4.x)
+sudo apt-get install libzmq3-dev
 
-1. On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
-individual boost development packages, so the following can be used to only
-install necessary parts of boost:
+# Miniupnpc
+sudo apt-get install libminiupnpc-dev
+```
 
-        sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+## Build steps
 
-2. If that doesn't work, you can install all boost development packages with:
+According to installed dependencies, the following steps will compile `dogecoind`, `dogecoin-cli` and `dogecoin-qt`.
 
-        sudo apt-get install libboost-all-dev
+```bash
+./autogen.sh
+./configure
+make
+make install # optional
+```
+See [Build configuration](#build-configuration) for extra settings.
 
-BerkeleyDB is required for the wallet.
+## Build configuration
 
-    sudo apt-get install libdb5.1-dev libdb5.1++-dev
+Configurations are done during the `./configure` step. Use `--help` to see all available options.
 
-       Note that if you have Berkeley DB 4.8 packages installed (i.e. for other
-       wallet software), they are incompatible with the packages for 5.1. You
-       will have to manually download 5.1 from
-       http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz and compile
-       it, install it to /usr/local where the configure script should locate it
-       automatically.
+#### Enable Qt GUI
+Create `dogecoin-qt`, the core wallet GUI.
+```bash
+./configure --with-gui
+```
 
+#### Wallet
+BerkeleyDB is required for wallet functionality and use the `wallet.dat` file.
 
-See the section "Disable-wallet mode" to build Dogecoin Core without wallet.
+By default, **Dogecoin Core expect BerkeleyDB 5.1**.  
+You can use a different version by specifying `--with-incompatible-bdb` flag.
 
-Optional (see --with-miniupnpc and --enable-upnp-default):
+If no package is available for your distribution  in optional dependencies, you can build BerkeleyDB from source :
+```bash
+# Install script for BerkeleyDB 5.1
 
-    sudo apt-get install libminiupnpc-dev
+# BerkeleyDB installation directory
+BDB_PREFIX=$(pwd)/bdb
+mkdir $BDB_PREFIX
 
-ZMQ dependencies (provides ZMQ API 4.x):
+# Fetch the source and verify shasum
+wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
+echo '08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c db-5.1.29.NC.tar.gz' | sha256sum -c
 
-    sudo apt-get install libzmq3-dev
+# Extract sources
+tar -xzvf db-5.1.29.NC.tar.gz
+cd db-5.1.29.NC/build_unix/
 
-Dependencies for the GUI: Ubuntu & Debian
------------------------------------------
+# Apply patch (see https://gist.github.com/danieldk/5700533)
+sed -i  's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' ../src/dbinc/atomic.h
 
-If you want to build Dogecoin-Qt, make sure that the required packages for Qt development
-are installed. Either Qt 5 or Qt 4 are necessary to build the GUI.
-If both Qt 4 and Qt 5 are installed, Qt 5 will be used. Pass `--with-gui=qt4` to configure to choose Qt4.
-To build without GUI pass `--without-gui`.
+# Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
+../dist/configure --prefix=$BDB_PREFIX --enable-cxx --disable-shared --with-pic
+make install
+```
 
-To build with Qt 5 (recommended) you need the following:
+Then use `LDFLAGS` and `CPPFLAGS` during configuration to link the database :
+```bash
+./configure  LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
+```
 
-    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
+#### Disable-wallet mode
+When the intention is to run only a P2P node without a wallet, Dogecoin may be compiled in
+disable-wallet mode with:
 
-Alternatively, to build with Qt 4 you need the following:
+```bash
+./configure --disable-wallet
+```
 
-    sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler
+Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
+call, not `getwork`.
 
-libqrencode (optional) can be installed with:
-
-    sudo apt-get install libqrencode-dev
-
-Once these are installed, they will be found by configure and a dogecoin-qt executable will be
-built by default.
-
-Notes
------
-The release is built with GCC and then "strip dogecoind" to strip the debug
-symbols, which reduces the executable size by about 90%.
-
-
-miniupnpc
----------
+#### Miniupnpc
 
 [miniupnpc](http://miniupnp.free.fr/) may be used for UPnP port mapping.  It can be downloaded from [here](
 http://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
 turned off by default.  See the configure options for upnp behavior desired:
 
-	--without-miniupnpc      No UPnP support miniupnp not required
-	--disable-upnp-default   (the default) UPnP support turned off by default at runtime
-	--enable-upnp-default    UPnP support turned on by default at runtime
-
-
-Berkeley DB
------------
-It is recommended to use Berkeley DB 5.1. If you have to build it yourself:
-
 ```bash
-BITCOIN_ROOT=$(pwd)
-
-# Pick some path to install BDB to, here we create a directory within the dogecoin directory
-BDB_PREFIX="${BITCOIN_ROOT}/db5"
-mkdir -p $BDB_PREFIX
-
-# Fetch the source and verify that it is not tampered with
-wget 'http://download.oracle.com/berkeley-db/db-5.1.29.NC.tar.gz'
-echo '08238e59736d1aacdd47cfb8e68684c695516c37f4fbe1b8267dde58dc3a576c db-5.1.29.NC.tar.gz' | sha256sum -c
-# -> db-5.1.29.NC.tar.gz: OK
-tar -xzvf db-5.1.29.NC.tar.gz
-
-# Build the library and install to our prefix
-cd db-5.1.29.NC/build_unix/
-#  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
-make install
-
-# Configure Dogecoin Core to use our own-built instance of BDB
-cd $BITCOIN_ROOT
-./autogen.sh
-./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)
+--without-miniupnpc      #No UPnP support miniupnp not required
+--disable-upnp-default   #(the default) UPnP support turned off by default at runtime
+--enable-upnp-default    #UPnP support turned on by default at runtime
 ```
 
-**Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).
-
-Boost
------
-If you need to build Boost yourself:
-
-	sudo su
-	./bootstrap.sh
-	./bjam install
-
-
-Security
---------
+#### Security
 To help make your Dogecoin installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, binaries are hardened by default.
 This can be disabled with:
 
 Hardening Flags:
-
-	./configure --enable-hardening
-	./configure --disable-hardening
-
+```bash
+./configure --enable-hardening
+./configure --disable-hardening
+```
 
 Hardening enables the following features:
 
@@ -203,16 +167,15 @@ Hardening enables the following features:
     randomly located as well.
 
     On an AMD64 processor where a library was not compiled with -fPIC, this will cause an error
-    such as: "relocation R_X86_64_32 against `......' can not be used when making a shared object;"
+    such as: `relocation R_X86_64_32 against '......' can not be used when making a shared object;`
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-	scanelf -e ./dogecoin
+	`scanelf -e ./dogecoin`
 
     The output should contain:
 
-     TYPE
-    ET_DYN
+    `TYPE ET_DYN`
 
 * Non-executable Stack
     If the stack is executable, trivial stack-based buffer overflow exploits are possible if
@@ -225,48 +188,39 @@ Hardening enables the following features:
     `scanelf -e ./dogecoin`
 
     the output should contain:
-	STK/REL/PTL
-	RW- R-- RW-
+    `STK/REL/PTL RW- R-- RW-`
 
-    The STK RW- means that the stack is readable and writeable, but not executable.
-
-Disable-wallet mode
---------------------
-When the intention is to run only a P2P node without a wallet, Dogecoin may be compiled in
-disable-wallet mode with:
-
-    ./configure --disable-wallet
-
-In this case there is no dependency on Berkeley DB 4.8.
-
-Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
-call, not `getwork`.
-
-Additional Configure Flags
---------------------------
-A list of additional configure flags can be displayed with:
-
-    ./configure --help
+    The `STK RW-` means that the stack is readable and writeable, but not executable.
 
 
-ARM Cross-compilation
--------------------
+#### Memory Requirements
+
+C++ compilers are memory-hungry. It is recommended to have at
+least 1.5 GB of memory available when compiling Dogecoin Core.
+On systems with less, gcc can be tuned to conserve memory with additional CXXFLAGS:
+
+```bash
+./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+```
+
+## ARM Cross-compilation
+
 These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
 Make sure you install the build requirements mentioned above.
 Then, install the toolchain and curl:
-
-    sudo apt-get install g++-arm-linux-gnueabihf curl
+```bash
+sudo apt-get install g++-arm-linux-gnueabihf curl
+```
 
 To build executables for ARM:
-
-    cd depends
-    make HOST=arm-linux-gnueabihf NO_QT=1
-    cd ..
-    ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
-    make
-
-
+```bash
+cd depends
+make HOST=arm-linux-gnueabihf NO_QT=1
+cd ..
+./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
+make
+```
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -6,6 +6,7 @@ and guides for different OSs can be found in separate documentation, as listed
 below.
 
 1. [Install dependencies](#install-dependencies)
+    * [Using packaged dependencies](#using-packaged-dependencies)
     * [Ubuntu & Debian example](#ubuntu--debian-example)
 2. [Build steps](#build-steps)
 3. [Build configuration](#build-configuration)
@@ -51,6 +52,13 @@ Wallet is optional to run a node, see [Wallet](#wallet) section to enable them.
 
 For the versions used in the release, see [release-process.md](release-process.md) under *Fetch and build inputs*.
 
+### Using packaged dependencies
+
+Dogecoin Core's released binaries are built using the "depends system", which
+contains exact, tested versions of all dependencies. To create binaries that are
+using only fully tested dependencies, see the documentation in the
+[depends directory](../depends/README.md) and the
+[Release process documentation](release-process.md).
 
 ### Ubuntu & Debian example
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -123,24 +123,6 @@ libqrencode (optional) can be installed with:
 Once these are installed, they will be found by configure and a dogecoin-qt executable will be
 built by default.
 
-Dependency Build Instructions: Fedora
--------------------------------------
-Build requirements:
-
-    sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
-
-Optional:
-
-    sudo dnf install miniupnpc-devel
-
-To build with Qt 5 (recommended) you need the following:
-
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
-
-libqrencode (optional) can be installed with:
-
-    sudo dnf install qrencode-devel
-
 Notes
 -----
 The release is built with GCC and then "strip dogecoind" to strip the debug
@@ -267,47 +249,6 @@ A list of additional configure flags can be displayed with:
     ./configure --help
 
 
-Setup and Build Example: Arch Linux
------------------------------------
-This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
-
-    pacman -S git base-devel boost libevent python
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin/
-    ./autogen.sh
-    ./configure --disable-wallet --without-gui --without-miniupnpc
-    make check
-
-Note:
-Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
-or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
-`--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
-As mentioned above, when maintaining portability of the wallet between the standard Dogecoin Core distributions and independently built
-node software is desired, Berkeley DB 4.8 must be used.
-
-Setup and Build Example: NixOS
-------------------------------
-This example lists the steps necessary to setup and build a full GUI distribution of the latest changes on NixOS.
-
-Clone and enter the repo:
-
-    $ git clone https://github.com/dogecoin/dogecoin
-    $ cd dogecoin
-
-Enter the `nix-shell` environment with all the Dogecoin dependencies present:
-
-    $ nix-shell ./contrib/nixos/shell.nix
-
-Run the build steps with flags necessary for NixOS:
-
-    $ ./autogen.sh
-    $ ./configure --with-incompatible-bdb --with-boost-libdir="$(nix eval --raw nixpkgs.boost.out)/lib" --with-gui
-    $ make
-
-Start the GUI!
-
-    $ ./src/qt/dogecoin-qt
-
 ARM Cross-compilation
 -------------------
 These steps can be performed on, for example, an Ubuntu VM. The depends system
@@ -329,37 +270,3 @@ To build executables for ARM:
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-
-Building on FreeBSD
---------------------
-
-(Updated as of FreeBSD 11.0)
-
-Clang is installed by default as `cc` compiler, this makes it easier to get
-started than on [OpenBSD](build-openbsd.md). Installing dependencies:
-
-    pkg install autoconf automake libtool pkgconf
-    pkg install boost-libs openssl libevent
-    pkg install gmake
-
-You need to use GNU make (`gmake`) instead of `make`.
-(`libressl` instead of `openssl` will also work)
-
-For the wallet (optional):
-
-    pkg install db5
-
-This will give a warning "configure: WARNING: Found Berkeley DB other
-than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
-had a binary release, this may not matter. If backwards compatibility
-with 4.8-built Dogecoin Core is needed follow the steps under "Berkeley DB" above.
-
-Then build using:
-
-    ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
-    gmake
-
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command e.g. `gdb7111`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,9 +1,12 @@
 # Unix Build of Dogecoin Core
 
+This installation guide serves as a basis for all UNIX and UNIX-like operating
+systems. All examples in this guide are illustrated using an Ubuntu/Debian OS,
+and guides for different OSs can be found in separate documentation, as listed
+below.
+
 1. [Install dependencies](#install-dependencies)
-    * [Ubuntu & Debian](#ubuntu--debian)
-    * [Fedora](#Fedora)
-    * [FreeBSD](#FreeBSD)
+    * [Ubuntu & Debian example](#ubuntu--debian-example)
 2. [Build steps](#build-steps)
 3. [Build configuration](#build-configuration)
     * [Enable Qt GUI](#enable-qt-gui)
@@ -13,6 +16,12 @@
     * [Security](#security)
     * [Memory requirements](#memory-requirements)
 4. [ARM Cross-compilation](#arm-cross-compilation)
+5. OS-specific documentation:
+    * [Archlinux](build-archlinux.md)
+    * [Fedora](build-fedora.md)
+    * [FreeBSD](build-freebsd.md)
+    * [NixOs](build-nixos.md)
+    * [OpenBSD](build-openbsd.md)
 
 ## Install dependencies
 
@@ -43,7 +52,7 @@ Wallet is optional to run a node, see [Wallet](#wallet) section to enable them.
 For the versions used in the release, see [release-process.md](release-process.md) under *Fetch and build inputs*.
 
 
-### Ubuntu & Debian
+### Ubuntu & Debian example
 
 **Required dependencies** :
 ```bash


### PR DESCRIPTION
Updates instructions according to #2328, but splits off all OS/distro specific instructions into separate files, while defaulting to Ubuntu/Debian in `build-unix.md`.

Here's what I did:

1. Split off all non-debian distros to retain best-known instructions from 1.14.4-dev not reflected in #2328
2. Squashed #2328 as of 23c7353 and cherry-picked it on top, resolved conflicts
3. Wrote a small intro because that was missing, and relinked the top menu to resolve to new files
4. Added a section mentioning the use of the depends system per [this comment](https://github.com/dogecoin/dogecoin/pull/2328#issuecomment-867852121)
5. Added a warning to the top of all documents that contain outdated build instructions (all but nixOs, oof!)

I do have some fixes for Fedora and FreeBSD, but I'm running out of time for the current release so I will have to raise these later. Those can now be raised individually, so that one does not need to create merge conflicts with the other, taking care of blockers.

This will pull in the majority of work from #2328 and can replace that PR.