### PR TITLE
Fix implicit switch fallthrough warnings

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -49,8 +49,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
         switch (vDataToHash.size() & 3) {
         case 3:
             k1 ^= tail[2] << 16;
+            // Falls through
         case 2:
             k1 ^= tail[1] << 8;
+            // Falls through
         case 1:
             k1 ^= tail[0];
             k1 *= c1;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -268,7 +268,9 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 }
                 if (breakParsing)
                     break;
+
             }
+            // Falls through
             case STATE_ARGUMENT: // In or after argument
             case STATE_EATING_SPACES_IN_ARG:
             case STATE_EATING_SPACES_IN_BRACKETS:
@@ -374,6 +376,7 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                 strResult = lastResult.get_str();
             else
                 strResult = lastResult.write(2);
+            // Falls through
         case STATE_ARGUMENT:
         case STATE_EATING_SPACES:
             return true;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -461,6 +461,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         std::vector<unsigned char> strRequestV = ParseHex(strRequestMutable);
         strRequestMutable.assign(strRequestV.begin(), strRequestV.end());
     }
+    // Falls through
 
     case RF_BINARY: {
         try {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -666,9 +666,11 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 // Not exposed to GBT at all
                 break;
             case THRESHOLD_LOCKED_IN:
-                // Ensure bit is set in block version
+            {
+                // Ensure bit is set in block version, then fall through to get vbavailable set
                 pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-                // FALL THROUGH to get vbavailable set...
+            }
+            // Falls through
             case THRESHOLD_STARTED:
             {
                 const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -705,23 +705,27 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             break;
         case 'X':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'x': case 'p':
             out.setf(std::ios::hex, std::ios::basefield);
             intConversion = true;
             break;
         case 'E':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'e':
             out.setf(std::ios::scientific, std::ios::floatfield);
             out.setf(std::ios::dec, std::ios::basefield);
             break;
         case 'F':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
         case 'G':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'g':
             out.setf(std::ios::dec, std::ios::basefield);
             // As in boost::format, let stream decide float format.


### PR DESCRIPTION
This cherry-picks a tinyformat commit:

https://github.com/c42f/tinyformat/commit/8a2812d8480bfb66923eea0bb5cdda79fe4f17ba

The effect should be to remove all compilation warnings about implicit
switch fallthroughs.

Updating the entire header file to the latest release at once brings in
other changes that may be more invasive for 1.14.5, and this commit
should not interfere with a further update.

See PR #2484 for the motivation.