### PR TITLE
1.14: Remove redundant explicitly defined copy constructors

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -44,7 +44,6 @@ public:
     explicit CFeeRate(const CAmount& _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) { }
     /** Constructor for a fee rate in satoshis per kB. The size in bytes must not exceed (2^63 - 1)*/
     CFeeRate(const CAmount& nFeePaid, size_t nBytes);
-    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
     /**
      * Return the wallet fee in koinus for the given size in bytes.
      */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -45,11 +45,6 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     nSigOpCostWithAncestors = sigOpCost;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTxMemPoolEntry& other)
-{
-    *this = other;
-}
-
 double
 CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -117,8 +117,6 @@ public:
                     CAmount _inChainInputValue, bool spendsCoinbase,
                     int64_t nSigOpsCost, LockPoints lp);
 
-    CTxMemPoolEntry(const CTxMemPoolEntry& other);
-
     const CTransaction& GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }
     /**


### PR DESCRIPTION
Removes redundant copy constructors for `CFeeRate` and `CTxMemPoolEntry`. This takes out a whole bunch of warnings from -Wdeprecated-copy that was flagged with #1912 and were proposed to be suppressed in #2484. 

I'm trying to do **Fixing issues > suppressing visibility of issues** here, as these are quick wins and we retain the visibility of future changes that compilers can complain about.

Cherry-picked from bitcoin/bitcoin: b426e2467

Solved conflict where upstream moved `CFeeRate` into `./policy/` whereas we still have it as part of amount.h/cpp on 1.14.

Does not need porting to 1.21, as this commit is already in that tree.