### PR TITLE
Fix self-assigned nVersion in CAlert serialization

### DIFF
--- a/src/alert.h
+++ b/src/alert.h
@@ -50,8 +50,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
+        READWRITE(nVersion);
         READWRITE(nRelayUntil);
         READWRITE(nExpiration);
         READWRITE(nID);


### PR DESCRIPTION
This takes away a bunch of compiler warnings for every file where alert.h is included. 

Unit testsuite Alert_tests (`src/test/test_dogecoin --run_test=Alert_tests --log_level=all` for verbose test results) still succeeds after this change.