### PR TITLE
snap packaging for 1.14.5

### DIFF
--- a/contrib/snap/README.md
+++ b/contrib/snap/README.md
@@ -4,15 +4,21 @@ All the commands I used for building and pushing to Snapcraft. I've only tested 
 
 ## Building Locally
 
+```
 sudo apt install snapd
 sudo snap install --classic snapcraft
 snapcraft
+```
 
 ### To Install Locally
+```
 snap install \*.snap --devmode
+```
 
 ### To Push to Snapcraft
+```
 snapcraft login
 snapcraft register dogecoin-core
 snapcraft push \*.snap --release=edge
 sudo snap install dogecoin-core --channel=edge
+```

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dogecoin-core # you probably want to 'snapcraft register <name>'
-version: '1.14.4'
+version: '1.14.5'
 summary: Reference client of Dogecoin, a peer-to-peer digital currency like Bitcoin.
 description: |
   Dogecoin is a cryptocurrency like Bitcoin, although it does not use SHA256 as its proof of work (POW). Taking development cues from Tenebrix and Litecoin, Dogecoin currently employs a simplified variant of scrypt. MIT licenced.
@@ -39,19 +39,26 @@ parts:
       unzip master.zip
       echo "Verifying secure hash matches signed values..."
       checksum=$(sha256sum dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz)
-      if ! grep -r $checksum *; then
+      if ! (grep -r $checksum * | grep dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz); then
         echo "Secure hash not verified."
         return
+      else
+        echo "Secure hash verified."
       fi
       tar -xvf dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
       echo "Running tests..."
-      dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_dogecoin
+      if ! (dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_dogecoin); then
+        echo "Dogecoin tests failed."
+        return
+      else
+        echo "Dogecoin tests passed."
+      fi
       echo "Installing Dogecoin..."
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoind
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-qt
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-cli
-      wget https://raw.githubusercontent.com/dogecoin/dogecoin/v${SNAPCRAFT_PROJECT_VERSION}/share/pixmaps/bitcoin128.png
-      install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps bitcoin128.png
+      wget https://raw.githubusercontent.com/dogecoin/dogecoin/master/share/pixmaps/dogecoin128.png
+      install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps dogecoin128.png
     build-packages:
       - unzip
       - wget


### PR DESCRIPTION
A couple changes:

- Fixed formatting of packaging instructions
- Updated location of dogecoin icon because of c42dba492ba9c12a79a3dcf8526e17b4215c452e  
- Incremented version number
- Notify user if the tests passed/failed
- Improve the security, now instead of checking if the hash exists _somewhere_ in the gitian repo, now the script checks if the hash exists _and_ is for the same file