### PR TITLE
fees: Make wallet minimum change parameters dynamic

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -543,7 +543,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
                 nChange -= nPayFee;
 
             // Never create dust outputs; if we would, just add the dust to the fee.
-            if (nChange > 0 && nChange < MIN_CHANGE)
+            if (nChange > 0 && nChange < CWallet::GetMinChange())
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
                 if (txout.IsDust(CWallet::discardThreshold))

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -201,31 +201,31 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // empty the wallet and start again, now with fractions of a coin, to test small change avoidance
 
         empty_wallet();
-        add_coin(MIN_CHANGE * 1 / 10);
-        add_coin(MIN_CHANGE * 2 / 10);
-        add_coin(MIN_CHANGE * 3 / 10);
-        add_coin(MIN_CHANGE * 4 / 10);
-        add_coin(MIN_CHANGE * 5 / 10);
+        add_coin(CWallet::GetMinChange() * 1 / 10);
+        add_coin(CWallet::GetMinChange() * 2 / 10);
+        add_coin(CWallet::GetMinChange() * 3 / 10);
+        add_coin(CWallet::GetMinChange() * 4 / 10);
+        add_coin(CWallet::GetMinChange() * 5 / 10);
 
-        // try making 1 * MIN_CHANGE from the 1.5 * MIN_CHANGE
-        // we'll get change smaller than MIN_CHANGE whatever happens, so can expect MIN_CHANGE exactly
-        BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);
+        // try making 1 * GetMinChange() from the 1.5 * GetMinChange()
+        // we'll get change smaller than GetMinChange() whatever happens, so can expect GetMinChange() exactly
+        BOOST_CHECK( wallet.SelectCoinsMinConf(CWallet::GetMinChange(), 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, CWallet::GetMinChange());
 
         // but if we add a bigger output, small change is avoided
-        add_coin(1111*MIN_CHANGE);
+        add_coin(1111*CWallet::GetMinChange());
 
         // try making 1 from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CWallet::GetMinChange(), 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CWallet::GetMinChange()); // we should get the exact amount
 
         // if we add more small output:
-        add_coin(MIN_CHANGE * 6 / 10);
-        add_coin(MIN_CHANGE * 7 / 10);
+        add_coin(CWallet::GetMinChange() * 6 / 10);
+        add_coin(CWallet::GetMinChange() * 7 / 10);
 
-        // and try again to make 1.0 * MIN_CHANGE
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1 * MIN_CHANGE); // we should get the exact amount
+        // and try again to make 1.0 * GetMinChange()
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CWallet::GetMinChange(), 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1 * CWallet::GetMinChange()); // we should get the exact amount
 
         // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
         // they tried to consolidate 10 50k outputs into one 500k output, and ended up with 50k in change
@@ -237,43 +237,43 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 10U); // in ten outputs
 
-        // if there's not enough in the smaller coins to make at least 1 * MIN_CHANGE change (0.5+0.6+0.7 < 1.0+1.0),
+        // if there's not enough in the smaller coins to make at least 1 * GetMinChange() change (0.5+0.6+0.7 < 1.0+1.0),
         // we need to try finding an exact subset anyway
 
         // sometimes it will fail, and so we use the next biggest output:
         empty_wallet();
