### PR TITLE
depends: make freetype independent from build system libs too

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --disable-static
+  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -73,6 +73,7 @@ $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-libjpeg
 $(package)_config_opts += -qt-pcre
+$(package)_config_opts += -qt-harfbuzz
 $(package)_config_opts += -system-zlib
 $(package)_config_opts += -reduce-exports
 $(package)_config_opts += -static


### PR DESCRIPTION
Found, while trying to extend the CI, that `freetype` is taking `libharfbuzz` from system libraries if it's available. Gitian hosts don't have it but the CI does, so this is needed to be able to do more extensive checks on the CI, to leave less bugs to be found on gitian building (and it makes free type compilation more deterministic, which is what it's meant to be anyway)

As Bitcoin Core already patched this, this was an easy backport. 