### PR TITLE
Split the dust definition 3-way to enable lower limits

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -164,6 +164,7 @@ testScripts = [
     'listsinceblock.py',
     'p2p-leaktests.py',
     'replace-by-fee.py',
+    'p2p-policy.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -279,20 +279,32 @@ def test_locked_wallet_fails(rbf_node, dest_address):
 
 def test_dogecoin_wallet_minchange(rbf_node, dest_address):
     input = Decimal("10.00000000")
-    min_change = Decimal("0.03000000")
-    min_fee = Decimal("0.01000000")
-    bumpfee = Decimal("0.001")
-    est_tx_size = Decimal("0.193")
+    discard_threshold = Decimal("0.01000000")    # DEFAULT_DISCARD_THRESHOLD
+    min_fee = Decimal("0.01000000")              # DEFAULT_TRANSACTION_FEE
+    min_change = discard_threshold + 2 * min_fee # MIN_CHANGE
+    bumpfee = Decimal("0.001")                   # WALLET_INCREMENTAL_RELAY_FEE
+    est_tx_size = Decimal("0.226")               # 1 in, 2 out
+
+    # create a transaction with minimum fees
     destamount = input - min_change - min_fee * est_tx_size
     rbfid = spend_one_input(rbf_node,
                             input,
                             {dest_address: destamount,
                              get_change_address(rbf_node): min_change})
+
+    # bump the fee with the default incremental fee; this should add 0.001 DOGE
     bumped_tx = rbf_node.bumpfee(rbfid)
     assert_equal(bumped_tx["fee"], min_fee * est_tx_size + bumpfee)
-    newfee = int((input - destamount - min_fee - bumpfee / 2 ) * 100000000)
+
+    # bump the fee to only have a change output with the discard threshold
+    # plus half the incremental fee
+    newfee = int((input - destamount - discard_threshold - bumpfee / 2 ) * 100000000)
     bumped_tx = rbf_node.bumpfee(bumped_tx["txid"], {"totalFee": newfee})
-    assert_equal(bumped_tx["fee"], input - destamount - min_fee - bumpfee / 2)
+    assert_equal(bumped_tx["fee"], input - destamount - discard_threshold - bumpfee / 2)
+
+    # now bump with the default incremental fee again; as the resulting change
+    # output will be under the discard threshold, this must discard all change
+    # to fee
     bumped_tx = rbf_node.bumpfee(bumped_tx["txid"])
     assert_equal(bumped_tx["fee"], input - destamount)
     rbf_node.settxfee(Decimal("0.00000000"))

--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -279,7 +279,7 @@ def test_locked_wallet_fails(rbf_node, dest_address):
 
 def test_dogecoin_wallet_minchange(rbf_node, dest_address):
     input = Decimal("10.00000000")
-    discard_threshold = Decimal("0.01000000")    # DEFAULT_DISCARD_THRESHOLD
+    discard_threshold = Decimal("1.00000000")    # DEFAULT_DISCARD_THRESHOLD
     min_fee = Decimal("0.01000000")              # DEFAULT_TRANSACTION_FEE
     min_change = discard_threshold + 2 * min_fee # MIN_CHANGE
     bumpfee = Decimal("0.001")                   # WALLET_INCREMENTAL_RELAY_FEE

--- a/qa/rpc-tests/p2p-policy.py
+++ b/qa/rpc-tests/p2p-policy.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""P2P Policies QA test
+
+# Tests relay and mempool acceptance policies from p2p perspective
+"""
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class TestNode(NodeConnCB):
+    def __init__(self):
+        NodeConnCB.__init__(self)
+        self.connection = None
+        self.ping_counter = 1
+        self.last_pong = msg_pong()
+        self.txinvs = {}
+        self.rejects = []
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    # Track transaction invs for wait_for_tx_inv
+    def on_inv(self, conn, message):
+        for i in message.inv:
+            if (i.type == 1):
+                self.txinvs[format(i.hash, '064x')] = True
+
+    # Track pongs for sync_with_ping
+    def on_pong(self, conn, message):
+        self.last_pong = message
+
+    # Track reject messages
+    def on_reject(self, conn, message):
+        self.rejects.append(message)
+
+    # wait for verack to make sure the node accepts our connection attempt
+    def wait_for_verack(self):
+        def veracked():
+            return self.verack_received
+        return wait_until(veracked, timeout=10)
+
+    # Wait until we have received an inv of a specific tx
+    def wait_for_tx_inv(self, hash, timeout=30):
+        def have_received_tx_inv():
+            try:
+                return self.txinvs[hash]
+            except KeyError as e:
+                return False
+        return wait_until(have_received_tx_inv, timeout=timeout)
+
+    # Send a ping message and wait until we get the pong message back
+    def sync_with_ping(self, timeout=30):
+        def received_pong():
+            return (self.last_pong.nonce == self.ping_counter)
+        self.connection.send_message(msg_ping(nonce=self.ping_counter))
+        success = wait_until(received_pong, timeout=timeout)
+        self.ping_counter += 1
+        return success
+
+class P2PPolicyTests(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.utxo = []
+
+        # a private key and corresponding address and p2pkh output script
+        self.srcPrivKey = "cRhVU6TU1qHfRg3ee59yqg7ifhREKPLPPk8eccrrAEEY74bY1dCY"
+        self.srcAddr = "mmMP9oKFdADezYzduwJFcLNmmi8JHUKdx9"
+        self.srcOutScript = "76a91440015860f45d48eeeb2224dce3ad94ba91763e1e88ac"
+
+        # valid regtest address that no one has the key to
+        self.tgtAddr = "mkwDHkWXF8x6aFtdGVm5E9PVC7yPY8cb4r"
+
+    def create_testnode(self, node_idx=0):
+        node = TestNode()
+        conn = NodeConn('127.0.0.1', p2p_port(node_idx), self.nodes[node_idx], node)
+        node.add_connection(conn)
+        return node
+
+    def setup_network(self):
+        self.nodes = []
+
+        # a Dogecoin Core node that behaves similar to mainnet policies
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-acceptnonstdtxn=0"]))
+
+        # custom testnodes
+        self.sendNode = self.create_testnode() # to send tx from
+        self.recvNode = self.create_testnode() # to check relay from
+
+        # start networking and handshake the mininodes
+        NetworkThread().start()
+        self.sendNode.wait_for_verack()
+        self.recvNode.wait_for_verack()
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+
+        ### test constants ###
+        koinu = Decimal("0.00000001")          # 1 Koinu expressed in DOGE
+        ten = Decimal("10.0")                  # uniform 10 DOGE seed moneys
+
+        ### parameters from fee policy ###
+        relay_fee = Decimal("0.001")           # DEFAULT_MIN_RELAY_TX_FEE
+        soft_dust_limit = Decimal("0.01")      # DEFAULT_DUST_LIMIT
+
+        relay_fee_per_byte = relay_fee / 1000
+
+        # create a bunch of UTXO with seed money from the Dogecoin Core wallet
+        for i in range(10):
+            inputs = [self.nodes[0].listunspent()[0]]
+            outputs = { self.srcAddr : ten }
+            tx = self.nodes[0].createrawtransaction(inputs, outputs)
+            signed = self.nodes[0].signrawtransaction(tx)
+            txid = self.nodes[0].sendrawtransaction(signed['hex'], True)
+            self.utxo.append(txid)
+        self.nodes[0].generate(1)
+
+        # test legacy output of 1 DOGE output and 1 DOGE fee
+        output = { self.tgtAddr : 1, self.srcAddr: 8 }
+        self.run_relay_test(output, None)
+
+        # test exact relay fee rate
+        output = { self.tgtAddr: ten - relay_fee_per_byte * 192}
+        tx = self.run_relay_test(output, None)
+
+        # test too low relay fee rate
+        output = { self.tgtAddr: ten - relay_fee_per_byte * 191 + koinu }
+        tx = self.run_relay_test(output, 66) # 66 = too low fee
+
+        # test exact dust limit
+        change = ten - soft_dust_limit - relay_fee_per_byte * 226
+        output = { self.tgtAddr : soft_dust_limit, self.srcAddr: change}
+        self.run_relay_test(output, None)
+
+        # test soft dust limit with sufficient fee
+        amount = soft_dust_limit - koinu
+        change = ten - amount - relay_fee_per_byte * 226 - relay_fee
+        output = { self.tgtAddr : amount, self.srcAddr: change }
+        self.run_relay_test(output, None)
+
+        # test soft dust limit with insufficient fee
+        amount = soft_dust_limit - koinu
+        change = ten - amount - relay_fee_per_byte * 225 - relay_fee + koinu
+        output = { self.tgtAddr : amount, self.srcAddr: change }
+        self.run_relay_test(output, 66)
+
+        # test a 1 koinu output with sufficient fee
+        amount = koinu
+        change = ten - amount - relay_fee_per_byte * 226 - relay_fee
+        output = { self.tgtAddr : amount, self.srcAddr: change }
+        self.run_relay_test(output, 64) # 64 = dust
+
+        # test a 1 koinu output with insufficient fee
+        amount = koinu
+        change = ten - amount - relay_fee_per_byte * 225 - relay_fee + koinu
+        output = { self.tgtAddr : amount, self.srcAddr: change }
+        self.run_relay_test(output, 64)
+
+
+    # test mempool acceptance and relay outcomes
+    def run_relay_test(self, output, expected_reject_code):
+        num_rejects = len(self.sendNode.rejects)
+
+        tx = self.spend_utxo(output)
+        self.sendNode.sync_with_ping(timeout=10)
+
+        if (expected_reject_code is None):
+            # test that the tx got relayed
+            assert_equal(self.recvNode.wait_for_tx_inv(tx.hash), True)
+            assert_equal(len(self.sendNode.rejects), num_rejects)
+        else:
+            # test that there was a rejection received with the correct code
+            assert_greater_than(len(self.sendNode.rejects), num_rejects)
+            assert_equal(self.sendNode.rejects[-1].code, expected_reject_code)
+
+        return tx
+
+    # spend seed money with a key not in the Dogecoin Core wallet.
+    def spend_utxo(self, output):
+        # construct the transaction using Dogecoin Core raw tx APIs
+        input = [{ "txid": self.utxo.pop(), "vout": 0, "scriptPubKey": self.srcOutScript }]
+        rawtx = self.nodes[0].createrawtransaction(input, output)
+        signed_tx = self.nodes[0].signrawtransaction(rawtx, input, [self.srcPrivKey])
+
+        # import the signed tx into a format the mininode client understands
+        # and send the tx from there rather than from Dogecoin Core, to test
+        # mempool acceptance as it would happen on mainnet: through relay
+        tx = FromHex(CTransaction(), signed_tx['hex'])
+        tx.rehash()
+        self.sendNode.connection.send_message(msg_tx(tx))
+
+        return tx
+
+if __name__ == '__main__':
+    P2PPolicyTests().main()

--- a/src/dogecoin-fees.cpp
+++ b/src/dogecoin-fees.cpp
@@ -92,7 +92,7 @@ CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool
     }
 
     CAmount nMinFee = ::minRelayTxFeeRate.GetFee(nBytes);
-    nMinFee += GetDogecoinDustFee(tx.vout, ::minRelayTxFeeRate);
+    nMinFee += GetDogecoinDustFee(tx.vout, nDustLimit, ::minRelayTxFeeRate);
 
     if (fAllowFree)
     {
@@ -109,12 +109,12 @@ CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool
     return nMinFee;
 }
 
-CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, CFeeRate &baseFeeRate) {
+CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit, CFeeRate &baseFeeRate) {
     CAmount nFee = 0;
 
-    // To limit dust spam, add base fee for each output less than a COIN
+    // To limit dust spam, add base fee for each output less than the (soft) dustlimit
     BOOST_FOREACH(const CTxOut& txout, vout)
-        if (txout.IsDust(::minRelayTxFeeRate))
+        if (txout.IsDust(dustLimit))
             nFee += baseFeeRate.GetFeePerK();
 
     return nFee;

--- a/src/dogecoin-fees.h
+++ b/src/dogecoin-fees.h
@@ -28,6 +28,6 @@ CFeeRate GetDogecoinWalletFeeRate();
 CAmount GetDogecoinMinWalletFee(unsigned int nBytes_);
 #endif // ENABLE_WALLET
 CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree);
-CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, CFeeRate &baseFeeRate);
+CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit, CFeeRate &baseFeeRate);
 
 #endif // BITCOIN_DOGECOIN_FEES_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -476,6 +476,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost about 1/3 of its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)));
     }
     strUsage += HelpMessageOpt("-dustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered dust, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_DUST_LIMIT)));
+    strUsage += HelpMessageOpt("-harddustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_HARD_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
@@ -1044,11 +1045,26 @@ bool AppInitParameterInteraction()
         return InitError(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
     nBytesPerSigOp = GetArg("-bytespersigop", nBytesPerSigOp);
 
+    if (IsArgSet("-harddustlimit"))
+    {
+        CAmount n = nHardDustLimit;
+        if (!ParseMoney(GetArg("-harddustlimit", ""), n))
+            return InitError(AmountErrMsg("harddustlimit", GetArg("-harddustlimit", "")));
+        nHardDustLimit = n;
+    }
+
     if (IsArgSet("-dustlimit"))
     {
         CAmount n = nDustLimit;
         if (!ParseMoney(GetArg("-dustlimit", ""), n))
             return InitError(AmountErrMsg("dustlimit", GetArg("-dustlimit", "")));
+
+        if (n < nHardDustLimit)
+        {
+          n = nHardDustLimit;
+          LogPrintf("Increasing -dustlimit to %s to match -harddustlimit\n", FormatMoney(nHardDustLimit));
+        }
+
         nDustLimit = n;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -473,7 +473,6 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug) {
         strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !Params(CBaseChainParams::TESTNET).RequireStandard()));
         strUsage += HelpMessageOpt("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)));
-        strUsage += HelpMessageOpt("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost about 1/3 of its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)));
     }
     strUsage += HelpMessageOpt("-dustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered dust, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-harddustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_HARD_DUST_LIMIT)));
@@ -1028,16 +1027,6 @@ bool AppInitParameterInteraction()
         CAmount n = 0;
         if (!ParseMoney(GetArg("-blockmintxfee", ""), n))
             return InitError(AmountErrMsg("blockmintxfee", GetArg("-blockmintxfee", "")));
-    }
-
-    // Feerate used to define dust.  Shouldn't be changed lightly as old
-    // implementations may inadvertently create non-standard transactions
-    if (IsArgSet("-dustrelayfee"))
-    {
-        CAmount n = 0;
-        if (!ParseMoney(GetArg("-dustrelayfee", ""), n) || 0 == n)
-            return InitError(AmountErrMsg("dustrelayfee", GetArg("-dustrelayfee", "")));
-        dustRelayFee = CFeeRate(n);
     }
 
     fRequireStandard = !GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -105,7 +105,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
-        } else if (txout.IsDust(dustRelayFee)) {
+        } else if (txout.IsDust(nDustLimit)) {
             reason = "dust";
             return false;
         }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -105,7 +105,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd)) {
             reason = "bare-multisig";
             return false;
-        } else if (txout.IsDust(nDustLimit)) {
+        } else if (txout.IsDust(nHardDustLimit)) {
             reason = "dust";
             return false;
         }
@@ -210,6 +210,7 @@ CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
 CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 CAmount nDustLimit = DEFAULT_DUST_LIMIT;
+CAmount nHardDustLimit = DEFAULT_HARD_DUST_LIMIT;
 
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost)
 {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -207,7 +207,6 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 }
 
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
-CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 CAmount nDustLimit = DEFAULT_DUST_LIMIT;
 CAmount nHardDustLimit = DEFAULT_HARD_DUST_LIMIT;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -61,12 +61,6 @@ static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
 /** The maximum size of a standard witnessScript */
 static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
-/** Min feerate for defining dust. Historically this has been the same as the
- * minRelayTxFee, however changing the dust limit changes which transactions are
- * standard and should be done with care and ideally rarely. It makes sense to
- * only increase the dust limit after prior releases were already not creating
- * outputs below the new threshold */
-static const CAmount DUST_RELAY_TX_FEE = RECOMMENDED_MIN_TX_FEE / 1000;
 /**
  * Dogecoin: Default dust limit that is evaluated when considering whether a
  * transaction output is required to pay additional fee for relay and inclusion
@@ -77,6 +71,11 @@ static const CAmount DEFAULT_DUST_LIMIT = RECOMMENDED_MIN_TX_FEE;
  * Dogecoin: Default hard dust limit that is evaluated when considering whether
  * a transaction is standard. Transactions under this limit will not be accepted
  * to the mempool and thus not relayed. Can be overridden by -harddustlimit
+ *
+ * Changing the hard dust limit changes which transactions are standard and
+ * should be done with care and ideally rarely. It makes sense to only increase
+ * this limit after prior releases were already not creating outputs below the
+ * new threshold
  */
 static const CAmount DEFAULT_HARD_DUST_LIMIT = DEFAULT_DUST_LIMIT / 10;
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -73,6 +73,12 @@ static const CAmount DUST_RELAY_TX_FEE = RECOMMENDED_MIN_TX_FEE / 1000;
  * in blocks. Overridden by -dustlimit
  */
 static const CAmount DEFAULT_DUST_LIMIT = RECOMMENDED_MIN_TX_FEE;
+/**
+ * Dogecoin: Default hard dust limit that is evaluated when considering whether
+ * a transaction is standard. Transactions under this limit will not be accepted
+ * to the mempool and thus not relayed. Can be overridden by -harddustlimit
+ */
+static const CAmount DEFAULT_HARD_DUST_LIMIT = DEFAULT_DUST_LIMIT / 10;
 
 /**
  * Standard script verification flags that standard transactions will comply
@@ -125,6 +131,7 @@ extern CFeeRate incrementalRelayFee;
 extern CFeeRate dustRelayFee;
 extern unsigned int nBytesPerSigOp;
 extern CAmount nDustLimit;
+extern CAmount nHardDustLimit;
 
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -206,6 +206,15 @@ public:
         return (nValue < GetDustThreshold(minRelayTxFeeRate));
     }
 
+    // Dogecoin: allow comparison against different dustlimit parameters
+    bool IsDust(const CAmount dustLimit) const
+    {
+      if (scriptPubKey.IsUnspendable())
+          return false;
+
+      return (nValue < dustLimit);
+    }
+
     friend bool operator==(const CTxOut& a, const CTxOut& b)
     {
         return (a.nValue       == b.nValue &&

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -433,7 +433,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
-            if (txout.IsDust(dustRelayFee))
+            if (txout.IsDust(CWallet::discardThreshold))
                fDust = true;
         }
     }
@@ -546,10 +546,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
-                if (txout.IsDust(dustRelayFee))
+                if (txout.IsDust(CWallet::discardThreshold))
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = txout.GetDustThreshold(dustRelayFee);
+                        nChange = CWallet::discardThreshold;
                     else
                     {
                         nPayFee += nChange;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -18,6 +18,10 @@
 #include "script/standard.h"
 #include "util.h"
 
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h"
+#endif
+
 #ifdef WIN32
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT
@@ -248,13 +252,15 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
     return ret;
 }
 
+#ifdef ENABLE_WALLET
 bool isDust(const QString& address, const CAmount& amount)
 {
     CTxDestination dest = CBitcoinAddress(address.toStdString()).Get();
     CScript script = GetScriptForDestination(dest);
     CTxOut txOut(amount, script);
-    return txOut.IsDust(dustRelayFee);
+    return txOut.IsDust(CWallet::discardThreshold);
 }
+#endif
 
 QString HtmlEscape(const QString& str, bool fMultiLine)
 {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -51,8 +51,11 @@ namespace GUIUtil
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
     QString formatBitcoinURI(const SendCoinsRecipient &info);
 
+//Dogecoin: need wallet to establish dust from a wallet perspective
+#ifdef ENABLE_WALLET
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);
+#endif
 
     // HTML escaping for rich text controls
     QString HtmlEscape(const QString& str, bool fMultiLine=false);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -580,8 +580,8 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, Sen
 
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
-        if (txOut.IsDust(dustRelayFee)) {
-            Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).")
+        if (txOut.IsDust(CWallet::discardThreshold)) {
+            Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (below discard threshold).")
                 .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
                 CClientUIInterface::MSG_ERROR);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2947,7 +2947,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
 
     // If the output would become dust, discard it (converting the dust to fee)
     poutput->nValue -= nDelta;
-    if (poutput->nValue <= poutput->GetDustThreshold(::dustRelayFee)) {
+    if (poutput->nValue <= CWallet::discardThreshold) {
         LogPrint("rpc", "Bumping fee and discarding dust output\n");
         nNewFee += poutput->nValue;
         tx.vout.erase(tx.vout.begin() + nOutput);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -528,9 +528,9 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nDustPenalty + (nMinTxFee * 1.000));
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), nDustPenalty + (nMinTxFee * 1.999));
 
-    // change the hard dust limit
+    // change the discard threshold
 
-    nDustLimit = COIN / 1000;
+    CWallet::discardThreshold = COIN / 1000;
 
     // Confirm dust penalty fees are not added
 
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nMinTxFee * 1.000);
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), nMinTxFee * 1.999);
 
-    nDustLimit = COIN;
+    CWallet::discardThreshold = COIN / 100;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -58,6 +58,12 @@ CFeeRate CWallet::minTxFee = CFeeRate(DEFAULT_TRANSACTION_MINFEE);
  * Override with -fallbackfee
  */
 CFeeRate CWallet::fallbackFee = CFeeRate(DEFAULT_FALLBACK_FEE);
+/**
+ * Dogecoin: Effective dust limit for the wallet
+ * - Outputs smaller than this get rejected
+ * - Change smaller than this gets discarded to fee
+ */
+CAmount CWallet::discardThreshold = DEFAULT_DISCARD_THRESHOLD;
 
 /** @defgroup mapWallet
  *
@@ -2500,7 +2506,15 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         }
                     }
 
-                    if (txout.IsDust(dustRelayFee))
+                    /*
+                     * Dogecoin: check all outputs against the discard threshold
+                     *           to make sure that the wallet's dust policy gets
+                     *           followed rather than the current relay rules,
+                     *           because the larger network may settle on a
+                     *           higher hard limit than the current version's
+                     *           soft limit.
+                     */
+                    if (txout.IsDust(discardThreshold))
                     {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
@@ -2578,16 +2592,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(dustRelayFee))
+                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(discardThreshold))
                     {
-                        CAmount nDust = newTxOut.GetDustThreshold(dustRelayFee) - newTxOut.nValue;
-                        newTxOut.nValue += nDust; // raise change until no more dust
+                        CAmount changeDelta = discardThreshold - newTxOut.nValue;
+                        newTxOut.nValue += changeDelta; // raise change until we reach the discard threshold
                         for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
                         {
                             if (vecSend[i].fSubtractFeeFromAmount)
                             {
-                                txNew.vout[i].nValue -= nDust;
-                                if (txNew.vout[i].IsDust(dustRelayFee))
+                                txNew.vout[i].nValue -= changeDelta;
+                                if (txNew.vout[i].IsDust(discardThreshold))
                                 {
                                     strFailReason = _("The transaction amount is too small to send after the fee has been deducted");
                                     return false;
@@ -2597,9 +2611,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         }
                     }
 
-                    // Never create dust outputs; if we would, just
-                    // add the dust to the fee.
-                    if (newTxOut.IsDust(dustRelayFee))
+                    // Never create change under the discard threshold;
+                    // if we would, just discard the change to the fee.
+                    if (newTxOut.IsDust(discardThreshold))
                     {
                         nChangePosInOut = -1;
                         nFeeRet += nChange;
@@ -2852,8 +2866,8 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB *pwa
 
 CAmount CWallet::GetRequiredFee(const CMutableTransaction& tx, unsigned int nTxBytes)
 {
-    // Dogecoin: Add an increased fee for each dust output
-    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, nDustLimit, minTxFee), ::minRelayTxFeeRate.GetFee(nTxBytes));
+    // Dogecoin: Add an increased fee for each output that is lower than the discard threshold
+    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, discardThreshold, minTxFee), ::minRelayTxFeeRate.GetFee(nTxBytes));
 }
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)
@@ -3620,6 +3634,8 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
+    strUsage += HelpMessageOpt("-discardthreshold=<amt>", strprintf(_("The minimum transaction output size (in %s) used to validate wallet transactions and discard change (to fee) (default: %s)"),
+                                                                    CURRENCY_UNIT, FormatMoney(DEFAULT_DISCARD_THRESHOLD)));
     strUsage += HelpMessageOpt("-fallbackfee=<amt>", strprintf(_("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)"),
                                                                CURRENCY_UNIT, FormatMoney(DEFAULT_FALLBACK_FEE)));
     strUsage += HelpMessageOpt("-mintxfee=<amt>", strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)"),
@@ -3952,6 +3968,22 @@ bool CWallet::ParameterInteraction()
             return InitError(strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)"),
                                        GetArg("-maxtxfee", ""), ::minRelayTxFeeRate.ToString()));
         }
+    }
+    if (IsArgSet("-discardthreshold"))
+    {
+        CAmount nDiscardThreshold = 0;
+        if (!ParseMoney(GetArg("-discardthreshold", ""), nDiscardThreshold))
+            return InitError(AmountErrMsg("discardthreshold", GetArg("-discardthreshold", "")));
+
+        if (nDiscardThreshold < nDustLimit)
+        {
+            return InitError(strprintf(_("Invalid amount for -discardthreshold=<amount>: '%s' (must be at least the dust limit of %s to prevent stuck transactions)"),
+                                       GetArg("-discardthreshold", ""), FormatMoney(nDustLimit)));
+        }
+        if (nDiscardThreshold > HIGH_TX_FEE_PER_KB)
+            InitWarning(_("-discardthreshold is set very high! This is the output amount that the wallet will discard (to fee) if it is smaller than this setting."));
+
+        CWallet::discardThreshold = nDiscardThreshold;
     }
     nTxConfirmTarget = GetArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     bSpendZeroConfChange = GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2853,7 +2853,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB *pwa
 CAmount CWallet::GetRequiredFee(const CMutableTransaction& tx, unsigned int nTxBytes)
 {
     // Dogecoin: Add an increased fee for each dust output
-    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, minTxFee), ::minRelayTxFeeRate.GetFee(nTxBytes));
+    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, nDustLimit, minTxFee), ::minRelayTxFeeRate.GetFee(nTxBytes));
 }
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -57,7 +57,12 @@ static const CAmount DEFAULT_FALLBACK_FEE = RECOMMENDED_MIN_TX_FEE;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = RECOMMENDED_MIN_TX_FEE;
 //! -discardthreshold default
-static const CAmount DEFAULT_DISCARD_THRESHOLD = DEFAULT_DUST_LIMIT;
+/* 1.14.5: set the wallet's discard threshold to 1 DOGE because that's what 97%
+ *         of the network currently implements as the hard dust limit. This
+ *         value can be changed when a significant portion of the relay network
+ *         and miners have adopted a different hard dust limit.
+ */
+static const CAmount DEFAULT_DISCARD_THRESHOLD = COIN;
 
 //! minimum recommended increment for BIP 125 replacement txs
 /*

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -56,6 +56,9 @@ static const CAmount DEFAULT_TRANSACTION_FEE = RECOMMENDED_MIN_TX_FEE;
 static const CAmount DEFAULT_FALLBACK_FEE = RECOMMENDED_MIN_TX_FEE;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = RECOMMENDED_MIN_TX_FEE;
+//! -discardthreshold default
+static const CAmount DEFAULT_DISCARD_THRESHOLD = DEFAULT_DUST_LIMIT;
+
 //! minimum recommended increment for BIP 125 replacement txs
 /*
  * Dogecoin: Scaled to 1/10th of the recommended transaction fee to make RBF
@@ -70,7 +73,7 @@ static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 10;
 /*
  * Dogecoin: Creating change outputs at exactly the dustlimit is counter-
  * productive because it leaves no space to bump the fee up, so we make the
- * MIN_CHANGE parameter higher than the MIN_FINAL_CHANGE parameter.
+ * MIN_CHANGE parameter higher than the DEFAULT_DISCARD_THRESHOLD parameter.
  *
  * When RBF is not a default policy, we need to scale for both that and CPFP,
  * to have a facility for those that did not manually enable RBF, yet need to
@@ -85,24 +88,20 @@ static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 10;
  * or transaction size, we assume that most transactions are < 1kb, leading
  * to the following when planning for a replacements with 2x original fee:
  *
- * RBF: MIN_CHANGE = dust limit + min fee or
- * CPFP: MIN_CHANGE = dust limit + 2 * min fee * 0.147 + min fee
+ * RBF: MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + min fee or
+ * CPFP: MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * min fee * 0.147 + min fee
  *
  * Where the CPFP requirement is higher than the RBF one to lead to the same
  * result.
  *
  * This can be rounded up to the nearest multiple of RECOMMENDED_MIN_TX_FEE as:
  *
- * MIN_CHANGE = DEFAULT_DUST_LIMIT + 2 * RECOMMENDED_MIN_TX_FEE
- *
- * The MIN_FINAL_CHANGE parameter can stay equal to DEFAULT_DUST_LIMIT as this
- * influences when the wallet will discard all remaining dust as fee instead of
- * change.
+ * MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * RECOMMENDED_MIN_TX_FEE
  */
 //! target minimum change amount
-static const CAmount MIN_CHANGE = DEFAULT_DUST_LIMIT + 2 * RECOMMENDED_MIN_TX_FEE;
+static const CAmount MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * RECOMMENDED_MIN_TX_FEE;
 //! final minimum change amount after paying for fees
-static const CAmount MIN_FINAL_CHANGE = DEFAULT_DUST_LIMIT;
+static const CAmount MIN_FINAL_CHANGE = DEFAULT_DISCARD_THRESHOLD;
 
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
@@ -793,6 +792,7 @@ public:
 
     static CFeeRate minTxFee;
     static CFeeRate fallbackFee;
+    static CAmount discardThreshold;
     /**
      * Estimate the minimum fee considering user set parameters
      * and the required fee


### PR DESCRIPTION
Implements the changes needed to resolve #2601 and most of #2603. This was missed (by me) in the [fee proposal](https://github.com/dogecoin/dogecoin/discussions/2347) and subsequently 1.14.4

### High level overview

1. Introduces a policy test (`p2p-policy.py`) that ensures policy changes surrounding dust and fees get flagged up on the CI in the future, making shenanigans like this situation less likely to occur. The test implements policy values proposed in [#2603](https://github.com/dogecoin/dogecoin/issues/2603). 
2. Split the policy side of the dust limit into configurable soft and hard limits, where the soft limit enforces the economic disincentive (dust can be paid for with additional fee), and the hard limit makes nodes reject outputs under that threshold into their mempools. Per [#2603](https://github.com/dogecoin/dogecoin/issues/2603), the hard dust limit is proposed to be set at at 0.001 DOGE
3. Decouple wallet and mempool dust policy by introducing a configurable, separate limit for the wallet called `discard threshold`, allowing the network to roll out policy changes without increasing the potential for user's transactions to get stuck. Per [#2603](https://github.com/dogecoin/dogecoin/issues/2603), the threshold is proposed to be set at at 1 DOGE for the time being, because that's enforced as a hard limit by 97% of the relay network and (probably) all miners.

### Rationale for each change

- b17ddb3 creates a test that fails on its own: it shows that the soft dust limit didn't work at all. Transactions that should be rejected for providing too little fee, are rejected for being dust. The problem with that is that even if you would pay a million DOGE fee, it would still be rejected, and that's not how the dust mechanism was advertised.
- fc3b9f0 adds a facility to transaction outputs that checks dust against a fixed amount rather than a fee rate, because for Dogecoin, dust has never been a rate, and even though the rate is passed to the original function, it is not used there. I have retained the original function for now, to be cleaned up later, because this is not exposed to users.
- 352a5a3 implements the policy-side split. The reason for retaining the hard limit is to not go from a much-too-high hard limit to none at all. Because both limits are now configurable, miners (and relay operators) can change this independent from default policies, or, if we ultimately want to go back to the situation where there is no hard dust limit at all, this can be done by gradually reducing the defaults with subsequent releases.
- fd6da81 introduces `-discardthreshold`, which is basically the Dogecoin version of Bitcoin's `-discardfee`, but as an explicit threshold rather than a rate. Besides becoming the "dust" threshold that the wallet tests all outputs against, it also becomes the new base for `MIN_CHANGE` and `MIN_FINAL_CHANGE` as those are used by coin selection algorithms. This commit on its own does **not** change any values yet, to prove that the rework is sane.
- 6173ca3 removes `-dustrelayfee` as that is exposed to the user (and has been defunct since 1.14.2)
- a4d9655 sets the discard threshold to 1 DOGE, to make sure that transactions sent from the wallet will not get rejected as hard dust by 1.14.2-1.14.4 nodes (both miners and relay).

### Other changes not included here

I've tried to make this PR as small as I could while keeping it complete because I felt that if I'd fragment it too much, review would be hard, as would a single huge PR be. Further changes should be made to make the the wallet's change constants more dynamic (use user-defined parametrization rather than hardcoded defaults only), more tests should be written to ensure wallet operations are consistent cross-version and there can be some additional cleanup done to functions we don't use anymore.
