### PR TITLE
wallet/fee: Update MIN_CHANGE, related tests and document why

### DIFF
--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -279,7 +279,7 @@ def test_locked_wallet_fails(rbf_node, dest_address):
 
 def test_dogecoin_wallet_minchange(rbf_node, dest_address):
     input = Decimal("10.00000000")
-    min_change = Decimal("0.01000000")
+    min_change = Decimal("0.03000000")
     min_fee = Decimal("0.01000000")
     bumpfee = Decimal("0.001")
     est_tx_size = Decimal("0.193")

--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -15,7 +15,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.num_nodes = 2
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-spendzeroconfchange=0'], None])
         connect_nodes_bi(self.nodes,0,1)
         self.is_network_split=False
         self.sync_all()
@@ -25,7 +25,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[0].generate(101)
 
         self.sync_all()
-        
+
         # address
         address1 = self.nodes[0].getnewaddress()
         # pubkey
@@ -59,18 +59,18 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         #Send funds to self
         txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
-        self.nodes[0].generate(1)
         rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
-        proof1 = self.nodes[0].gettxoutproof([txnid1])
 
         txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
-        self.nodes[0].generate(1)
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
-        proof2 = self.nodes[0].gettxoutproof([txnid2])
 
         txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
-        self.nodes[0].generate(1)
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
+
+        self.nodes[0].generate(1)
+
+        proof1 = self.nodes[0].gettxoutproof([txnid1])
+        proof2 = self.nodes[0].gettxoutproof([txnid2])
         proof3 = self.nodes[0].gettxoutproof([txnid3])
 
         self.sync_all()


### PR DESCRIPTION
Changes the value of `MIN_CHANGE` and make it clear in parameter coding that both change parameters are derived from the dust limit and the recommended fee, not just the recommended fee.

### Changes:

1. Add a test case to `bumpfee.py` to test the performance of the `MIN_CHANGE` value. Fails on its own.
2. Change the value of `MIN_CHANGE` and clarify that `MIN_FINAL_CHANGE` is the `DEFAULT_DUST_LIMIT` rather than the `RECOMMENDED_MIN_TX_FEE`
3. Fix `importprunedfunds.py`, but instead of changing the values again that rely on `MIN_CHANGE` magic to not respend outputs that are tested, harden the test to work regardless of wallet parametrization by changing when the tested transactions get mined.

### Rationale for changing `MIN_CHANGE`, also documented inline:

Creating change outputs at exactly the dust limit is counter-productive because it leaves no space to bump the fee up, so we make the `MIN_CHANGE` parameter higher than the `MIN_FINAL_CHANGE` parameter. When RBF is not a default policy, we need to scale for both that and CPFP, to have a facility for those that did not manually enable RBF, yet need to bump a fee for their transaction to get mined.

Using bumpfee (without additional parameters) currently will add `WALLET_INCREMENTAL_RELAY_FEE` as a fixed increment, and CPFP would need the spending fee for at least 147 bytes (1 input, 1 output), and additional space for actually increasing the fee for both transactions.

Because the change calculation is currently not taking into account feerate or transaction size, we assume that most transactions are < 1kb, leading to the following when planning for a replacements with 2x original fee:

```
RBF: MIN_CHANGE = dust limit + min fee or
CPFP: MIN_CHANGE = dust limit + 2 * min fee * 0.147 + min fee
```

Where the CPFP requirement is higher than the RBF one to lead to the same result.

This can be rounded up to the nearest multiple of `RECOMMENDED_MIN_TX_FEE` as: 
```cpp
MIN_CHANGE = DEFAULT_DUST_LIMIT + 2 * RECOMMENDED_MIN_TX_FEE
```

The `MIN_FINAL_CHANGE` parameter can stay equal to `DEFAULT_DUST_LIMIT` as this influences when the wallet will discard all remaining dust as fee instead of change.

### Not touched

I have a commit that also changes `DUST_RELAY_TX_FEE` in `policy/policy.h` but since that is unrelated to the wallet and we may need some more discussion on that one, I will PR that separately.