### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/dogecoin-fees.cpp
+++ b/src/dogecoin-fees.cpp
@@ -23,6 +23,7 @@ CAmount GetDogecoinWalletFee(size_t nBytes_)
 {
     //mlumin: super simple fee calc for dogecoin
     CAmount nFee=GetDogecoinWalletFeeRate().GetFee(nBytes_);
+    return nFee;
 }
 
 //mlumin 5/2021: Establish a wallet rate of n koinu per kb.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -151,13 +151,14 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             }
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, NULL))
+        if (!ProcessNewBlock(Params(), shared_pblock, true, NULL)) {
             if (nMineAuxPow) {
                 continue;
             }
             else { 
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted"); 
             }
+        }
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -155,8 +155,8 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             if (nMineAuxPow) {
                 continue;
             }
-            else { 
-                throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted"); 
+            else {
+                throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
             }
         }
         ++nHeight;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3900,10 +3900,10 @@ bool CWallet::ParameterInteraction()
                                        GetArg("-paytxfee", ""), ::minRelayTxFeeRate.ToString()));
         }
 
-	    // if -mintxfee is not set, then a lower payTxFee overrides minTxFee
-	    if (!IsArgSet("-mintxfee") && payTxFee < CWallet::minTxFee)
+        // if -mintxfee is not set, then a lower payTxFee overrides minTxFee
+        if (!IsArgSet("-mintxfee") && payTxFee < CWallet::minTxFee)
         {
-            LogPrintf("%s: parameter interaction: -paytxfee=%s -> setting -mintxfee=%s\n", __func__, GetArg("-paytxfee",""), GetArg("-paytxfee",""));        
+            LogPrintf("%s: parameter interaction: -paytxfee=%s -> setting -mintxfee=%s\n", __func__, GetArg("-paytxfee",""), GetArg("-paytxfee",""));
             CWallet::minTxFee = CFeeRate(nFeePerK,1000);
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3904,7 +3904,7 @@ bool CWallet::ParameterInteraction()
 	    if (!IsArgSet("-mintxfee") && payTxFee < CWallet::minTxFee)
         {
             LogPrintf("%s: parameter interaction: -paytxfee=%s -> setting -mintxfee=%s\n", __func__, GetArg("-paytxfee",""), GetArg("-paytxfee",""));        
-            CWallet:minTxFee = CFeeRate(nFeePerK,1000);
+            CWallet::minTxFee = CFeeRate(nFeePerK,1000);
         }
     }
     if (IsArgSet("-maxtxfee"))


### PR DESCRIPTION
This PR fixes a handful of compiler warnings found when testing #2484.

While editing, I found and cleaned up a couple of whitespace inconsistencies in a separate commit at the end.

