### PR TITLE
french translations update (sync with Dogecoin instead Bitcoin network)

### DIFF
--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -887,7 +887,7 @@
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the dogecoin network, as detailed below.</source>
-        <translation>Les transactions récentes ne sont peut-être pas encore visibles, et par conséquent, le solde de votre porte-monnaie est peut-être erroné. Cette information sera juste une fois que votre porte-monnaie aura fini de se synchroniser avec le réseau Bitcoin, comme décrit ci-dessous. </translation>
+        <translation>Les transactions récentes ne sont peut-être pas encore visibles, et par conséquent, le solde de votre porte-monnaie est peut-être erroné. Cette information sera juste une fois que votre porte-monnaie aura fini de se synchroniser avec le réseau Dogecoin, comme décrit ci-dessous. </translation>
     </message>
     <message>
         <source>Attempting to spend dogecoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>


### PR DESCRIPTION
New users running Dogecoin Core (in french) for first time (like me), have main message that they sync with "Bitcoin network" instead "Dogecoin". This commit provide lot of hard work to update string` 'Bitcoin' to 'Dogecoin'` :-D 

Current state: 
![image](https://user-images.githubusercontent.com/2789203/131698348-92b4af7c-3e91-4d2a-846c-95305f307f3a.png)
