### PR TITLE
rpc: improve error message in submitblock

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -787,8 +787,14 @@ UniValue submitblock(const JSONRPCRequest& request)
     if (!DecodeHexBlk(block, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a coinbase");
+    if (block.vtx.empty())
+    {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not contain a coinbase transaction");
+    } 
+
+    if (!block.vtx[0]->IsCoinBase())
+    {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a valid coinbase transaction");
     }
 
     uint256 hash = block.GetHash();


### PR DESCRIPTION
split previous conditional statement into 2
check that block both starts with and contains a coinbase transaction