### PR TITLE
cleanup: remove dead code related to fee and dust changes 

### DIFF
--- a/src/dogecoin-fees.cpp
+++ b/src/dogecoin-fees.cpp
@@ -62,21 +62,6 @@ const std::string GetDogecoinPriorityLabel(int priority)
     return _("Default");
 }
 
-//mlumin 5/2021: walletfees, all attached to GetDogecoinWalletFeeRate which is just the newly exposed ::minWalletTxFee
-CAmount GetDogecoinWalletFee(size_t nBytes_)
-{
-    //mlumin: super simple fee calc for dogecoin
-    CAmount nFee=GetDogecoinWalletFeeRate().GetFee(nBytes_);
-    return nFee;
-}
-
-//mlumin 5/2021: Establish a wallet rate of n koinu per kb.
-//mlumin: this is somewhat redundant to the globally exposed ::minWalletTxFee, but honestly I'd like to have both the rate and amount (with size) here
-CFeeRate GetDogecoinWalletFeeRate()
-{
-    //mlumin 5/2021: currently 1x COIN or 1 dogecoin or 100,000,000 koinu
-    return CWallet::minTxFee;
-}
 #endif
 
 CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree)

--- a/src/dogecoin-fees.h
+++ b/src/dogecoin-fees.h
@@ -24,8 +24,6 @@ enum FeeRatePreset
 /** Estimate fee rate needed to get into the next nBlocks */
 CFeeRate GetDogecoinFeeRate(int priority);
 const std::string GetDogecoinPriorityLabel(int priority);
-CFeeRate GetDogecoinWalletFeeRate();
-CAmount GetDogecoinMinWalletFee(unsigned int nBytes_);
 #endif // ENABLE_WALLET
 CAmount GetDogecoinMinRelayFee(const CTransaction& tx, unsigned int nBytes, bool fAllowFree);
 CAmount GetDogecoinDustFee(const std::vector<CTxOut> &vout, const CAmount dustLimit);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -164,48 +164,6 @@ public:
         return (nValue == -1);
     }
 
-    CAmount GetDustThreshold(const CFeeRate &minRelayTxFeeRate) const
-    {
-        // "Dust" is defined in terms of CTransaction::minRelayTxFee,
-        // which has units satoshis-per-kilobyte.
-        // If you'd pay more than 1/3 in fees
-        // to spend something, then we consider it dust.
-        // A typical spendable non-segwit txout is 34 bytes big, and will
-        // need a CTxIn of at least 148 bytes to spend:
-        // so dust is a spendable txout less than
-        // 546*minRelayTxFee/1000 (in satoshis).
-        // A typical spendable segwit txout is 31 bytes big, and will
-        // need a CTxIn of at least 67 bytes to spend:
-        // so dust is a spendable txout less than
-        // 294*minRelayTxFee/1000 (in satoshis).
-        if (scriptPubKey.IsUnspendable())
-            return 0;
-
-        /*
-        size_t nSize = GetSerializeSize(*this, SER_DISK, 0);
-        int witnessversion = 0;
-        std::vector<unsigned char> witnessprogram;
-
-        if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
-            // sum the sizes of the parts of a transaction input
-            // with 75% segwit discount applied to the script size.
-            nSize += (32 + 4 + 1 + (107 / WITNESS_SCALE_FACTOR) + 4);
-        } else {
-            nSize += (32 + 4 + 1 + 107 + 4); // the 148 mentioned above
-        }
-
-        return 3 * minRelayTxFee.GetFee(nSize);
-        */
-
-        // Dogecoin: Anything below 1 DOGE is always dust
-        return nDustLimit;
-    }
-
-    bool IsDust(const CFeeRate &minRelayTxFeeRate) const
-    {
-        return (nValue < GetDustThreshold(minRelayTxFeeRate));
-    }
-
     // Dogecoin: allow comparison against different dustlimit parameters
     bool IsDust(const CAmount dustLimit) const
     {


### PR DESCRIPTION
Removes functions that are no longer used after reworking fees and dust.

Not used because all dust determination uses an absolute dust limit:

- `CTransaction::GetDustThreshold(CFeeRate)`
- `CTransaction::IsDust(CFeeRate)`

Never implemented because the wallet uses configurable rates:

- `GetDogecoinWalletFee(size_t)`
- `GetDogecoinWalletFeeRate()`