-        add_coin(MIN_CHANGE * 5 / 10);
-        add_coin(MIN_CHANGE * 6 / 10);
-        add_coin(MIN_CHANGE * 7 / 10);
-        add_coin(1111 * MIN_CHANGE);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 1111 * MIN_CHANGE); // we get the bigger output
+        add_coin(CWallet::GetMinChange() * 5 / 10);
+        add_coin(CWallet::GetMinChange() * 6 / 10);
+        add_coin(CWallet::GetMinChange() * 7 / 10);
+        add_coin(1111 * CWallet::GetMinChange());
+        BOOST_CHECK( wallet.SelectCoinsMinConf(1 * CWallet::GetMinChange(), 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 1111 * CWallet::GetMinChange()); // we get the bigger output
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
         empty_wallet();
-        add_coin(MIN_CHANGE * 4 / 10);
-        add_coin(MIN_CHANGE * 6 / 10);
-        add_coin(MIN_CHANGE * 8 / 10);
-        add_coin(1111 * MIN_CHANGE);
-        BOOST_CHECK( wallet.SelectCoinsMinConf(MIN_CHANGE, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE);   // we should get the exact amount
+        add_coin(CWallet::GetMinChange() * 4 / 10);
+        add_coin(CWallet::GetMinChange() * 6 / 10);
+        add_coin(CWallet::GetMinChange() * 8 / 10);
+        add_coin(1111 * CWallet::GetMinChange());
+        BOOST_CHECK( wallet.SelectCoinsMinConf(CWallet::GetMinChange(), 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, CWallet::GetMinChange());   // we should get the exact amount
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two outputs 0.4+0.6
 
         // test avoiding small change
         empty_wallet();
-        add_coin(MIN_CHANGE * 5 / 100);
-        add_coin(MIN_CHANGE * 1);
-        add_coin(MIN_CHANGE * 100);
+        add_coin(CWallet::GetMinChange() * 5 / 100);
+        add_coin(CWallet::GetMinChange() * 1);
+        add_coin(CWallet::GetMinChange() * 100);
 
         // trying to make 100.01 from these three outputs
-        BOOST_CHECK(wallet.SelectCoinsMinConf(MIN_CHANGE * 10001 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, MIN_CHANGE * 10105 / 100); // we should get all outputs
+        BOOST_CHECK(wallet.SelectCoinsMinConf(CWallet::GetMinChange() * 10001 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, CWallet::GetMinChange() * 10105 / 100); // we should get all outputs
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
         // but if we try to make 99.9, we should take the bigger of the two small outputs to avoid small change
-        BOOST_CHECK(wallet.SelectCoinsMinConf(MIN_CHANGE * 9990 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-        BOOST_CHECK_EQUAL(nValueRet, 101 * MIN_CHANGE);
+        BOOST_CHECK(wallet.SelectCoinsMinConf(CWallet::GetMinChange() * 9990 / 100, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
+        BOOST_CHECK_EQUAL(nValueRet, 101 * CWallet::GetMinChange());
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // test with many inputs
@@ -283,9 +283,9 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
              for (uint16_t j = 0; j < 676; j++)
                  add_coin(amt);
              BOOST_CHECK(wallet.SelectCoinsMinConf(20*CENT, 1, 1, 0, vCoins, setCoinsRet, nValueRet));
-             if (amt - 20*CENT < MIN_CHANGE) {
+             if (amt - 20*CENT < CWallet::GetMinChange()) {
                  // needs more than one input:
-                 uint16_t returnSize = std::ceil((20.0 * CENT + MIN_CHANGE)/amt);
+                 uint16_t returnSize = std::ceil((20.0 * CENT + CWallet::GetMinChange())/amt);
                  CAmount returnValue = amt * returnSize;
                  BOOST_CHECK_EQUAL(nValueRet, returnValue);
                  BOOST_CHECK_EQUAL(setCoinsRet.size(), returnSize);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2735,7 +2735,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
                     vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
                     // Only reduce change if remaining amount is still a large enough output.
-                    if (change_position->nValue >= MIN_FINAL_CHANGE + additionalFeeNeeded) {
+                    /* Dogecoin: this has been changed from a static MIN_FINAL_CHANGE that
+                     * followed DEFAULT_DISCARD_THRESHOLD to instead use the configurable
+                     * discard threshold.
+                     *
+                     * Note:
+                     * If MIN_CHANGE ever becomes configurable or otherwise changes to no
+                     * longer be derived from DEFAULT_DISCARD_THRESHOLD, then this check
+                     * must be adapted.
+                     */
+                    if (change_position->nValue >= discardThreshold + additionalFeeNeeded) {
                         change_position->nValue -= additionalFeeNeeded;
                         nFeeRet += additionalFeeNeeded;
                         break; // Done, able to increase fee from change

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -74,11 +74,10 @@ static const CAmount DEFAULT_DISCARD_THRESHOLD = COIN;
  * This way, replacements for fee bumps are transient rather than persisted.
  */
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 10;
-
 /*
  * Dogecoin: Creating change outputs at exactly the dustlimit is counter-
  * productive because it leaves no space to bump the fee up, so we make the
- * MIN_CHANGE parameter higher than the DEFAULT_DISCARD_THRESHOLD parameter.
+ * minimum change higher than the discard threshold.
  *
  * When RBF is not a default policy, we need to scale for both that and CPFP,
  * to have a facility for those that did not manually enable RBF, yet need to
@@ -93,18 +92,18 @@ static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 10;
  * or transaction size, we assume that most transactions are < 1kb, leading
  * to the following when planning for a replacements with 2x original fee:
  *
- * RBF: MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + min fee or
- * CPFP: MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * min fee * 0.147 + min fee
+ * RBF: min change = discardThreshold + minTxFee(1000) or
+ * CPFP: min change = discardThreshold + 2 * minTxFee(147) + minTxFee(1000)
  *
  * Where the CPFP requirement is higher than the RBF one to lead to the same
  * result.
  *
- * This can be rounded up to the nearest multiple of RECOMMENDED_MIN_TX_FEE as:
+ * This can be rounded up to the nearest multiple of minTxFee(1000) as:
  *
- * MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * RECOMMENDED_MIN_TX_FEE
+ * min change = discardThreshold + 2 * minTxFee(1000)
  */
-//! target minimum change amount
-static const CAmount MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * RECOMMENDED_MIN_TX_FEE;
+//! target minimum change fee multiplier
+static const CAmount MIN_CHANGE_FEE_MULTIPLIER = 2;
 
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
@@ -796,6 +795,12 @@ public:
     static CFeeRate minTxFee;
     static CFeeRate fallbackFee;
     static CAmount discardThreshold;
+
+    /**
+     * Minimum change as a function of discardThreshold
+     */
+    static CAmount GetMinChange();
+
     /**
      * Estimate the minimum fee considering user set parameters
      * and the required fee

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -105,8 +105,6 @@ static const CAmount WALLET_INCREMENTAL_RELAY_FEE = RECOMMENDED_MIN_TX_FEE / 10;
  */
 //! target minimum change amount
 static const CAmount MIN_CHANGE = DEFAULT_DISCARD_THRESHOLD + 2 * RECOMMENDED_MIN_TX_FEE;
-//! final minimum change amount after paying for fees
-static const CAmount MIN_FINAL_CHANGE = DEFAULT_DISCARD_THRESHOLD;
 
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;


### PR DESCRIPTION
Makes the wallet features of having a `MIN_CHANGE` and `MIN_FINAL_CHANGE` dynamic and derived from user-set variables rather than hardcoded by developers.

### Rationale

I'm proposing this mostly because it makes no sense to have the wallet test compliance against changeable parameters yet the coin selection being based off static values of those same parameters. This results in creating much larger change outputs than needed while the network lowers the enforced dust limit, with no way to change it other than waiting for a new release.

The reason why this implementation is significantly easier to achieve for Dogecoin than for Bitcoin is because our dust thresholds are, like the minimum change parameters, exact values and not rates, with #2606 we will have a decoupled wallet dust limit and we've always allowed change outputs to be at or close to dust (where we've [recently agreed](https://github.com/dogecoin/dogecoin/pull/2594) that under ideal circumstances, it would be sitting around 3x the soft dust limit / recommended fee.) The only thing that remains hardcoded is the formula from #2594 that establishes that the minimum change is the dust limit (now discard threshold) plus 2x the minimum fee for 1 kb.

### Changes
- Make `MIN_CHANGE` dynamically calculated from the discard threshold (`-discardthreshold`) and wallet's minimum fee (`-mintxfee`) , retaining the calculation we recently introduced.
- Remove `MIN_FINAL_CHANGE` and instead just calculate the single check done against this constant against the discard threshold, because it was anyway derived from the default value of that.

### Constraints

The following constraints are in place (after #2606) to make this safer and protect the user against accidentally configuring dust wrong:
1. The soft dust limit can not be set under the hard dust limit, avoiding situations where wallet transactions would not be accepted to the mempool for being dust.
2. The discard threshold can not be set under the soft dust limit, avoiding situations where more fee must be paid than what the wallet would account for (and, indirectly, it also cannot be lower than the hard dust limit, per 1.)
