### PR TITLE
qa: enhance CI to catch more release-time errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
             check-security: false
             check-symbols: false
             dep-opts: ""
-            config-opts: "--enable-gui=qt5"
+            config-opts: "--enable-gui=qt5 --disable-tests"
             goal: deploy
             sdk: 10.11
 


### PR DESCRIPTION
Enhances the GH Actions CI to catch errors that are currently only caught by doing a gitian build:

1. `make check-security` on everything but macOS
2. `make check-symbols` on i686 and x86_64 linux
3. `aarch64-linux-gnu` build

and enhances the build to be closer to the gitian results (though not necessarily the same because we use a lot of caching to speed the process up).

As a side-effect, the binary artifacts from CI runs become more portable and can be ran on a much wider range of systems now, the linux ones (except for the debug binary) in particular.