### PR TITLE
[ Security Check ] Testing the bitcoin inherited SHA512 implementatio…

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -11,23 +11,23 @@
 
 #include <stdint.h>
 #include <string.h>
-//
-//#include "compat/endian.h"
-//
-//uint16_t static inline ReadLE16(const unsigned char* ptr)
-//{
-//    uint16_t x;
-//    memcpy((char*)&x, ptr, 2);
-//    return le16toh(x);
-//}
-//
-//uint32_t static inline ReadLE32(const unsigned char* ptr)
-//{
-//    uint32_t x;
-//    memcpy((char*)&x, ptr, 4);
-//    return le32toh(x);
-//}
-//
+
+#include "compat/endian.h"
+
+uint16_t static inline ReadLE16(const unsigned char* ptr)
+{
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return le16toh(x);
+}
+
+uint32_t static inline ReadLE32(const unsigned char* ptr)
+{
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return le32toh(x);
+}
+
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
@@ -35,31 +35,31 @@ uint64_t static inline ReadLE64(const unsigned char* ptr)
     return le64toh(x);
 }
 
-//void static inline WriteLE16(unsigned char* ptr, uint16_t x)
-//{
-//    uint16_t v = htole16(x);
-//    memcpy(ptr, (char*)&v, 2);
-//}
-//
-//void static inline WriteLE32(unsigned char* ptr, uint32_t x)
-//{
-//    uint32_t v = htole32(x);
-//    memcpy(ptr, (char*)&v, 4);
-//}
-//
-//void static inline WriteLE64(unsigned char* ptr, uint64_t x)
-//{
-//    uint64_t v = htole64(x);
-//    memcpy(ptr, (char*)&v, 8);
-//}
-//
-//uint32_t static inline ReadBE32(const unsigned char* ptr)
-//{
-//    uint32_t x;
-//    memcpy((char*)&x, ptr, 4);
-//    return be32toh(x);
-//}
-//
+void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+{
+    uint16_t v = htole16(x);
+    memcpy(ptr, (char*)&v, 2);
+}
+
+void static inline WriteLE32(unsigned char* ptr, uint32_t x)
+{
+    uint32_t v = htole32(x);
+    memcpy(ptr, (char*)&v, 4);
+}
+
+void static inline WriteLE64(unsigned char* ptr, uint64_t x)
+{
+    uint64_t v = htole64(x);
+    memcpy(ptr, (char*)&v, 8);
+}
+
+uint32_t static inline ReadBE32(const unsigned char* ptr)
+{
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return be32toh(x);
+}
+
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
@@ -67,12 +67,12 @@ uint64_t static inline ReadBE64(const unsigned char* ptr)
     return be64toh(x);
 }
 
-//void static inline WriteBE32(unsigned char* ptr, uint32_t x)
-//{
-//    uint32_t v = htobe32(x);
-//    memcpy(ptr, (char*)&v, 4);
-//}
-//
+void static inline WriteBE32(unsigned char* ptr, uint32_t x)
+{
+    uint32_t v = htobe32(x);
+    memcpy(ptr, (char*)&v, 4);
+}
+
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -4,30 +4,30 @@
 
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
-
-#if defined(HAVE_CONFIG_H)
-#include "bitcoin-config.h"
-#endif
-
+//
+//#if defined(HAVE_CONFIG_H)
+//#include "bitcoin-config.h"
+//#endif
+//
 #include <stdint.h>
 #include <string.h>
-
-#include "compat/endian.h"
-
-uint16_t static inline ReadLE16(const unsigned char* ptr)
-{
-    uint16_t x;
-    memcpy((char*)&x, ptr, 2);
-    return le16toh(x);
-}
-
-uint32_t static inline ReadLE32(const unsigned char* ptr)
-{
-    uint32_t x;
-    memcpy((char*)&x, ptr, 4);
-    return le32toh(x);
-}
-
+//
+//#include "compat/endian.h"
+//
+//uint16_t static inline ReadLE16(const unsigned char* ptr)
+//{
+//    uint16_t x;
+//    memcpy((char*)&x, ptr, 2);
+//    return le16toh(x);
+//}
+//
+//uint32_t static inline ReadLE32(const unsigned char* ptr)
+//{
+//    uint32_t x;
+//    memcpy((char*)&x, ptr, 4);
+//    return le32toh(x);
+//}
+//
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
@@ -35,31 +35,31 @@ uint64_t static inline ReadLE64(const unsigned char* ptr)
     return le64toh(x);
 }
 
