### PR TITLE
fees: clarify what the actual recommended fee is

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -14,6 +14,13 @@
 
 class CCoinsViewCache;
 
+/** Recommended transaction fee by Dogecoin Core developers
+  *
+  * All fee defaults used throughout the client derive their
+  * value from this base default.
+  */
+static const CAmount RECOMMENDED_MIN_TX_FEE = COIN / 100;
+
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
@@ -21,7 +28,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = COIN / 100;
+static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = (unsigned int) RECOMMENDED_MIN_TX_FEE;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
@@ -31,7 +38,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
-static const CAmount DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
+static const CAmount DEFAULT_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 1000;
 /** Default for -bytespersigop */
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 /** The maximum number of witness stack items in a standard P2WSH script */
@@ -45,13 +52,13 @@ static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
-static const CAmount DUST_RELAY_TX_FEE = COIN / 100000;
+static const CAmount DUST_RELAY_TX_FEE = RECOMMENDED_MIN_TX_FEE / 1000;
 /**
  * Dogecoin: Default dust limit that is evaluated when considering whether a
  * transaction output is required to pay additional fee for relay and inclusion
  * in blocks. Overridden by -dustlimit
  */
-static const CAmount DEFAULT_DUST_LIMIT = COIN / 100;
+static const CAmount DEFAULT_DUST_LIMIT = RECOMMENDED_MIN_TX_FEE;
 
 /**
  * Standard script verification flags that standard transactions will comply

--- a/src/validation.h
+++ b/src/validation.h
@@ -13,6 +13,7 @@
 #include "amount.h"
 #include "chain.h"
 #include "coins.h"
+#include "policy/policy.h" // For RECOMMENDED_MIN_TX_FEE
 #include "protocol.h" // For CMessageHeader::MessageStartChars
 #include "script/script_error.h"
 #include "sync.h"
@@ -54,14 +55,14 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const CAmount DEFAULT_MIN_RELAY_TX_FEE = COIN / 1000;
+static const CAmount DEFAULT_MIN_RELAY_TX_FEE = RECOMMENDED_MIN_TX_FEE / 10;
 //! -maxtxfee default
 //rnicoll: 8/2021 scaled down as recommended fee is lowered
-static const CAmount DEFAULT_TRANSACTION_MAXFEE = 100 * COIN;
+static const CAmount DEFAULT_TRANSACTION_MAXFEE = RECOMMENDED_MIN_TX_FEE * 10000;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
 //mlumin: 5/2021 adjusted downward for fee revisions
 //rnicoll: 8/2021 scale further down as recommended fee is lowered
-static const CAmount HIGH_TX_FEE_PER_KB = COIN;
+static const CAmount HIGH_TX_FEE_PER_KB = RECOMMENDED_MIN_TX_FEE * 100;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 //mlumin: 5/2021 adjusted max upward in terms of coin
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -14,6 +14,7 @@
 #include "ui_interface.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "policy/policy.h"
 #include "script/ismine.h"
 #include "script/sign.h"
 #include "wallet/crypter.h"
@@ -48,19 +49,19 @@ extern bool fWalletRbf;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default
-static const CAmount DEFAULT_TRANSACTION_FEE = COIN / 100;
+static const CAmount DEFAULT_TRANSACTION_FEE = RECOMMENDED_MIN_TX_FEE;
 //! -fallbackfee default
 //mlumin: 5/2021 scaled minimum, this likely will have to change for fee reduction
 //rnicoll: 8/2021 reduce to 1,000,000 Koinu
-static const CAmount DEFAULT_FALLBACK_FEE = COIN / 100;
+static const CAmount DEFAULT_FALLBACK_FEE = RECOMMENDED_MIN_TX_FEE;
 //! -mintxfee default
-static const CAmount DEFAULT_TRANSACTION_MINFEE = COIN / 100;
+static const CAmount DEFAULT_TRANSACTION_MINFEE = RECOMMENDED_MIN_TX_FEE;
 //! minimum recommended increment for BIP 125 replacement txs
-static const CAmount WALLET_INCREMENTAL_RELAY_FEE = COIN/10 * 5;
+static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE * 50;
 //! target minimum change amount
-static const CAmount MIN_CHANGE = COIN / 100;
+static const CAmount MIN_CHANGE = RECOMMENDED_MIN_TX_FEE;
 //! final minimum change amount after paying for fees
-static const CAmount MIN_FINAL_CHANGE = COIN / 100;
+static const CAmount MIN_FINAL_CHANGE = RECOMMENDED_MIN_TX_FEE;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -sendfreetransactions


### PR DESCRIPTION
Introduces RECOMMENDED_MIN_TX_FEE as a constant that explicitly sets a single value and then implements this value for each fee related constant throughout the code, instead of using values relative to COIN.

This helps because it makes the relation of other defaults to the fee recommendation clear and makes
choices made by developers in wallet configuration easier to read and understand. In the past we had the problem that
one constant / default was being used for multiple reasons, but now, all the logic between the different defaults is extremely hard to read because everything is expressed relative to `COIN`, and this makes it error-prone, for both developer and reviewer. 

**NOTE: This commit only changes existing values to be expressed relative to the recommended fee and does not change actual values.**

Issues I detect by looking at it this way:
- `DEFAULT_INCREMENTAL_RELAY_FEE` and `DUST_RELAY_TX_FEE` are probably wrong
- `DEFAULT_TRANSACTION_MAXFEE` is on the high side
- `HIGH_TX_FEE_PER_KB` is lower than the 5.21 DOGE from the slider
- `MIN_CHANGE` is suboptimal
- `WALLET_INCREMENTAL_RELAY_FEE` is probably wrong

Fixes to these can (and imho should) be proposed and discussed separately, so that this PR stays clean of changes, creating a clean audit trail.