### PR TITLE
Mark getauxblock RPC command as deprecated

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -975,7 +975,7 @@ UniValue getauxblockbip22(const JSONRPCRequest& request)
           || (request.params.size() != 0 && request.params.size() != 2))
         throw std::runtime_error(
             "getauxblock (hash auxpow)\n"
-            "\nCreate or submit a merge-mined block.\n"
+            "\nDEPRECATED. Create or submit a merge-mined block.\n"
             "\nWithout arguments, create a new block and return information\n"
             "required to merge-mine it.  With arguments, submit a solved\n"
             "auxpow for a previously returned block.\n"


### PR DESCRIPTION
Addresses #2300 .

The remaining mentions of this command are all in error messages or QA tests, so I haven't removed them. I could find no other documentation or non-code mention of this command.

The release notes for the next version (1.14.5?) should include a line about this deprecation.