### PR TITLE
fees: Require dust limit as dust penalty

### DIFF
--- a/qa/rpc-tests/p2p-policy.py
+++ b/qa/rpc-tests/p2p-policy.py
@@ -140,25 +140,25 @@ class P2PPolicyTests(BitcoinTestFramework):
 
         # test soft dust limit with sufficient fee
         amount = soft_dust_limit - koinu
-        change = ten - amount - relay_fee_per_byte * 226 - relay_fee
+        change = ten - amount - relay_fee_per_byte * 226 - soft_dust_limit
         output = { self.tgtAddr : amount, self.srcAddr: change }
         self.run_relay_test(output, None)
 
         # test soft dust limit with insufficient fee
         amount = soft_dust_limit - koinu
-        change = ten - amount - relay_fee_per_byte * 225 - relay_fee + koinu
+        change = ten - amount - relay_fee_per_byte * 225 - soft_dust_limit + koinu
         output = { self.tgtAddr : amount, self.srcAddr: change }
         self.run_relay_test(output, 66)
 
         # test a 1 koinu output with sufficient fee
         amount = koinu
-        change = ten - amount - relay_fee_per_byte * 226 - relay_fee
+        change = ten - amount - relay_fee_per_byte * 226 - soft_dust_limit
         output = { self.tgtAddr : amount, self.srcAddr: change }
         self.run_relay_test(output, 64) # 64 = dust
 
         # test a 1 koinu output with insufficient fee
         amount = koinu
-        change = ten - amount - relay_fee_per_byte * 225 - relay_fee + koinu
+        change = ten - amount - relay_fee_per_byte * 225 - soft_dust_limit + koinu
         output = { self.tgtAddr : amount, self.srcAddr: change }
         self.run_relay_test(output, 64)
 

--- a/src/dogecoin-fees.cpp
+++ b/src/dogecoin-fees.cpp
@@ -92,7 +92,7 @@ CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool
     }
 
     CAmount nMinFee = ::minRelayTxFeeRate.GetFee(nBytes);
-    nMinFee += GetDogecoinDustFee(tx.vout, nDustLimit, ::minRelayTxFeeRate);
+    nMinFee += GetDogecoinDustFee(tx.vout, nDustLimit);
 
     if (fAllowFree)
     {
@@ -109,13 +109,14 @@ CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool
     return nMinFee;
 }
 
-CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit, CFeeRate &baseFeeRate) {
+CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit) {
     CAmount nFee = 0;
 
-    // To limit dust spam, add base fee for each output less than the (soft) dustlimit
+    // To limit dust spam, add the dust limit for each output
+    // less than the (soft) dustlimit
     BOOST_FOREACH(const CTxOut& txout, vout)
         if (txout.IsDust(dustLimit))
-            nFee += baseFeeRate.GetFeePerK();
+            nFee += dustLimit;
 
     return nFee;
 }

--- a/src/dogecoin-fees.h
+++ b/src/dogecoin-fees.h
@@ -28,6 +28,6 @@ CFeeRate GetDogecoinWalletFeeRate();
 CAmount GetDogecoinMinWalletFee(unsigned int nBytes_);
 #endif // ENABLE_WALLET
 CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree);
-CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit, CFeeRate &baseFeeRate);
+CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit);
 
 #endif // BITCOIN_DOGECOIN_FEES_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -522,7 +522,9 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     CAmount nMinTxFee = COIN / 100;
 
     // Confirm dust penalty fees are added on
-    CAmount nDustPenalty = COIN / 100;
+    // Because this is ran by the wallet, this takes the discardThreshold,
+    // not the dust limit
+    CAmount nDustPenalty = COIN;
 
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 963, 0, pool), nDustPenalty + (nMinTxFee * 0.963));
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nDustPenalty + (nMinTxFee * 1.000));
@@ -538,7 +540,7 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nMinTxFee * 1.000);
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), nMinTxFee * 1.999);
 
-    CWallet::discardThreshold = COIN / 100;
+    CWallet::discardThreshold = COIN;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2867,7 +2867,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB *pwa
 CAmount CWallet::GetRequiredFee(const CMutableTransaction& tx, unsigned int nTxBytes)
 {
     // Dogecoin: Add an increased fee for each output that is lower than the discard threshold
-    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, discardThreshold, minTxFee), ::minRelayTxFeeRate.GetFee(nTxBytes));
+    return std::max(minTxFee.GetFee(nTxBytes) + GetDogecoinDustFee(tx.vout, discardThreshold), ::minRelayTxFeeRate.GetFee(nTxBytes));
 }
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)


### PR DESCRIPTION
Changes the dust policy to require transactions to add the dust limit itself rather than the relay or wallet fee to the fees paid
when creating dust outputs. 

### Rationale

- disincentivizes dust outputs the same as before when dust and minumum fee were equal, and 
- greatly simplifies the rule, as it no longer requires 2 variables to calculate dust, but just one: *"If an output is under `x`, add `x` to the fee."*

The alternative is that dust is effective only at the minimum fee rate (for relay, which is 0.001 DOGE) and that everything above that is penalized, but not economically unviable. The latter is how it has been since early 2014, until 1.14.2. 

Right now is **_the most opportune_** moment to set this straight if we want to, because after 1.14.5 gets released, dust will be accepted in the field again, and any change to this calculation will hurt.