-void static inline WriteLE16(unsigned char* ptr, uint16_t x)
-{
-    uint16_t v = htole16(x);
-    memcpy(ptr, (char*)&v, 2);
-}
-
-void static inline WriteLE32(unsigned char* ptr, uint32_t x)
-{
-    uint32_t v = htole32(x);
-    memcpy(ptr, (char*)&v, 4);
-}
-
-void static inline WriteLE64(unsigned char* ptr, uint64_t x)
-{
-    uint64_t v = htole64(x);
-    memcpy(ptr, (char*)&v, 8);
-}
-
-uint32_t static inline ReadBE32(const unsigned char* ptr)
-{
-    uint32_t x;
-    memcpy((char*)&x, ptr, 4);
-    return be32toh(x);
-}
-
+//void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+//{
+//    uint16_t v = htole16(x);
+//    memcpy(ptr, (char*)&v, 2);
+//}
+//
+//void static inline WriteLE32(unsigned char* ptr, uint32_t x)
+//{
+//    uint32_t v = htole32(x);
+//    memcpy(ptr, (char*)&v, 4);
+//}
+//
+//void static inline WriteLE64(unsigned char* ptr, uint64_t x)
+//{
+//    uint64_t v = htole64(x);
+//    memcpy(ptr, (char*)&v, 8);
+//}
+//
+//uint32_t static inline ReadBE32(const unsigned char* ptr)
+//{
+//    uint32_t x;
+//    memcpy((char*)&x, ptr, 4);
+//    return be32toh(x);
+//}
+//
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
@@ -67,12 +67,12 @@ uint64_t static inline ReadBE64(const unsigned char* ptr)
     return be64toh(x);
 }
 
-void static inline WriteBE32(unsigned char* ptr, uint32_t x)
-{
-    uint32_t v = htobe32(x);
-    memcpy(ptr, (char*)&v, 4);
-}
-
+//void static inline WriteBE32(unsigned char* ptr, uint32_t x)
+//{
+//    uint32_t v = htobe32(x);
+//    memcpy(ptr, (char*)&v, 4);
+//}
+//
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -4,11 +4,11 @@
 
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
-//
+
 //#if defined(HAVE_CONFIG_H)
-//#include "bitcoin-config.h"
+#include "bitcoin-config.h"
 //#endif
-//
+
 #include <stdint.h>
 #include <string.h>
 //

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -213,33 +213,33 @@ CSHA512& CSHA512::Reset()
     return *this;
 }
 
-int main(){
-
-
-    //Prepare test data
-    unsigned char buf[64] = {0};
-    uint64_t      *prt;
-    prt = (uint64_t*) buf;
-
-    //Initialize digest and process buffer
-    CSHA512 hasher;
-
-    //Finalize digest
-    hasher.Finalize(buf);
-
-    //Print final digest 
-    std::cout << "Dogecoin's Bitcoin Sha512 Implementation (Input = 0xffffff )" << std::endl; 
-    std::cout << "Digest is: "; 
-    for( int kk=0; kk < 8; kk++){
-        std::cout << std::hex
-                  << std::noshowbase
-                  << std::setw(16)
-                  << std::setfill('0') 
-                  << prt[ kk ];
-    }
-
-    std::cout << std::endl;
-
-
-    return 0;
-}
+//int main(){
+//
+//
+//    //Prepare test data
+//    unsigned char buf[64] = {0};
+//    uint64_t      *prt;
+//    prt = (uint64_t*) buf;
+//
+//    //Initialize digest and process buffer
+//    CSHA512 hasher;
+//
+//    //Finalize digest
+//    hasher.Finalize(buf);
+//
+//    //Print final digest 
+//    std::cout << "Dogecoin's Bitcoin Sha512 Implementation (Input = 0xffffff )" << std::endl; 
+//    std::cout << "Digest is: "; 
+//    for( int kk=0; kk < 8; kk++){
+//        std::cout << std::hex
+//                  << std::noshowbase
+//                  << std::setw(16)
+//                  << std::setfill('0') 
+//                  << prt[ kk ];
+//    }
+//
+//    std::cout << std::endl;
+//
+//
+//    return 0;
+//}

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -3,10 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "crypto/sha512.h"
-
+#include <iostream>
 #include "crypto/common.h"
