### PR TITLE
Hide smart fee UI elements

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -759,6 +759,7 @@
             </item>
            </layout>
           </item>
+          <!--
           <item>
            <widget class="QLabel" name="fallbackFeeWarningLabel">
             <property name="toolTip">
@@ -778,6 +779,7 @@
             </property>
            </widget>
           </item>
+          -->
           <item>
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
@@ -896,14 +898,20 @@
                 <layout class="QHBoxLayout" name="horizontalLayoutFee8">
                  <item>
                   <widget class="QCheckBox" name="checkBoxMinimumFee">
+                   <!--
                    <property name="toolTip">
                     <string>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for dogecoin transactions than the network can process.</string>
                    </property>
+                     -->
                    <property name="text">
                     <string/>
                    </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
                   </widget>
                  </item>
+                 <!--
                  <item>
                   <widget class="QLabel" name="labelMinFeeWarning">
                    <property name="enabled">
@@ -920,6 +928,7 @@
                    </property>
                   </widget>
                  </item>
+                   -->
                  <item>
                   <spacer name="horizontalSpacer_2">
                    <property name="orientation">
@@ -944,8 +953,8 @@
                  <property name="text">
                   <string>Recommended:</string>
                  </property>
-                 <property name="checked">
-                  <bool>true</bool>
+                 <property name="enabled">
+                  <bool>false</bool>
                  </property>
                  <attribute name="buttonGroup">
                   <string notr="true">groupFee</string>
@@ -973,6 +982,9 @@
                 <widget class="QRadioButton" name="radioCustomFee">
                  <property name="text">
                   <string>Custom:</string>
+                 </property>
+                 <property name="enabled">
+                  <bool>false</bool>
                  </property>
                  <attribute name="buttonGroup">
                   <string notr="true">groupFee</string>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -594,7 +594,8 @@ void SendCoinsDialog::updateFeeSectionControls()
     //mlumin: 5/2021 - this label actually gates the 'slider and smart fee' functionality, so turn it off for dogecoin.
     ui->confirmationTargetLabel ->setEnabled(ui->radioSmartFee->isChecked());
     ui->checkBoxMinimumFee      ->setEnabled(ui->radioCustomFee->isChecked());
-    ui->labelMinFeeWarning      ->setEnabled(ui->radioCustomFee->isChecked());
+    // Dogecoin: We want minimum fees, don't warn about it
+    // ui->labelMinFeeWarning      ->setEnabled(ui->radioCustomFee->isChecked());
     ui->radioCustomPerKilobyte  ->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
     ui->radioCustomAtLeast      ->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked() && CoinControlDialog::coinControl->HasSelected());
     ui->customFee               ->setEnabled(ui->radioCustomFee->isChecked() && !ui->checkBoxMinimumFee->isChecked());
@@ -659,11 +660,12 @@ void SendCoinsDialog::updateSmartFeeLabel()
                                                                 std::max(CWallet::fallbackFee.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
-        ui->fallbackFeeWarningLabel->setVisible(true);
-        int lightness = ui->fallbackFeeWarningLabel->palette().color(QPalette::WindowText).lightness();
-        QColor warning_colour(255 - (lightness / 5), 176 - (lightness / 3), 48 - (lightness / 14));
-        ui->fallbackFeeWarningLabel->setStyleSheet("QLabel { color: " + warning_colour.name() + "; }");
-        ui->fallbackFeeWarningLabel->setIndent(QFontMetrics(ui->fallbackFeeWarningLabel->font()).width("x"));
+        // Dogecoin: We don't care we're using fallback fees
+        // ui->fallbackFeeWarningLabel->setVisible(true);
+        // int lightness = ui->fallbackFeeWarningLabel->palette().color(QPalette::WindowText).lightness();
+        // QColor warning_colour(255 - (lightness / 5), 176 - (lightness / 3), 48 - (lightness / 14));
+        // ui->fallbackFeeWarningLabel->setStyleSheet("QLabel { color: " + warning_colour.name() + "; }");
+        // ui->fallbackFeeWarningLabel->setIndent(QFontMetrics(ui->fallbackFeeWarningLabel->font()).width("x"));
     }
     else
     {
@@ -671,7 +673,7 @@ void SendCoinsDialog::updateSmartFeeLabel()
                                                                 std::max(feeRate.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
         ui->labelSmartFee2->hide();
         ui->labelFeeEstimation->setText(tr("Estimated to begin confirmation within %n block(s).", "", estimateFoundAtBlocks));
-        ui->fallbackFeeWarningLabel->setVisible(false);
+        // ui->fallbackFeeWarningLabel->setVisible(false);
     }
 
     updateFeeMinimizedLabel();


### PR DESCRIPTION
Hide smart fee UI elements, as they do not make sense for Dogecoin. Dogecoin uses the defined minimum in virtually all transactions, rather than smart fees, and this Bitcoin-focused UI does not match the expected workflow.