### PR TITLE
updated configure.ac to include ignore statements for -Wno-implicit-f…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,10 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   ## Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   ## unknown options if any other warning is produced. Test the -Wfoo case, and
   ## set the -Wno-foo case if it works.
+  
+  AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[CXXFLAGS="$CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[CXXFLAGS="$CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wunused-variable],[CXXFLAGS="$CXXFLAGS -Wunused-variable"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter],[CXXFLAGS="$CXXFLAGS -Wno-unused-parameter"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[CXXFLAGS="$CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[CXXFLAGS="$CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])


### PR DESCRIPTION
…allthrough, -Wno-deprecated-copy, -Wunused-variable. See https://github.com/dogecoin/dogecoin/issues/1912#issuecomment-903152862 .

Added the ignore statements to avoid annoying compiler warnings at compile time. Although does not eliminate all warnings at runtime, it certainly removes the annoying ones. 

See discussion: Compiler warnings when building Dogecoin. #1912 https://github.com/dogecoin/dogecoin/issues/1912