### PR TITLE
Fix FreeBSD scrypt compilation

### DIFF
--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -44,6 +44,7 @@
 #endif
 #endif
 
+#ifndef __FreeBSD__
 static inline uint32_t be32dec(const void *pp)
 {
 	const uint8_t *p = (uint8_t const *)pp;
@@ -60,6 +61,7 @@ static inline void be32enc(void *pp, uint32_t x)
 	p[0] = (x >> 24) & 0xff;
 }
 
+#endif
 /**
  * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
  * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-SHA256 as the PRF, and

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -27,6 +27,7 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
+#ifndef __FreeBSD__
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;
@@ -42,4 +43,5 @@ static inline void le32enc(void *pp, uint32_t x)
         p[2] = (x >> 16) & 0xff;
         p[3] = (x >> 24) & 0xff;
 }
+#endif
 #endif


### PR DESCRIPTION
This commit unifies src/crypto/scrypt.h with the version in the 1.21-dev
branch.

Note that while the header guard defined in this file has changed from
`SCRYPT_H` to `BITCOIN_CRYPTO_SCRYPT_H`, the former does not appear in
the codebase on this branch at all, so that change should also be safe.

Fixes #2475 .