### PR TITLE
Readme: add link to foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Dogecoin is a cryptocurrency like Bitcoin, although it does not use SHA256 as
 its proof of work (POW). Taking development cues from Tenebrix and Litecoin,
 Dogecoin currently employs a simplified variant of scrypt.
 
-**Website:** [dogecoin.com](https://dogecoin.com)
+**Website:** [dogecoin.com](https://dogecoin.com)  
+**Foundation:** [foundation.dogecoin.com](https://foundation.dogecoin.com/)
 
 ## Installation 💻
 


### PR DESCRIPTION
Because it's coming back :)

Also, it's missing [Dogecoin foundation](https://twitter.com/DogecoinFdn) and [dogecoin_devs](https://twitter.com/dogecoin_devs) Twitter accounts, maybe we should add it in communities links ? Idk how you want to integrate it.