### PR TITLE
Docs4Doge: add dogecoin (fee) policy into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current blockchain consensus of the Dogecoin network. Such fees, such speed !
 | Parameter       | Value     |
 | :-------------- | ---------:|
 | Transaction fee |   0.01 Ð/kb |
-| Minimum spend   |   0.01 Ð  |
+| Minimum output  |   1.02 Ð  |
 | Block time      | 1 minute  |
 | Block reward    | 10'000 Ð  |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu m
 
 **Website:** [dogecoin.com](https://dogecoin.com)
 
-## Dogecoin Policy 🪙
+## Dogecoin Policy 📜
 
 Current blockchain consensus of the Dogecoin network.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Current blockchain consensus of the Dogecoin network. Such fees, such speed !
 
 | Parameter       | Value     |
 | :-------------- | ---------:|
-| Transaction fee |   0.01 Ð  |
+| Transaction fee |   0.01 Ð/kb |
 | Minimum spend   |   0.01 Ð  |
 | Block time      | 1 minute  |
 | Block reward    | 10'000 Ð  |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu m
 
 ## Dogecoin Policy 📜
 
-Current blockchain consensus of the Dogecoin network.
+Current blockchain consensus of the Dogecoin network. Such fees and such speed !
 
 | Parameter       | Value     |
 | :-------------- | ---------:|

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu m
 
 ## Dogecoin Policy 📜
 
-Current blockchain consensus of the Dogecoin network. Such fees and such speed !
+Current blockchain consensus of the Dogecoin network. Such fees, such speed !
 
 | Parameter       | Value     |
 | :-------------- | ---------:|

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu m
 
 **Website:** [dogecoin.com](https://dogecoin.com)
 
+## Dogecoin Policy 🪙
+
+Current blockchain consensus of the Dogecoin network.
+
+| Parameter       | Value     |
+| :-------------- | ---------:|
+| Transaction fee |   0.01 Ð  |
+| Minimum spend   |   0.01 Ð  |
+| Block time      | 1 minute  |
+| Block reward    | 10'000 Ð  |
+
 ## Installation 💻
 
 Please see [the installation guide](INSTALL.md) for information about installing


### PR DESCRIPTION
*Related to [Docs4Doge initiative](https://github.com/dogecoin/dogecoin/issues/2271).*

Would be great to add basics information about transactions fees & blocks in the `README` to facilitate accessibility of this information. Will facilitate understanding of current fees applied by the network, as well as other useful info related to blocks, which may be unclear for people :)