### PR TITLE
fix COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2009-2017 The Bitcoin Core developers
+Copyright (c) 2013-2021 The Dogecoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Missed Dogecoin (c) line in the license file.