### PR TITLE
build: Add libxkbcommon 0.8.4

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -40,7 +40,8 @@ MAX_VERSIONS = {
 'GCC':     (4,4,0),
 'CXXABI':  (1,3,3),
 'GLIBCXX': (3,4,13),
-'GLIBC':   (2,11)
+'GLIBC':   (2,11),
+'V':       (0,5,0) # xkb (qt only)
 }
 # See here for a description of _IO_stdin_used:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=634261#109
@@ -66,6 +67,8 @@ b'ld-linux.so.2', # 32-bit dynamic linker
 b'libX11-xcb.so.1', # part of X11
 b'libX11.so.6', # part of X11
 b'libxcb.so.1', # part of X11
+b'libxkbcommon.so.0', # keyboard keymapping
+b'libxkbcommon-x11.so.0', # keyboard keymapping
 b'libfontconfig.so.1', # font support
 b'libfreetype.so.6', # font parsing
 b'libdl.so.2' # programming interface to dynamic linker
@@ -160,5 +163,3 @@ if __name__ == '__main__':
                 retval = 1
 
     exit(retval)
-
-

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -24,6 +24,7 @@ packages:
 - "libtool"
 - "automake"
 - "faketime"
+- "bison"
 - "bsdmainutils"
 - "ca-certificates"
 - "python"

--- a/depends/README.md
+++ b/depends/README.md
@@ -9,7 +9,7 @@ work.
 
 ```
 sudo apt-get install autoconf automake binutils-gold ca-certificates curl \
-                     faketime git-core libtool pkg-config python
+                     faketime git-core libtool pkg-config python bison
 ```
 
 #### Generic linux: i686-pc-linux-gnu and x86_64-linux-gnu

--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -1,0 +1,31 @@
+package=libxkbcommon
+$(package)_version=0.8.4
+$(package)_download_path=https://xkbcommon.org/download/
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
+$(package)_dependencies=libxcb
+
+define $(package)_set_vars
+$(package)_config_opts = --enable-option-checking --disable-dependency-tracking
+$(package)_config_opts += --disable-static --disable-docs
+endef
+
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+
+define $(package)_postprocess_cmds
+  rm -rf lib/*.la
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -4,7 +4,7 @@ native_packages := native_ccache
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib
 
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
+qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans libxkbcommon
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 
 qt_darwin_packages=qt

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -5,7 +5,7 @@ $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410
 $(package)_dependencies=openssl zlib
-$(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
+$(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext libxkbcommon
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib printsupport
 $(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch
@@ -89,8 +89,7 @@ $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option MAC_LD64_VERSION=$(LD64_VERSION)
 endif
 
-$(package)_config_opts_linux  = -qt-xkbcommon
-$(package)_config_opts_linux += -qt-xcb
+$(package)_config_opts_linux = -qt-xcb
 $(package)_config_opts_linux += -system-freetype
 $(package)_config_opts_linux += -no-sm
 $(package)_config_opts_linux += -fontconfig


### PR DESCRIPTION
Backport that adds [libxkbcommon](https://github.com/xkbcommon/libxkbcommon) to the depends system from Bitcoin Core's 0.22 branch, to fix both #2338 and the non-determinism in #2501 by getting rid of the `-qt-xkbcommon` build flag that uses qt's built-in xkbcommon sources, but then erroneously fall back to build system libs later in the process. I am proposing this independently from the build system upgrade PR, because this should work on both trusty and bionic build environments; this should be a non-blocking fix.

Fixes an error in the build process described in https://github.com/dogecoin/dogecoin/pull/2501#issuecomment-929369528 during qt depends build (grepped from gitian `build.log` for the run done on #2581):

```
31484:checking for xkbcommon... 
31485:make[1]: Entering directory `/home/ubuntu/build/dogecoin/depends/work/build/x86_64-linux-gnu/qt/5.7.1-5ba3dce7d75/qtbase/config.tests/unix/xkbcommon'
31486:g++ -c -pipe -pipe -O2 -I/home/ubuntu/build/dogecoin/depends/x86_64-linux-gnu/include -O2 -Wall -W -fPIC  -I. -I../../../mkspecs/linux-g++ -o xkbcommon.oxkbcommon.cpp
31487:xkbcommon.cpp:40:33: fatal error: xkbcommon/xkbcommon.h: No such file or directory
31488: #include <xkbcommon/xkbcommon.h>
31491:make[1]: *** [xkbcommon.o] Error 1
31492:make[1]: Leaving directory `/home/ubuntu/build/dogecoin/depends/work/build/x86_64-linux-gnu/qt/5.7.1-5ba3dce7d75/qtbase/config.tests/unix/xkbcommon'
31493:xkbcommon disabled.
```

### Origin
Cherry-picked and squashed from bitcoin/bitcoin:
-  3272e34f: adds the actual dependency
- [`cc25f89`](https://github.com/bitcoin/bitcoin/commit/cc25f892d27351e60a8cf7bf5e60b167ebe33201): cleans up the script
- [`a33381a`](https://github.com/bitcoin/bitcoin/commit/a33381acf5ae2b43616fffaf26b1c8962e8ef0bb): allows xkb symbols to be imported

### Conflicts resolved
- removed ci script and guix file changes that we don't have
- removed changes to libxcb, these will need to be re-done later when we update that dependency
- rewrote the change to depends/README

### Testing
- [x] Needs a gitian check on at least the x86_64 and i686 linux binaries.
- [x] Needs manual verification that this fixes #2338

### Gitian (trusty, docker) sha256sum digests (linux) for 557a921

```
03346cac736a3b558c4428421786177197e3d018d267380369824bf506434ab0  dogecoin-1.14.5-aarch64-linux-gnu-debug.tar.gz
d7585751a346203c602f2ce77a4cf5b281b54ebece54d06d69e0ec2e0d1f3707  dogecoin-1.14.5-aarch64-linux-gnu.tar.gz
f9f2caadae82acfd2da88cd384d1f1a54a4bfabd4273a3130ba2551bf3f0e15f  dogecoin-1.14.5-arm-linux-gnueabihf-debug.tar.gz
9bf9880c9f97cc68ef044947bb0c4e152a6ae27e34dba89d69c6befae5541f28  dogecoin-1.14.5-arm-linux-gnueabihf.tar.gz
6fbb00b249bb007cfa95c70f09d6960dd1d4973e0a6219c63c872bd013d1c7ed  dogecoin-1.14.5-i686-pc-linux-gnu-debug.tar.gz
a28a362f87f820fae648aedbbb68e4ff5384ad2ac21b3b3c839a672d7c063b64  dogecoin-1.14.5-i686-pc-linux-gnu.tar.gz
4385c4639f45b18421b4967166f2a63186f534ef4585ee13737176ead3ba24a3  dogecoin-1.14.5-x86_64-linux-gnu-debug.tar.gz
468ddd76f7dc816eb3d4572a05ba11d592c652c32adc9668fbef4ff61ef28f23  dogecoin-1.14.5-x86_64-linux-gnu.tar.gz
32c6e84ddd033a085cee167e52e3953eb2e8566cd89fc0a9078d28893c24ea8a  dogecoin-1.14.5.tar.gz
```
