### PR TITLE
[rpc] Add dustlimit info to getnetworkinfo

### DIFF
--- a/qa/rpc-tests/dustlimits.py
+++ b/qa/rpc-tests/dustlimits.py
@@ -59,6 +59,12 @@ class DustLimitTest(BitcoinTestFramework):
 
     def run_test(self):
 
+        # make sure the dust limits got configured
+        self.check_dust_config(self.nodes[0], Decimal("1.0"), Decimal("0.0"))
+        self.check_dust_config(self.nodes[1], Decimal("1.0"), Decimal("1.0"))
+        self.check_dust_config(self.nodes[2], Decimal("0.01"), Decimal("0.001"))
+        self.check_dust_config(self.nodes[3], Decimal("0.0"), Decimal("0.0"))
+
         # set up 10 seeded addresses for node 0-2
         addrs = []
         for i in range(3):
@@ -161,6 +167,11 @@ class DustLimitTest(BitcoinTestFramework):
     def get_dust_rejection(self, n, dust, fee):
         rawtx = self.create_dusty_tx(n, dust, fee)
         assert_raises_jsonrpc(-26, "dust", n.sendrawtransaction, rawtx['hex'])
+
+    def check_dust_config(self, n, soft, hard):
+        networkinfo = n.getnetworkinfo()
+        assert_equal(networkinfo["softdustlimit"], soft)
+        assert_equal(networkinfo["harddustlimit"], hard)
 
 if __name__ == '__main__':
     DustLimitTest().main()

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -422,6 +422,8 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
             "  ],\n"
             "  \"relayfee\": x.xxxxxxxx,                (numeric) minimum relay fee for non-free transactions in " + CURRENCY_UNIT + "/kB\n"
             "  \"incrementalfee\": x.xxxxxxxx,          (numeric) minimum fee increment for mempool limiting or BIP 125 replacement in " + CURRENCY_UNIT + "/kB\n"
+            "  \"softdustlimit\": x.xxxxxxxx,           (numeric) minimum output value under which this value needs to be added to fee, in " + CURRENCY_UNIT + "\n"
+            "  \"harddustlimit\": x.xxxxxxxx,           (numeric) minimum output value under which the node will no longer relay, in " + CURRENCY_UNIT + "\n"
             "  \"localaddresses\": [                    (array) list of local addresses\n"
             "  {\n"
             "    \"address\": \"xxxx\",                 (string) network address\n"
@@ -453,6 +455,8 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFeeRate.GetFeePerK()));
     obj.pushKV("incrementalfee", ValueFromAmount(::incrementalRelayFee.GetFeePerK()));
+    obj.pushKV("softdustlimit",  ValueFromAmount(nDustLimit));
+    obj.pushKV("harddustlimit",  ValueFromAmount(nHardDustLimit));
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);


### PR DESCRIPTION
Small enhancement to allow node operators to see their node's dust limit configurations by querying `getnetworkinfo`. Unfortunately we cannot show the dust limits of peers without a protocol update, so I think that for now this is the best we can accommodate.

This does not include the discard threshold for the wallet because that would benefit from UI integration too, so I felt that should be done separately.