### PR TITLE
Update README.md, introduce INSTALL.md and doc/FAQ.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,5 @@
 # Contributing to Dogecoin Core
 
-Dogecoin Core is open source software, and we would welcome contributions
-which improve the state of the software. For those wanting to discuss changes,
-or look for work that needs doing, please see:
-
-* [Help requests](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
-* [Projects](https://github.com/dogecoin/dogecoin/projects)
-* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
-
 ## Branch Strategy
 
 Dogecoin Core's default branch is intentionally a stable release, so that anyone

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing to Dogecoin Core
 
+Dogecoin Core is open source software, and we would welcome contributions
+which improve the state of the software. For those wanting to discuss changes,
+or look for work that needs doing, please see:
+
+* [Help requests](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
+* [Projects](https://github.com/dogecoin/dogecoin/projects)
+* [Dogecoindev on reddit](https://www.reddit.com/r/dogecoindev/)
+
 ## Branch Strategy
 
 Dogecoin Core's default branch is intentionally a stable release, so that anyone

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,35 +1,51 @@
-# Building Dogecoin Core
+# Installing Dogecoin Core
 
-Development is ongoing, and the development team, as well as other volunteers,
-can freely work in their own trees and submit pull requests when features or
-bug fixes are ready.
+### Pre-compiled binaries
 
-### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
+The easiest way to install the latest version of the Dogecoin Core software is
+by to download the latest precompiled binaries for your platform from the
+[release page](https://github.com/dogecoin/dogecoin/releases). Currently,
+binaries are released for the following platforms:
 
-  The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+- Windows, 64-bit and 32-bit
+- Linux, 64-bit and 32-bit
+- MacOS, Intel 64-bit
+- ARM, 64-bit and 32-bit Linux
 
-  - [OSX Build Notes](doc/build-osx.md)
+These binaries are created and verified by multiple independent people, to
+ensure honest and malware-free releases. See
+[the gitian building documentation](doc/gitian-building.md) for more information
+regarding that process.
+
+### Compiling using packaged dependencies
+
+It is possible to build your own copy of Dogecoin Core with the exact, tested,
+dependencies, as used for the binary releases, by using the
+[depends system](depends/description.md). Please refer to the
+[depends README](depends/README.md) for instructions to build Dogecoin using
+these dependencies.
+
+### Compiling using system-provided libraries
+
+  The following are developer notes on how to build Dogecoin on your native
+  platform, using the dependencies as provided by your system's package manager.
+  They are not complete guides, but include notes on the necessary libraries,
+  compile flags, etc.
+
   - [Unix Build Notes](doc/build-unix.md)
   - [Windows Build Notes](doc/build-windows.md)
+  - [macOS Build Notes](doc/Building-Dogecoin-1.14-for-Mac.md)
 
-#### Contributions ✍️
+### Testing
 
-Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`. Further details on running
+Unit tests can be compiled and ran with `make check`. Further details on running
 and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
 
-There are also [regression and integration tests](/qa) of the RPC interface, written
-in Python, that are run automatically on the build server.
-These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
+There are also [regression and integration tests](/qa) written in Python, that
+are run automatically on the build server. These tests can be run (if the
+[test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
 
-Changes should be tested by somebody other than the developer who wrote the
-code. This is especially important for large or high-risk changes. It is useful
-to add a test plan to the pull request description if testing the changes is
-not straightforward.
-
-
-## Development tips and tricks
+### Tips and tricks
 
 **compiling for debugging**
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,84 @@
-Building Dogecoin
-================
+# Building Dogecoin Core
 
-See doc/build-*.md for instructions on building the various
-elements of the Dogecoin Core reference implementation of Dogecoin.
+Development is ongoing, and the development team, as well as other volunteers,
+can freely work in their own trees and submit pull requests when features or
+bug fixes are ready.
+
+### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
+
+  The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+
+  - [OSX Build Notes](doc/build-osx.md)
+  - [Unix Build Notes](doc/build-unix.md)
+  - [Windows Build Notes](doc/build-windows.md)
+
+### Such ports
+
+- RPC 22555
+- P2P 22556
+
+#### Version strategy
+Version numbers are following ```major.minor.patch``` semantics.
+
+#### Branches
+There are 3 types of branches in this repository:
+
+- **master:** Stable, contains the latest version of the latest *major.minor* release.
+- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
+- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
+
+*Master and maintenance branches are exclusively mutable by release. Planned*
+*releases will always have a development branch and pull requests should be*
+*submitted against those. Maintenance branches are there for **bug fixes only,***
+*please submit new features against the development branch with the highest version.*
+
+#### Contributions ✍️
+
+Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
+submit new unit tests for old code. Unit tests can be compiled and run
+(assuming they weren't disabled in configure) with: `make check`. Further details on running
+and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
+
+There are also [regression and integration tests](/qa) of the RPC interface, written
+in Python, that are run automatically on the build server.
+These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
+
+Changes should be tested by somebody other than the developer who wrote the
+code. This is especially important for large or high-risk changes. It is useful
+to add a test plan to the pull request description if testing the changes is
+not straightforward.
+
+
+## Development tips and tricks
+
+**compiling for debugging**
+
+Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
+`CXXFLAGS="-g -ggdb -O0"` or whatever debug flags you need.
+
+**debug.log**
+
+If the code is behaving strangely, take a look in the debug.log file in the data directory;
+error and debugging messages are written there.
+
+The `-debug=...` command-line option controls debugging; running with just `-debug` will turn
+on all categories (and give you a very large debug.log file).
+
+The Qt code routes `qDebug()` output to debug.log under category "qt": run with `-debug=qt`
+to see it.
+
+**testnet and regtest modes**
+
+Run with the `-testnet` option to run with "play dogecoins" on the test network, if you
+are testing multi-machine code that needs to operate across the internet.
+
+If you are testing something that can run on one machine, run with the `-regtest` option.
+In regression test mode, blocks can be created on-demand; see qa/rpc-tests/ for tests
+that run in `-regtest` mode.
+
+**DEBUG_LOCKORDER**
+
+Dogecoin Core is a multithreaded application, and deadlocks or other multithreading bugs
+can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
+CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
+are held, and adds warnings to the debug.log file if inconsistencies are detected.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,26 +12,6 @@ bug fixes are ready.
   - [Unix Build Notes](doc/build-unix.md)
   - [Windows Build Notes](doc/build-windows.md)
 
-### Such ports
-
-- RPC 22555
-- P2P 22556
-
-#### Version strategy
-Version numbers are following ```major.minor.patch``` semantics.
-
-#### Branches
-There are 3 types of branches in this repository:
-
-- **master:** Stable, contains the latest version of the latest *major.minor* release.
-- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
-- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
-
-*Master and maintenance branches are exclusively mutable by release. Planned*
-*releases will always have a development branch and pull requests should be*
-*submitted against those. Maintenance branches are there for **bug fixes only,***
-*please submit new features against the development branch with the highest version.*
-
 #### Contributions ✍️
 
 Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to

--- a/README.md
+++ b/README.md
@@ -7,55 +7,97 @@ Dogecoin Core [DOGE, Ð]
 <div align="center">
 
 [![DogecoinBadge](https://img.shields.io/badge/Doge-Coin-yellow.svg)](https://dogecoin.com)
-[![Build Status](https://travis-ci.com/dogecoin/dogecoin.svg?branch=master)](https://travis-ci.com/dogecoin/dogecoin)
 [![MuchWow](https://img.shields.io/badge/Much-Wow-yellow.svg)](https://dogecoin.com)
 
 </div>
 
-Select Doc Language: ENG | [CN_simplified](./README_zh_CN.md) | [more...](./README.md)
+Select language: EN | [CN](./README_zh_CN.md)
 
 Dogecoin is a cryptocurrency like Bitcoin, although it does not use SHA256 as
 its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
-- **Website:** [dogecoin.com](https://dogecoin.com)
+
+**Website:** [dogecoin.com](https://dogecoin.com)
 
 ## Ongoing development - Moon plan 🌒
 
-Dogecoin Core is an open source and community driven software.  
-Development process is done publicly. Anyone can see, discuss and work on them.  
+Dogecoin Core is an open source and community driven software. The development
+process is open and publicly visible; anyone can see, discuss and work on the
+software.
 
-Main tools used for the core development :
+Main development resources:
 
-* [Github Projects](https://github.com/dogecoin/dogecoin/projects) to see all developments and [Github Discussion](https://github.com/dogecoin/dogecoin/discussions) to discuss them
-* [Dogecoin Improvement Proposals (DIPs)](https://github.com/dogecoin/dips) for major improvements
+* [Github Projects](https://github.com/dogecoin/dogecoin/projects) is used to
+  follow planned and in-progress work for upcoming releases.
+* [Github Discussion](https://github.com/dogecoin/dogecoin/discussions) is used
+  to discuss features, planned and unplanned, related to both the development of
+  the Dogecoin Core software, the underlying protocols and the DOGE asset.  
 * [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
 
-## Installation – omg developers 👨‍💻
+### Version strategy
+Version numbers are following ```major.minor.patch``` semantics.
 
-To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
+### Branches
+There are 3 types of branches in this repository:
 
-## Contribute 🤝
+- **master:** Stable, contains the latest version of the latest *major.minor* release.
+- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
+- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
 
-Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
+*Master and maintenance branches are exclusively mutable by release. Planned*
+*releases will always have a development branch and pull requests should be*
+*submitted against those. Maintenance branches are there for **bug fixes only,***
+*please submit new features against the development branch with the highest version.*
 
-Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
+## Installation 💻
 
-## Community 🚀🍾
+Please see [the installation guide](INSTALL.md) for information about installing
+Dogecoin Core.
 
-You can join the community on different social media !
-To see what's going on, meet people & discuss, find the lastest meme, learn about dogecoin,
-give or ask different type of help, to share your project... some places to visit !
+### Such ports
 
-* [Discord](https://discord.gg/dogecoin)
+Dogecoin Core by default uses port `22556` for peer-to-peer communication that
+is needed to synchronize the "mainnet" blockchain and stay informed of new
+transactions and blocks. Additionally, a JSONRPC port can be opened, which
+defaults to port `22555` for mainnet nodes. It is strongly recommended to not
+expose RPC ports to the public internet.
+
+| Function | mainnet | testnet | regtest |
+| :------- | ------: | ------: | ------: |
+| P2P      |   22556 |   44556 |   18444 |
+| RPC      |   22555 |   44555 |   18332 |
+
+## Contributing 🤝
+
+If you find a bug or experience issues with this software, please report it
+using the [issue system](https://github.com/dogecoin/dogecoin/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5Bbug%5D+).
+
+Please see [the contribution guide](CONTRIBUTING.md) to see how you can
+participate in the development of Dogecoin Core. There are often
+[topics seeking help](https://github.com/dogecoin/dogecoin/labels/help%20wanted)
+where your contributions will have high impact and get very appreciation. wow.
+
+## Communities 🚀🍾
+
+You can join the communities on different social media.
+To see what's going on, meet people & discuss, find the lastest meme, learn
+about Dogecoin, give or ask for help, to share your project.
+
+Here are some places to visit:
+
 * [Dogecoin subreddit](https://www.reddit.com/r/dogecoin/)
 * [Dogeducation subreddit](https://www.reddit.com/r/dogeducation/)
-* [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
+* [Discord](https://discord.gg/dogecoin)
+* [Dogecoin Twitter](https://twitter.com/dogecoin)
 
 ## Very Much Frequently Asked Questions ❓
 
-You have a question regarding dogecoin ? An answer is perhaps already in the [FAQ](doc/FAQ.md) !
+Do you have a question regarding Dogecoin? An answer is perhaps already in the
+[FAQ](doc/FAQ.md) or the
+[Q&A section](https://github.com/dogecoin/dogecoin/discussions/categories/q-a)
+of the discussion board!
 
-## License – Much license ⚖️
+## License - Much license ⚖️
 Dogecoin Core is released under the terms of the MIT license. See
 [COPYING](COPYING) for more information or see
 [opensource.org](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -19,144 +19,43 @@ its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 - **Website:** [dogecoin.com](https://dogecoin.com)
 
+## Ongoing development - Moon plan 🌒
+
+Dogecoin Core is an open source and community driven software.  
+Development process is done publicly. Anyone can see, discuss and work on them.  
+
+Main tools used for the core development :
+
+* [Github Projects](https://github.com/dogecoin/dogecoin/projects) to see all developments and [Github Discussion](https://github.com/dogecoin/dogecoin/discussions) to discuss them
+* [Dogecoin Improvement Proposals (DIPs)](https://github.com/dogecoin/dips) for major improvements
+* [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
+
+## Installation – omg developers 👨‍💻
+
+To get all information to setup Dogecoin Core locally, see [INSTALL.md](INSTALL.md).
+
+## Contribute 🤝
+
+Look at [CONTRIBUTING.md](CONTRIBUTING.md) to see how you can participate !
+
+Do not limitate yourself to guidelines, feel free to contribute in your own way 🚀.
+
+## Community 🚀🍾
+
+You can join the community on different social media !
+To see what's going on, meet people & discuss, find the lastest meme, learn about dogecoin,
+give or ask different type of help, to share your project... some places to visit !
+
+* [Discord](https://discord.gg/dogecoin)
+* [Dogecoin subreddit](https://www.reddit.com/r/dogecoin/)
+* [Dogeducation subreddit](https://www.reddit.com/r/dogeducation/)
+* [Dogecoin Devs Twitter](https://twitter.com/dogecoin_devs)
+
+## Very Much Frequently Asked Questions ❓
+
+You have a question regarding dogecoin ? An answer is perhaps already in the [FAQ](doc/FAQ.md) !
+
 ## License – Much license ⚖️
 Dogecoin Core is released under the terms of the MIT license. See
 [COPYING](COPYING) for more information or see
 [opensource.org](https://opensource.org/licenses/MIT)
-
-## Development and contributions – omg developers
-Development is ongoing, and the development team, as well as other volunteers,
-can freely work in their own trees and submit pull requests when features or
-bug fixes are ready.
-
-#### Version strategy
-Version numbers are following ```major.minor.patch``` semantics.
-
-#### Branches
-There are 3 types of branches in this repository:
-
-- **master:** Stable, contains the latest version of the latest *major.minor* release.
-- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
-- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
-
-*Master and maintenance branches are exclusively mutable by release. Planned*
-*releases will always have a development branch and pull requests should be*
-*submitted against those. Maintenance branches are there for **bug fixes only,***
-*please submit new features against the development branch with the highest version.*
-
-#### Contributions ✍️
-
-Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`. Further details on running
-and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
-
-There are also [regression and integration tests](/qa) of the RPC interface, written
-in Python, that are run automatically on the build server.
-These tests can be run (if the [test dependencies](/qa) are installed) with: `qa/pull-tester/rpc-tests.py`
-
-Changes should be tested by somebody other than the developer who wrote the
-code. This is especially important for large or high-risk changes. It is useful
-to add a test plan to the pull request description if testing the changes is
-not straightforward.
-
-## Very Much Frequently Asked Questions ❓
-
-### How much doge can exist? – So many puppies! 🐕
-Early 2015 (approximately a year and a half after release) there were
-approximately 100,000,000,000 coins.
-Each subsequent block will grant 10,000 coins to encourage miners to continue to
-secure the network and make up for lost wallets on hard drives/phones/lost
-encryption passwords/etc.
-
-
-### Such mining information ⛏
-
-Dogecoin uses a simplified variant of the scrypt key derivation function as its
-proof of work with a target time of one minute per block and difficulty
-readjustment after every block. The block rewards are fixed and halve every
-100,000 blocks. Starting with the 600,000th block, a permanent reward of
-10,000 Dogecoin per block will be issued.  
-
-Originally, a different payout scheme was envisioned with block rewards being
-determined by taking the maximum reward as per the block schedule and applying
-the result of a Mersenne Twister pseudo-random number generator to arrive at a
-number between 0 and the maximum reward.
-
-This was changed starting with block 145,000, to prevent large pools from gaming
-the system and mining only high reward blocks. At the same time, the difficulty
-retargeting was also changed from four hours to once per block (every minute),
-implementing an algorithm courtesy of the DigiByte Coin development team, to
-lessen the impact of sudden increases and decreases of network hashing rate.
-
-**The current block reward schedule:**
-
-| Block                | Reward in Dogecoin |
-| :------------------- | -----------------: |
-| 1–99,999             |        0–1,000,000 |
-| 100,000–144,999      |          0–500,000 |
-| 145,000–199,999      |            250,000 |
-| 200,000–299,999      |            125,000 |
-| 300,000–399,999      |             62,500 |
-| 400,000–499,999      |             31,250 |
-| 500,000–599,999      |             15,625 |
-| 600,000+             |             10,000 |
-
-**The original block reward schedule, with one-minute block targets and four-hour difficulty readjustment:**
-
-| Block                | Reward in Dogecoin |
-| :------------------- | -----------------: |
-| 1–99,999             |        0–1,000,000 |
-| 100,000–199,999      |          0–500,000 |
-| 200,000–299,999      |          0–250,000 |
-| 300,000–399,999      |          0–125,000 |
-| 400,000–499,999      |           0–62,500 |
-| 500,000–599,999      |           0–31,250 |
-| 600,000+             |             10,000 |
-
-### Wow plz make dogecoind/dogecoin-cli/dogecoin-qt
-
-  The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
-
-  - [OSX Build Notes](doc/build-osx.md)
-  - [Unix Build Notes](doc/build-unix.md)
-  - [Windows Build Notes](doc/build-windows.md)
-
-### Such ports
-
-- RPC 22555
-- P2P 22556
-
-## Development tips and tricks
-
-**compiling for debugging**
-
-Run `configure` with the `--enable-debug` option, then `make`. Or run `configure` with
-`CXXFLAGS="-g -ggdb -O0"` or whatever debug flags you need.
-
-**debug.log**
-
-If the code is behaving strangely, take a look in the debug.log file in the data directory;
-error and debugging messages are written there.
-
-The `-debug=...` command-line option controls debugging; running with just `-debug` will turn
-on all categories (and give you a very large debug.log file).
-
-The Qt code routes `qDebug()` output to debug.log under category "qt": run with `-debug=qt`
-to see it.
-
-**testnet and regtest modes**
-
-Run with the `-testnet` option to run with "play dogecoins" on the test network, if you
-are testing multi-machine code that needs to operate across the internet.
-
-If you are testing something that can run on one machine, run with the `-regtest` option.
-In regression test mode, blocks can be created on-demand; see qa/rpc-tests/ for tests
-that run in `-regtest` mode.
-
-**DEBUG_LOCKORDER**
-
-Dogecoin Core is a multithreaded application, and deadlocks or other multithreading bugs
-can be very difficult to track down. Compiling with `-DDEBUG_LOCKORDER` (`configure
-CXXFLAGS="-DDEBUG_LOCKORDER -g"`) inserts run-time checks to keep track of which locks
-are held, and adds warnings to the debug.log file if inconsistencies are detected.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ Dogecoin currently employs a simplified variant of scrypt.
 
 **Website:** [dogecoin.com](https://dogecoin.com)
 
+## Installation 💻
+
+Please see [the installation guide](INSTALL.md) for information about installing
+Dogecoin Core.
+
+### Such ports
+
+Dogecoin Core by default uses port `22556` for peer-to-peer communication that
+is needed to synchronize the "mainnet" blockchain and stay informed of new
+transactions and blocks. Additionally, a JSONRPC port can be opened, which
+defaults to port `22555` for mainnet nodes. It is strongly recommended to not
+expose RPC ports to the public internet.
+
+| Function | mainnet | testnet | regtest |
+| :------- | ------: | ------: | ------: |
+| P2P      |   22556 |   44556 |   18444 |
+| RPC      |   22555 |   44555 |   18332 |
+
 ## Ongoing development - Moon plan 🌒
 
 Dogecoin Core is an open source and community driven software. The development
@@ -48,24 +66,6 @@ There are 3 types of branches in this repository:
 *releases will always have a development branch and pull requests should be*
 *submitted against those. Maintenance branches are there for **bug fixes only,***
 *please submit new features against the development branch with the highest version.*
-
-## Installation 💻
-
-Please see [the installation guide](INSTALL.md) for information about installing
-Dogecoin Core.
-
-### Such ports
-
-Dogecoin Core by default uses port `22556` for peer-to-peer communication that
-is needed to synchronize the "mainnet" blockchain and stay informed of new
-transactions and blocks. Additionally, a JSONRPC port can be opened, which
-defaults to port `22555` for mainnet nodes. It is strongly recommended to not
-expose RPC ports to the public internet.
-
-| Function | mainnet | testnet | regtest |
-| :------- | ------: | ------: | ------: |
-| P2P      |   22556 |   44556 |   18444 |
-| RPC      |   22555 |   44555 |   18332 |
 
 ## Contributing 🤝
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -14,7 +14,7 @@ Dogecoin uses a simplified variant of the scrypt key derivation function as its
 proof of work with a target time of one minute per block and difficulty
 readjustment after every block. The block rewards are fixed and halve every
 100,000 blocks. Starting with the 600,000th block, a permanent reward of
-10,000 Dogecoin per block will be issued.  
+10,000 Dogecoin per block will be issued.
 
 Originally, a different payout scheme was envisioned with block rewards being
 determined by taking the maximum reward as per the block schedule and applying
@@ -29,18 +29,26 @@ lessen the impact of sudden increases and decreases of network hashing rate.
 
 **The current block reward schedule:**
 
-1–99,999: 0–1,000,000 Dogecoin
+| Block                | Reward in Dogecoin |
+| :------------------- | -----------------: |
+| 1–99,999             |        0–1,000,000 |
+| 100,000–144,999      |          0–500,000 |
+| 145,000–199,999      |            250,000 |
+| 200,000–299,999      |            125,000 |
+| 300,000–399,999      |             62,500 |
+| 400,000–499,999      |             31,250 |
+| 500,000–599,999      |             15,625 |
+| 600,000+             |             10,000 |
 
-100,000–144,999: 0–500,000 Dogecoin
+**The original block reward schedule, with one-minute block targets and
+four-hour difficulty readjustment:**
 
-145,000–199,999: 250,000 Dogecoin
-
-200,000–299,999: 125,000 Dogecoin
-
-300,000–399,999: 62,500 Dogecoin
-
-400,000–499,999: 31,250 Dogecoin
-
-500,000–599,999: 15,625 Dogecoin
-
-600,000+: 10,000 Dogecoin
+| Block                | Reward in Dogecoin |
+| :------------------- | -----------------: |
+| 1–99,999             |        0–1,000,000 |
+| 100,000–199,999      |          0–500,000 |
+| 200,000–299,999      |          0–250,000 |
+| 300,000–399,999      |          0–125,000 |
+| 400,000–499,999      |           0–62,500 |
+| 500,000–599,999      |           0–31,250 |
+| 600,000+             |             10,000 |

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -1,0 +1,46 @@
+## Very Much Frequently Asked Questions ❓
+
+### How much doge can exist? – So many puppies! 🐕
+Early 2015 (approximately a year and a half after release) there were
+approximately 100,000,000,000 coins.
+Each subsequent block will grant 10,000 coins to encourage miners to continue to
+secure the network and make up for lost wallets on hard drives/phones/lost
+encryption passwords/etc.
+
+
+### Such mining information ⛏
+
+Dogecoin uses a simplified variant of the scrypt key derivation function as its
+proof of work with a target time of one minute per block and difficulty
+readjustment after every block. The block rewards are fixed and halve every
+100,000 blocks. Starting with the 600,000th block, a permanent reward of
+10,000 Dogecoin per block will be issued.  
+
+Originally, a different payout scheme was envisioned with block rewards being
+determined by taking the maximum reward as per the block schedule and applying
+the result of a Mersenne Twister pseudo-random number generator to arrive at a
+number between 0 and the maximum reward.
+
+This was changed starting with block 145,000, to prevent large pools from gaming
+the system and mining only high reward blocks. At the same time, the difficulty
+retargeting was also changed from four hours to once per block (every minute),
+implementing an algorithm courtesy of the DigiByte Coin development team, to
+lessen the impact of sudden increases and decreases of network hashing rate.
+
+**The current block reward schedule:**
+
+1–99,999: 0–1,000,000 Dogecoin
+
+100,000–144,999: 0–500,000 Dogecoin
+
+145,000–199,999: 250,000 Dogecoin
+
+200,000–299,999: 125,000 Dogecoin
+
+300,000–399,999: 62,500 Dogecoin
+
+400,000–499,999: 31,250 Dogecoin
+
+500,000–599,999: 15,625 Dogecoin
+
+600,000+: 10,000 Dogecoin


### PR DESCRIPTION
Pulls in #2313, integrates it with 1.14.4-dev, fixes it up and finishes `INSTALL.md`

Notably:
1. Pulled in and squashed all of #2313
2. Reverted the change to the contribution guide
3. Reverted the ports and branching strategy back into README, out of INSTALL, because both are important information to have on the first page people see (it prevents questions)
4. Fixed a lot of formulation, added some elaboration here and there
5. Moved the "development" section to be beneath "installation" because more people install than develop, so people will get to the relevant parts quicker.
6. Added sections for binary installs and depends system builds to INSTALL.md
7. Linked the Dogecoin-specific macOS documentation instead of the outdated build-osx one.