### PR TITLE
fix: always check nDustLimit to be >= nHardDustLimit

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1048,13 +1048,13 @@ bool AppInitParameterInteraction()
         if (!ParseMoney(GetArg("-dustlimit", ""), n))
             return InitError(AmountErrMsg("dustlimit", GetArg("-dustlimit", "")));
 
-        if (n < nHardDustLimit)
-        {
-          n = nHardDustLimit;
-          LogPrintf("Increasing -dustlimit to %s to match -harddustlimit\n", FormatMoney(nHardDustLimit));
-        }
-
         nDustLimit = n;
+    }
+
+    if (nDustLimit < nHardDustLimit)
+    {
+      nDustLimit = nHardDustLimit;
+      LogPrintf("Increasing -dustlimit to %s to match -harddustlimit\n", FormatMoney(nHardDustLimit));
     }
 
 #ifdef ENABLE_WALLET


### PR DESCRIPTION
Moves the check for parameter interaction between both dust limits to be done regardless of setting a custom soft dust limit.

The implementation from #2606 did the check inside the block that only triggers if `-dustlimit` is set, but it needs to be done regardless, also when just `-harddustlimit` is set.

To reproduce on current 1.14.5-dev:

```
$ src/dogecoind -harddustlimit=1 -printtoconsole | grep Increasing
<nothing>
```

```
$ src/dogecoind -dustlimit=0.1 -harddustlimit=1 -printtoconsole | grep Increasing
2021-10-12 17:52:37 Increasing -dustlimit to 1.00 to match -harddustlimit
```

