### PR TITLE
qa: facilitate MIN_CHANGE to be higher than COIN in tests

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -200,7 +200,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : Decimal(4.0) }
+        outputs = { self.nodes[0].getnewaddress() : Decimal("3.9") }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
@@ -336,7 +336,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         #compare fee of a standard pubkeyhash transaction with multiple outputs
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1,self.nodes[1].getnewaddress():1.2,self.nodes[1].getnewaddress():0.1,self.nodes[1].getnewaddress():1.3,self.nodes[1].getnewaddress():0.2,self.nodes[1].getnewaddress():0.3}
+        outputs = {self.nodes[1].getnewaddress():1.1,self.nodes[1].getnewaddress():1.2,self.nodes[1].getnewaddress():1.1,self.nodes[1].getnewaddress():1.3,self.nodes[1].getnewaddress():1.2,self.nodes[1].getnewaddress():1.3}
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawTx)
         #create same transaction over sendtoaddress
@@ -508,13 +508,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         for i in range(0,20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
         self.nodes[0].generate(1)
         self.sync_all()
 
         #fund a tx with ~20 small inputs
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():1.15,self.nodes[0].getnewaddress():1.04}
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawTx)
 
@@ -538,7 +538,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         for i in range(0,20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
         self.nodes[0].generate(1)
         self.sync_all()
 
@@ -546,7 +546,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():1.15,self.nodes[0].getnewaddress():1.04}
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawTx)
         fundedAndSignedTx = self.nodes[1].signrawtransaction(fundedTx['hex'])
@@ -554,7 +554,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
-        assert_equal(oldBalance+Decimal('500000.19000'), self.nodes[0].getbalance()) #0.19+block reward
+        assert_equal(oldBalance+Decimal('500002.19000'), self.nodes[0].getbalance()) #2.19+block reward
 
         #####################################################
         # test fundrawtransaction with OP_RETURN and no vin #
@@ -677,7 +677,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
 
         inputs = []
-        outputs = {self.nodes[2].getnewaddress(): 1}
+        outputs = {self.nodes[2].getnewaddress(): 2}
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
 
         result = [self.nodes[3].fundrawtransaction(rawtx), # uses min_relay_tx_fee (set by settxfee)
@@ -700,7 +700,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(change[3] + result[3]['fee'], change[4])
 
         inputs = []
-        outputs = {self.nodes[2].getnewaddress(): value for value in (1.0, 1.1, 1.2, 1.3)}
+        outputs = {self.nodes[2].getnewaddress(): value for value in (1.05, 1.1, 1.2, 1.3)}
         keys = list(outputs.keys())
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
 

--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -58,13 +58,13 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['ismine'], False)
 
         #Send funds to self
-        txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
+        txnid1 = self.nodes[0].sendtoaddress(address1, 10)
         rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
 
-        txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
+        txnid2 = self.nodes[0].sendtoaddress(address2, 5)
         rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
 
-        txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
+        txnid3 = self.nodes[0].sendtoaddress(address3, 2.5)
         rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
 
         self.nodes[0].generate(1)
@@ -85,15 +85,15 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[1].importaddress(address2, "add2", False)
         result2 = self.nodes[1].importprunedfunds(rawtxn2, proof2)
         balance2 = self.nodes[1].getbalance("add2", 0, True)
-        assert_equal(balance2, Decimal('0.05'))
+        assert_equal(balance2, Decimal('5.0'))
 
         #Import with private key with no rescan
         self.nodes[1].importprivkey(address3_privkey, "add3", False)
         result3 = self.nodes[1].importprunedfunds(rawtxn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
-        assert_equal(balance3, Decimal('0.025'))
+        assert_equal(balance3, Decimal('2.5'))
         balance3 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance3, Decimal('0.075'))
+        assert_equal(balance3, Decimal('7.5'))
 
         #Addresses Test - after import
         address_info = self.nodes[1].validateaddress(address1)
@@ -110,11 +110,11 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_raises_jsonrpc(-8, "Transaction does not exist in wallet.", self.nodes[1].removeprunedfunds, txnid1)
 
         balance1 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance1, Decimal('0.075'))
+        assert_equal(balance1, Decimal('7.5'))
 
         self.nodes[1].removeprunedfunds(txnid2)
         balance2 = self.nodes[1].getbalance("*", 0, True)
-        assert_equal(balance2, Decimal('0.025'))
+        assert_equal(balance2, Decimal('2.5'))
 
         self.nodes[1].removeprunedfunds(txnid3)
         balance3 = self.nodes[1].getbalance("*", 0, True)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -93,109 +93,109 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // with an empty wallet we can't even pay one coin
         BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        add_coin(1*COIN, 4);        // add a new 1 coin output
