### PR TITLE
Update smart fee parameters to Dogecoin

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -449,6 +449,10 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, int *answerFoun
     if (median < 0)
         return CFeeRate(0);
 
+    if (abs(median - SMOOTHING_TARGET) < SMOOTHING_TOLERANCE) {
+        return CFeeRate(SMOOTHING_TARGET);
+    }
+
     return CFeeRate(median);
 }
 

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -169,8 +169,8 @@ public:
 /** Track confirm delays up to 25 blocks, can't estimate beyond that */
 static const unsigned int MAX_BLOCK_CONFIRMS = 25;
 
-/** Decay of .9998 is a half-life of 3465 blocks or about 2.4 days */
-static const double DEFAULT_DECAY = .9998;
+/** Decay of .998 is a half-life of 346 blocks or about 2.4 days */
+static const double DEFAULT_DECAY = .998;
 
 /** Require greater than 95% of X feerate transactions to be confirmed within Y blocks for X to be big enough */
 static const double MIN_SUCCESS_PCT = .95;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -175,12 +175,6 @@ static const double DEFAULT_DECAY = .998;
 /** Require greater than 95% of X feerate transactions to be confirmed within Y blocks for X to be big enough */
 static const double MIN_SUCCESS_PCT = .95;
 
-// Dogecoin: Smooth estimated fee so if it's close to 1.14.5 default, we use that default instead.
-// This avoids floating point math causing the estimate to drop just below the default inclusion
-// rate, while retaining the ability to use fees below 1.14.5 default.
-static const double SMOOTHING_TARGET = COIN / 100;
-static const double SMOOTHING_TOLERANCE = COIN / 100000;
-
 /** Require an avg of 1 tx in the combined feerate bucket per block to have stat significance */
 static const double SUFFICIENT_FEETXS = 1;
 
@@ -205,7 +199,7 @@ class CBlockPolicyEstimator
 {
 public:
     /** Create new BlockPolicyEstimator and initialize stats tracking classes with default values */
-    CBlockPolicyEstimator(const CFeeRate& minRelayFee);
+    CBlockPolicyEstimator(const CFeeRate& minRelayFee, const CFeeRate& minReasonableInclusionFee);
 
     /** Process all the transactions that have been included in a block */
     void processBlock(unsigned int nBlockHeight,
@@ -251,6 +245,7 @@ public:
 
 private:
     CFeeRate minTrackedFee;    //!< Passed to constructor to avoid dependency on main
+    CFeeRate minReasonableInclusionFee;    //!< Passed to constructor to avoid dependency on main
     unsigned int nBestSeenHeight;
     struct TxStatsInfo
     {

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -169,18 +169,24 @@ public:
 /** Track confirm delays up to 25 blocks, can't estimate beyond that */
 static const unsigned int MAX_BLOCK_CONFIRMS = 25;
 
-/** Decay of .998 is a half-life of 346 blocks or about 2.4 days */
-static const double DEFAULT_DECAY = .998;
+/** Decay of .9998 is a half-life of 3465 blocks or about 2.4 days */
+static const double DEFAULT_DECAY = .9998;
 
 /** Require greater than 95% of X feerate transactions to be confirmed within Y blocks for X to be big enough */
 static const double MIN_SUCCESS_PCT = .95;
+
+// Dogecoin: Smooth estimated fee so if it's close to 1.14.5 default, we use that default instead.
+// This avoids floating point math causing the estimate to drop just below the default inclusion
+// rate, while retaining the ability to use fees below 1.14.5 default.
+static const double SMOOTHING_TARGET = COIN / 100;
+static const double SMOOTHING_TOLERANCE = COIN / 100000;
 
 /** Require an avg of 1 tx in the combined feerate bucket per block to have stat significance */
 static const double SUFFICIENT_FEETXS = 1;
 
 // Minimum and Maximum values for tracking feerates
-static constexpr double MIN_FEERATE = 10;
-static const double MAX_FEERATE = 1e7;
+static constexpr double MIN_FEERATE = COIN / 1000;
+static const double MAX_FEERATE = COIN * 10.0;
 static const double INF_FEERATE = MAX_MONEY;
 static const double INF_PRIORITY = 1e9 * MAX_MONEY;
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -48,10 +48,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     std::vector<CTransactionRef> block;
     int blocknum = 0;
 
-    // Loop through 2000 blocks
-    // At a decay .9998 and 4 fee transactions per block
+    // Loop through 200 blocks
+    // At a decay .998 and 4 fee transactions per block
     // This makes the tx count about 1.33 per bucket, above the 1 threshold
-    while (blocknum < 2000) {
+    while (blocknum < 200) {
         for (int j = 0; j < 10; j++) { // For each fee
             for (int k = 0; k < 4; k++) { // add 4 fee txs
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k; // make transaction unique
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         }
         mpool.removeForBlock(block, ++blocknum);
         block.clear();
-        if (blocknum == 300) {
+        if (blocknum == 30) {
             // At this point we should need to combine 5 buckets to get enough data points
             // So estimateFee(1,2,3) should fail and estimateFee(4) should return somewhere around
             // 8*baserate.  estimateFee(4) %'s are 100,100,100,100,90 = average 98%
@@ -113,9 +113,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         }
     }
 
-    // Mine 640 more blocks with no transactions happening, estimates shouldn't change
+    // Mine 50 more blocks with no transactions happening, estimates shouldn't change
     // We haven't decayed the moving average enough so we still have enough data points in every bucket
-    while (blocknum < 2640)
+    while (blocknum < 250)
         mpool.removeForBlock(block, ++blocknum);
 
     BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 
     // Mine 15 more blocks with lots of transactions happening and not getting mined
     // Estimates should go up
-    while (blocknum < 2655) {
+    while (blocknum < 265) {
         for (int j = 0; j < 10; j++) { // For each fee multiple
             for (int k = 0; k < 4; k++) { // add 4 fee txs
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
@@ -155,16 +155,16 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             txHashes[j].pop_back();
         }
     }
-    mpool.removeForBlock(block, 2655);
+    mpool.removeForBlock(block, 265);
     block.clear();
     BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
     for (int i = 2; i < 10;i++) {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
     }
 
-    // Mine 2000 more blocks where everything is mined every block
+    // Mine 200 more blocks where everything is mined every block
     // Estimates should be below original estimates
-    while (blocknum < 4655) {
+    while (blocknum < 465) {
         for (int j = 0; j < 10; j++) { // For each fee multiple
             for (int k = 0; k < 4; k++) { // add 4 fee txs
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -354,7 +354,16 @@ CTxMemPool::CTxMemPool(const CFeeRate& _minReasonableRelayFee) :
     // of transactions in the pool
     nCheckFrequency = 0;
 
-    minerPolicyEstimator = new CBlockPolicyEstimator(_minReasonableRelayFee);
+    CFeeRate _minReasonableInclusionFee;
+    if (IsArgSet("-blockmintxfee")) {
+        CAmount n = 0;
+        ParseMoney(GetArg("-blockmintxfee", ""), n);
+        _minReasonableInclusionFee = CFeeRate(n);
+    } else {
+        _minReasonableInclusionFee = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
+    }
+
+    minerPolicyEstimator = new CBlockPolicyEstimator(_minReasonableRelayFee, _minReasonableInclusionFee);
 }
 
 CTxMemPool::~CTxMemPool()


### PR DESCRIPTION
This updates fee data collection so the values are useful. While the integrated wallet does not use smart fees, external wallet providers have been depending on the smart fee estimates, and this will make them saner.

Note this intentionally invalidates previous fee estimate data as a consequence of changing bucket parameters.