### PR TITLE
depends: Update OpenSSL to 1.0.2u and fix issues it introduces  

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -119,11 +119,35 @@ $(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
 	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
 	$(AT)touch $@
 
+# $PATH is not preserved between ./configure and make by convention. Its
+# modification and overriding at ./configure time is (as I understand it)
+# supposed to be captured by the AC_{PROG_{,OBJ}CXX,PATH_{PROG,TOOL}} macros,
+# which will expand the program names to their full absolute paths. The notable
+# exception is command line overriding: ./configure CC=clang, which skips the
+# program name expansion step, and works because the user implicitly indicates
+# with CC=clang that clang will be available in $PATH at all times, and is most
+# likely part of the user's system.
+#
+# Therefore, when we "seed the autoconf cache"/"override well-known program
+# vars" by setting AR=<blah> in our config.site, either one of two things needs
+# to be true for the build system to work correctly:
+#
+#   1. If we refer to the program by name (e.g. AR=riscv64-gnu-linux-ar), the
+#      tool needs to be available in $PATH at all times.
+#
+#   2. If the tool is _**not**_ expected to be available in $PATH at all times
+#      (such as is the case for our native_cctools binutils tools), it needs to
+#      be referred to by its absolute path, such as would be output by the
+#      AC_PATH_{PROG,TOOL} macros.
+#
+# Minor note: it is also okay to refer to tools by their absolute path even if
+# we expect them to be available in $PATH at all times, more specificity does
+# not hurt.
 $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
 	$(AT)@mkdir -p $(@D)
 	$(AT)sed -e 's|@HOST@|$(host)|' \
-            -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
-            -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
+            -e 's|@CC@|$(host_CC)|' \
+            -e 's|@CXX@|$(host_CXX)|' \
             -e 's|@AR@|$(toolchain_path)$(host_AR)|' \
             -e 's|@RANLIB@|$(toolchain_path)$(host_RANLIB)|' \
             -e 's|@NM@|$(toolchain_path)$(host_NM)|' \

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -2,8 +2,12 @@ OSX_MIN_VERSION=10.8
 OSX_SDK_VERSION=10.11
 OSX_SDK=$(SDK_PATH)/MacOSX$(OSX_SDK_VERSION).sdk
 LD64_VERSION=253.9
-darwin_CC=clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)
-darwin_CXX=clang++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -stdlib=libc++
+
+clang_prog=$(build_prefix)/bin/clang
+clangxx_prog=$(clang_prog)++
+
+darwin_CC=$(build_prefix)/bin/clang -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION)
+darwin_CXX=$(clang_prog)++ -target $(host) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(OSX_SDK) -mlinker-version=$(LD64_VERSION) -stdlib=libc++
 
 darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -4,6 +4,7 @@ $(package)_version_suffix=u
 $(package)_download_path=https://www.openssl.org/source/old/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
 $(package)_sha256_hash=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
+$(package)_patches=secure_getenv.patch
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -58,6 +59,7 @@ $(package)_config_opts_i686_mingw32=mingw
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/secure_getenv.patch && \
   sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
   sed -i.old "s|engines apps test|engines|" Makefile.org
 endef

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,9 +1,9 @@
 package=openssl
-$(package)_version=1.0.1
-$(package)_version_suffix=l
+$(package)_version=1.0.2
+$(package)_version_suffix=u
 $(package)_download_path=https://www.openssl.org/source/old/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