+        add_coin(10*COIN, 4);        // add a new 10 coin output
 
-        // with only a new 1 coin output, we still can't find a mature 1 coin output
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 1 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // with only a new 1 coin output, we still can't find a mature 10 coin output
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 10 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        // but we can find a new 1 coin output
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 1 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);
+        // but we can find a new 10 coin output
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 10 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 10 * COIN);
 
-        add_coin(2*COIN);           // add a mature 2 coin output
+        add_coin(20*COIN);           // add a mature 20 coin output
 
-        // we can't make 3 coins of mature outputs
-        BOOST_CHECK(!wallet.SelectCoinsMinConf( 3 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // we can't make 30 coins of mature outputs
+        BOOST_CHECK(!wallet.SelectCoinsMinConf( 30 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
 
-        // we can make 3 coin of new outputs
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 3 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 3 * COIN);
+        // we can make 30 coin of new outputs
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 30 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 30 * COIN);
 
-        add_coin(5*COIN);           // add a mature 5 coin output,
-        add_coin(10*COIN, 3, true); // a new 10 coin output sent from one of our own addresses
-        add_coin(20*COIN);          // and a mature 20 coin output
+        add_coin(50*COIN);           // add a mature 50 coin output,
+        add_coin(100*COIN, 3, true); // a new 100 coin output sent from one of our own addresses
+        add_coin(200*COIN);          // and a mature 200 coin output
 
-        // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
+        // now we have new: 10+100=110 (of which 100 was self-sent), and mature: 20+50+200=270.  total = 380
 
-        // we can't make 38 coins only if we disallow new output:
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
-        // we can't even make 37 coins if we don't allow new output even if they're from us
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(38 * COIN, 6, 6, 0, vCoins, setCoinsRet, nValueRet));
-        // but we can make 37 coins if we accept new output from ourself
-        BOOST_CHECK( wallet.SelectCoinsMinConf(37 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 37 * COIN);
-        // and we can make 38 coins if we accept all new output
-        BOOST_CHECK( wallet.SelectCoinsMinConf(38 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 38 * COIN);
+        // we can't make 380 coins only if we disallow new output:
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(380 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // we can't even make 370 coins if we don't allow new output even if they're from us
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(380 * COIN, 6, 6, 0, vCoins, setCoinsRet, nValueRet));
+        // but we can make 370 coins if we accept new output from ourself
+        BOOST_CHECK( wallet.SelectCoinsMinConf(370 * COIN, 1, 6, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 370 * COIN);
+        // and we can make 380 coins if we accept all new output
+        BOOST_CHECK( wallet.SelectCoinsMinConf(380 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 380 * COIN);
 
-        // try making 34 coins from 1,2,5,10,20 - we can't do it exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(34 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 35 * COIN);       // but 35 coins is closest
-        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);     // the best should be 20+10+5.  it's incredibly unlikely the 1 or 2 got included (but possible)
+        // try making 340 coins from 10,20,50,100,200 - we can't do it exactly
+        BOOST_CHECK( wallet.SelectCoinsMinConf(340 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 350 * COIN);       // but 350 coins is closest
+        BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);     // the best should be 200+100+50.  it's incredibly unlikely the 10 or 20 got included (but possible)
 
-        // when we try making 7 coins, the smaller outputs (1,2,5) are enough.  We should see just 2+5
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 7 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 7 * COIN);
+        // when we try making 70 coins, the smaller outputs (10,20,50) are enough.  We should see just 20+50
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 70 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 70 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
-        // when we try making 8 coins, the smaller outputs (1,2,5) are exactly enough.
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 8 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(nValueRet == 8 * COIN);
+        // when we try making 80 coins, the smaller outputs (10,20,50) are exactly enough.
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 80 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(nValueRet == 80 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        // when we try making 9 coins, no subset of smaller outputs is enough, and we get the next bigger output (10)
-        BOOST_CHECK( wallet.SelectCoinsMinConf( 9 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 10 * COIN);
+        // when we try making 90 coins, no subset of smaller outputs is enough, and we get the next bigger output (100)
+        BOOST_CHECK( wallet.SelectCoinsMinConf( 90 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 100 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
         empty_wallet();
 
-        add_coin( 6*COIN);
-        add_coin( 7*COIN);
-        add_coin( 8*COIN);
-        add_coin(20*COIN);
-        add_coin(30*COIN); // now we have 6+7+8+20+30 = 71 coins total
+        add_coin( 60*COIN);
+        add_coin( 70*COIN);
+        add_coin( 80*COIN);
+        add_coin(200*COIN);
+        add_coin(300*COIN); // now we have 60+70+80+200+300 = 710 coins total
 
-        // check that we have 71 and not 72
-        BOOST_CHECK( wallet.SelectCoinsMinConf(71 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK(!wallet.SelectCoinsMinConf(72 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        // check that we have 710 and not 711
+        BOOST_CHECK( wallet.SelectCoinsMinConf(710 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK(!wallet.SelectCoinsMinConf(711 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
 
-        // now try making 16 coins.  the best smaller outputs can do is 6+7+8 = 21; not as good at the next biggest output, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 20 * COIN); // we should get 20 in one output
+        // now try making 160 coins.  the best smaller outputs can do is 60+70+80 = 210; not as good at the next biggest output, 200
+        BOOST_CHECK( wallet.SelectCoinsMinConf(160 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 200 * COIN); // we should get 200 in one output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        add_coin( 5*COIN); // now we have 5+6+7+8+20+30 = 75 coins total
+        add_coin( 50*COIN); // now we have 50+60+70+80+200+300 = 750 coins total
 
-        // now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 coins, better than the next biggest output, 20
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * COIN); // we should get 18 in 3 outputs
+        // now if we try making 160 coins again, the smaller outputs can make 50+60+70 = 18 coins, better than the next biggest output, 200
+        BOOST_CHECK( wallet.SelectCoinsMinConf(160 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 180 * COIN); // we should get 180 in 3 outputs
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        add_coin( 18*COIN); // now we have 5+6+7+8+18+20+30
+        add_coin( 180*COIN); // now we have 50+60+70+80+180+200+300
 
-        // and now if we try making 16 coins again, the smaller outputs can make 5+6+7 = 18 coins, the same as the next biggest output, 18
-        BOOST_CHECK( wallet.SelectCoinsMinConf(16 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 18 * COIN);  // we should get 18 in 1 output
+        // and now if we try making 16 coins again, the smaller outputs can make 50+60+70 = 180 coins, the same as the next biggest output, 180
+        BOOST_CHECK( wallet.SelectCoinsMinConf(160 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 180 * COIN);  // we should get 180 in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U); // because in the event of a tie, the biggest output wins
 
-        // now try making 11 coins.  we should get 5+6
-        BOOST_CHECK( wallet.SelectCoinsMinConf(11 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 11 * COIN);
+        // now try making 110 coins.  we should get 50+60
+        BOOST_CHECK( wallet.SelectCoinsMinConf(110 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 110 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // check that the smallest bigger output is used
-        add_coin( 100*COIN);
-        add_coin( 200*COIN);
-        add_coin( 300*COIN);
-        add_coin( 400*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 coins
-        BOOST_CHECK( wallet.SelectCoinsMinConf(95 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 100 * COIN);  // we should get 100 coins in 1 output
+        add_coin( 1000*COIN);
+        add_coin( 2000*COIN);
+        add_coin( 3000*COIN);
+        add_coin( 4000*COIN); // now we have 50+60+70+80+180+200+300+1000+2000+3000+4000 = 10940 coins
+        BOOST_CHECK( wallet.SelectCoinsMinConf(950 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1000 * COIN);  // we should get 1000 coins in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        BOOST_CHECK( wallet.SelectCoinsMinConf(195 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 200 * COIN);  // we should get 200 coins in 1 output
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1950 * COIN, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 2000 * COIN);  // we should get 2000 coins in 1 output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // empty the wallet and start again, now with fractions of a coin, to test small change avoidance


### PR DESCRIPTION
Some tests expect `MIN_CHANGE` to be less than (or equal to) `COIN`, which will not be the case as long as the network enforces a 1 DOGE hard dust limit. This PR prepares both unit and functional tests (and undoes a couple of changes from 9c6af6d84 that turned out to hurt more than I expected) to be able to have higher `MIN_CHANGE`.

- `wallet_tests.cpp`: Multiply all inputs and queries by 10 for tests that aren't relative to `MIN_CHANGE`
- `fundrawtransaction.py`: make sure there are no (change) outputs smaller than or equal to 1 DOGE
- `importprunedfunds.py`: Multiply all outputs by 100

This is an enabler for solving #2601 and #2603. By raising this before any changes are made to parametrization and dust logic, we can be sure that the tests are correct (after all, no code outside of tests has been changed and none of these tests are actually testing the dust limit itself) and this also lessens the complexity of the changes to be reviewed in upcoming PRs that actually solve the dust limit issues a bit.