-
+#include <iostream>
 #include <string.h>
+#include <iomanip>
+#include <openssl/evp.h>
+
 
 // Internal implementation code.
 namespace
@@ -167,17 +170,21 @@ CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
         data += 128 - bufsize;
         sha512::Transform(s, buf);
         bufsize = 0;
+        //std::cout << "SHA512::WRITE Path 1: Executed" << std::endl;
     }
     while (end >= data + 128) {
         // Process full chunks directly from the source.
         sha512::Transform(s, data);
         data += 128;
         bytes += 128;
+        //std::cout << "SHA512::WRITE Path 2: Executed" << std::endl;
     }
     if (end > data) {
         // Fill the buffer with what remains.
         memcpy(buf + bufsize, data, end - data);
         bytes += end - data;
+        //std::cout << "SHA512::WRITE Path 3: Executed";
+        //std::cout << "| SHA512:buf = " << std::dec << data[0] << std::hex << data[ 0 ] << std::endl;
     }
     return *this;
 }
@@ -205,3 +212,43 @@ CSHA512& CSHA512::Reset()
     sha512::Initialize(s);
     return *this;
 }
+
+int main(){
+
+
+    //Prepare test data
+    unsigned char buf[64] = {0};
+    buf[0] = 0xff;
+    buf[1] = 0xff;
+    buf[2] = 0xff;
+    uint64_t      *prt;
+    prt = (uint64_t*) buf;
+
+    //Initialize digest and process buffer
+    CSHA512 hasher;
+    hasher.Write(buf, 3);   //Tried both 3 and 64
+
+    //Finalize digest
+    hasher.Finalize(buf);
+
+    //Print final digest 
+    std::cout << "Dogecoin's Bitcoin Sha512 Implementation (Input = 0xffffff )" << std::endl; 
+    std::cout << "Digest is: "; 
+    for( int kk=0; kk < 8; kk++){
+        std::cout << std::hex
+                  << std::noshowbase
+                  << std::setw(16)
+                  << std::setfill('0') 
+                  << prt[ kk ];
+    }
+
+    std::cout << std::endl;
+
+
+    return 0;
+}
+
+
+
+
+

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -218,15 +218,11 @@ int main(){
 
     //Prepare test data
     unsigned char buf[64] = {0};
-    buf[0] = 0xff;
-    buf[1] = 0xff;
-    buf[2] = 0xff;
     uint64_t      *prt;
     prt = (uint64_t*) buf;
 
     //Initialize digest and process buffer
     CSHA512 hasher;
-    hasher.Write(buf, 3);   //Tried both 3 and 64
 
     //Finalize digest
     hasher.Finalize(buf);
@@ -247,8 +243,3 @@ int main(){
 
     return 0;
 }
-
-
-
-
-

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -19,18 +19,40 @@
 #include <boost/test/unit_test.hpp>
 #include <openssl/aes.h>
 #include <openssl/evp.h>
+#include <iostream>
+#include <iomanip>
 
 BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
 
 template<typename Hasher, typename In, typename Out>
 void TestVector(const Hasher &h, const In &in, const Out &out) {
+
+    bool test = true;
+
     Out hash;
     BOOST_CHECK(out.size() == h.OUTPUT_SIZE);
     hash.resize(out.size());
     {
+                if( test ){
+                    std::cout << "Pre: " << std::endl;
+                    for(int kk = 0 ; kk < out.size(); kk++){ std::cout << std::setw(2) << std::setfill('0') << std::hex << (int)out[kk]; }    
+                    std::cout << std::endl;
+                    for(int kk = 0 ; kk < out.size(); kk++){ std::cout << std::setw(2) << std::setfill('0') << std::hex << (int)hash[kk]; }    
+                    std::cout << std::endl << std::endl;
+                }
+
         // Test that writing the whole input string at once works.
         Hasher(h).Write((unsigned char*)&in[0], in.size()).Finalize(&hash[0]);
         BOOST_CHECK(hash == out);
+                if( test ){
+                    std::cout << "Post: " << std::endl;
+                    for(int kk = 0 ; kk < out.size(); kk++){ std::cout << std::setw(2) << std::setfill('0') << std::hex << (int)out[kk]; }    
+                    std::cout << std::endl;
+                    for(int kk = 0 ; kk < out.size(); kk++){ std::cout << std::setw(2) << std::setfill('0') << std::hex << (int)hash[kk]; }    
+                    std::cout << std::endl << "------------------------------------------------------------------" << std::endl << std::endl;
+                    test = false;
+                }
+
     }
     for (int i=0; i<32; i++) {
         // Test that writing the string broken up in random pieces works.

--- a/test_sha512.cpp
+++ b/test_sha512.cpp
@@ -6,10 +6,7 @@ int  main(int argc, char *argv[])
 {
     EVP_MD_CTX *mdctx;
     const EVP_MD *md;
-    char mess1[3];;
-    mess1[0] = 0xff;
-    mess1[1] = 0xff;
-    mess1[2] = 0xff;
+    char mess1[3] = {0};
     unsigned char md_value[EVP_MAX_MD_SIZE];
     unsigned int md_len, i;
     

--- a/test_sha512.cpp
+++ b/test_sha512.cpp
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <openssl/evp.h>
+#include <cstring>
+
+int  main(int argc, char *argv[])
+{
+    EVP_MD_CTX *mdctx;
+    const EVP_MD *md;
+    char mess1[3];;
+    mess1[0] = 0xff;
+    mess1[1] = 0xff;
+    mess1[2] = 0xff;
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len, i;
+    
+    OpenSSL_add_all_digests();
+    
+    if(!argv[1]) {
+           printf("Usage: mdtest digestname\n");
+           exit(1);
+    }
+    
+    md = EVP_get_digestbyname(argv[1]);
+    
+    if(!md) {
+           printf("Unknown message digest %s\n", argv[1]);
+           exit(1);
+    }
+    
+    mdctx = EVP_MD_CTX_create();
+    EVP_DigestInit_ex(mdctx, md, NULL);
+    EVP_DigestUpdate(mdctx, mess1, strlen(mess1));
+    EVP_DigestFinal_ex(mdctx, md_value, &md_len);
+    EVP_MD_CTX_destroy(mdctx);
+    
+    printf("Digest is: ");
+    for(i = 0; i < md_len; i++)
+           printf("%02x", md_value[i]);
+    printf("\n");
+    
+    /* Call this once before exit. */
+    EVP_cleanup();
+    exit(0);
+}
+

--- a/validate_sha512.sh
+++ b/validate_sha512.sh
@@ -13,7 +13,7 @@ echo " "
 
 #Build dogecoin's Bitcoin Sha512 Implementation with the same block message ( 0xffffff )
 cd src/crypto
-g++ -I.. sha512.cpp  -o dogesha512
+g++ -I.. -I../config/  sha512.cpp  -o dogesha512
 
 #Run dogecoin's Bitcoin Sha512 Implementation
 ./dogesha512

--- a/validate_sha512.sh
+++ b/validate_sha512.sh
@@ -1,0 +1,22 @@
+#Build the OpenSSL Sha512 reference 
+g++ test_sha512.cpp -lssl -lcrypto -o sha512_OpenSSL
+
+#Add Spacing
+echo " "
+
+#Run the OpenSSL Sha512 Implementation Reference
+echo "OpenSSL Sha512"
+./sha512_OpenSSL sha512
+
+#Add Spacing
+echo " "
+
+#Build dogecoin's Bitcoin Sha512 Implementation with the same block message ( 0xffffff )
+cd src/crypto
+g++ -I.. sha512.cpp  -o dogesha512
+
+#Run dogecoin's Bitcoin Sha512 Implementation
+./dogesha512
+
+#Add Spacing
+echo " "


### PR DESCRIPTION
…n for correctness. Not matching OpenSSL SHA512 implementation.

To test yourself, checkout this branch and run the ``validate_sha512.sh`` script on the root directory. @edtubbs @michilumin  @patricklodder  @rnicoll  Could you please take a look?  Am I missing something?

As far as I can tell our implementation is not correct.


**EDIT 1**

This is what I get:

```
OpenSSL Sha512
Digest is: 62080346799e74025e65e5d6da46e4612303fda014c38a15cadf59251a1e0259f236ad265dfde3e26bf69970c901d652dc300d77b3179881e6dd410cc00fc487
 
Dogecoin's Bitcoin Sha512 Implementation (Input = 0xffffff )
Digest is: 4fbc16eed98e230a9b2b4545115fa2e4a55dd505067c1dd34419e5da5a71ef5bc35cf85ecac2f8c78e1634754b30e6734fc7203a6b2d7309633df5e4a8d4a426

```

Note: the input for both is ``0xffffff``.