-$(package)_sha256_hash=b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4
+$(package)_sha256_hash=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -63,7 +63,8 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./Configure $($(package)_config_opts)
+  ./Configure $($(package)_config_opts) && \
+  make depend
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/openssl/secure_getenv.patch
+++ b/depends/patches/openssl/secure_getenv.patch
@@ -1,0 +1,37 @@
+Solves export of glibc 2.17 secure_getenv because we support down to 2.11
+
+Patches openssl 1.0.2's usage of secure_getenv from glibc 2.17 to instead
+always use the fallback OPENSSL_issetugid(), which essentially does the
+same thing on linux, with the only difference that the glibc version makes
+decisions on startup, whereas the openssl version does the same check each
+time the environment is read.
+
+glibc check: https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/enbl-secure.c;h=9e47526bd3e444e1a19a8ea9fd310b6f47c4db52;hb=HEAD
+glibc implementation: https://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/secure-getenv.c;h=a394eebcf794c1279d66e5bcb71d4b15725e6e5a;hb=HEAD
+
+openssl check: https://github.com/openssl/openssl/blob/OpenSSL_1_0_2u/crypto/uid.c
+
+This patch can be removed when glibc 2.17 is the minimum version supported
+
+Author: Patrick Lodder <patricklodder@users.noreply.github.com>
+
+diff -dur a/crypto/getenv.c b/crypto/getenv.c
+--- a/crypto/getenv.c	2019-12-20 13:02:41.000000000 +0000
++++ b/crypto/getenv.c	2021-09-20 03:02:04.125747397 +0000
+@@ -16,16 +16,7 @@
+
+ char *ossl_safe_getenv(const char *name)
+ {
+-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+-# if __GLIBC_PREREQ(2, 17)
+-#  define SECURE_GETENV
+-    return secure_getenv(name);
+-# endif
+-#endif
+-
+-#ifndef SECURE_GETENV
+     if (OPENSSL_issetugid())
+         return NULL;
+     return getenv(name);
+-#endif
+ }


### PR DESCRIPTION
Patches OpenSSL source and the OSX build system on top of #2580, and replaces that PR.

### OpenSSL source code patch - `cbc3aae`

This patches openssl 1.0.2's usage of `secure_getenv()` to always use the fallback `OPENSSL_issetugid()` instead, to remove reliance on a higher glibc than the minimum we currently support ([2.11](https://github.com/dogecoin/dogecoin/blob/4c93783ab64ba96e60b7ea37202c072c66f3f544/contrib/devtools/symbol-check.py#L43))

The fallback code essentially does the same thing on linux as glibc's method, with the only difference that the glibc version makes decisions on startup, whereas the openssl version does the same check each time the environment is read.

See the [glibc check](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/enbl-secure.c;h=9e47526bd3e444e1a19a8ea9fd310b6f47c4db52;hb=HEAD) and [implementation](https://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/secure-getenv.c;h=a394eebcf794c1279d66e5bcb71d4b15725e6e5a;hb=HEAD), and the [openssl check]( https://github.com/openssl/openssl/blob/OpenSSL_1_0_2u/crypto/uid.c) for reference.

This patch can be removed when glibc 2.17 is the minimum version supported, i.e. for 1.21, [where the minimum glibc version is 2.17](https://github.com/dogecoin/dogecoin/blob/b262c2b3be9e1f40b362e65cea01bdd9204260dc/contrib/devtools/symbol-check.py#L42)

### OSX build system fix - `043ce9a`

Because of `make depend` magic needed inside OpenSSL not using `config.site` (only autoconf uses it, not make), `clang` was not being found when not installed inside the `$PATH`, and making the CI, which has that installed inside the `$PATH`, compile with the wrong compiler (the provided one rather than the "native" dependency from `depends/`)

I've added this selectively cherry-picked backport from Bitcoin Core (880660a) that fixates the location of `clang` and `clang++` properly, making sure that the correct pinned binary (from native depends) gets used, and not any other `clang`, i.e. something installed on the build system exposed through `$PATH`. I have removed all code surrounding the macOS native depends build from the original commit, because we do not have that facility in 1.14.

Note that there's a detailed explanation added to the `depends/Makefile` that clarifies how binary locations specified in the different `host` and `package` descriptors are being used. More changes can and imho should be made to these descriptors, but as these do not block OpenSSL 1.0.2u compilation, we can do this separately and I have not included these with this PR.