### PR TITLE
[rpc] configure auxpow rpc methods to use Namecoin-compatible API

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -503,6 +503,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug) {
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
+        strUsage += HelpMessageOpt("-rpcnamecoinapi", strprintf(_("Use Namecoin-compatible AuxPow API structure, (default: %u)"), DEFAULT_USE_NAMECOIN_API));
     }
 
     return strUsage;
@@ -1061,6 +1062,9 @@ bool AppInitParameterInteraction()
     if (!CWallet::ParameterInteraction())
         return false;
 #endif
+
+    // Configure usage of the namecoin AuxPow API structure
+    fUseNamecoinApi = GetBoolArg("-rpcnamecoinapi", DEFAULT_USE_NAMECOIN_API);
 
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -968,6 +968,8 @@ UniValue estimatesmartpriority(const JSONRPCRequest& request)
 /* ************************************************************************** */
 /* Merge mining.  */
 
+bool fUseNamecoinApi;
+
 /**
  * The variables below are used to keep track of created and not yet
  * submitted auxpow blocks.  Lock them to be sure even for multiple
@@ -1084,7 +1086,7 @@ static UniValue AuxMiningCreateBlock(const CScript& scriptPubKey)
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
     result.pushKV("bits", strprintf("%08x", pblock->nBits));
     result.pushKV("height", static_cast<int64_t> (pindexPrev->nHeight + 1));
-    result.pushKV("target", HexStr(BEGIN(target), END(target)));
+    result.pushKV(fUseNamecoinApi ? "_target" : "target", HexStr(BEGIN(target), END(target)));
 
     return result;
 }
@@ -1141,8 +1143,12 @@ UniValue getauxblockbip22(const JSONRPCRequest& request)
             "  \"coinbasevalue\"      (numeric) value of the block's coinbase\n"
             "  \"bits\"               (string) compressed target of the block\n"
             "  \"height\"             (numeric) height of the block\n"
-            "  \"target\"             (string) target in reversed byte order\n"
-            "}\n"
+            + (std::string) (
+              fUseNamecoinApi
+              ? "  \"_target\"            (string) target in reversed byte order\n"
+              : "  \"target\"             (string) target in reversed byte order\n"
+            )
+            + "}\n"
             "\nResult (with arguments):\n"
             "xxxxx        (boolean) whether the submitted block was correct\n"
             "\nExamples:\n"
@@ -1225,7 +1231,7 @@ UniValue getauxblockbip22(const JSONRPCRequest& request)
         result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
         result.pushKV("bits", strprintf("%08x", pblock->nBits));
         result.pushKV("height", static_cast<int64_t> (pindexPrev->nHeight + 1));
-        result.pushKV("target", HexStr(BEGIN(target), END(target)));
+        result.pushKV(fUseNamecoinApi ? "_target" : "target", HexStr(BEGIN(target), END(target)));
 
         return result;
     }
@@ -1279,8 +1285,12 @@ UniValue createauxblock(const JSONRPCRequest& request)
             "  \"coinbasevalue\"      (numeric) value of the block's coinbase\n"
             "  \"bits\"               (string) compressed target of the block\n"
             "  \"height\"             (numeric) height of the block\n"
-            "  \"target\"             (string) target in reversed byte order\n"
-            "}\n"
+            + (std::string) (
+              fUseNamecoinApi
+              ? "  \"_target\"            (string) target in reversed byte order\n"
+              : "  \"target\"             (string) target in reversed byte order\n"
+            )
+            + "}\n"
             "\nExamples:\n"
             + HelpExampleCli("createauxblock", "\"address\"")
             + HelpExampleRpc("createauxblock", "\"address\"")

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -21,6 +21,7 @@
 #include <univalue.h>
 
 static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
+static const bool DEFAULT_USE_NAMECOIN_API = false;
 
 class CRPCCommand;
 
@@ -210,5 +211,7 @@ void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 // Retrieves any serialization flags requested in command line argument
 int RPCSerializationFlags();
+
+extern bool fUseNamecoinApi;
 
 #endif // BITCOIN_RPCSERVER_H


### PR DESCRIPTION
Allows easy integration with mining software that expects either a `_target` (Namecoin) or a `target` (Dogecoin, default) field when creating auxpow blocks. The Namecoin API can be selected by using the `-rpcnamecoinapi` startup argument. This saves pools effort in integrating the API they need whenever a new Dogecoin Core release comes out.

This follows some discussion on #2630 - am open to continue that based on the proposed code.

Note: I had to extend the configuration of the `getauxblock.py` rpc test a bit to be able to test this, however, the test now only spawns 2 nodes instead of 4, making this reduce the time the test takes.

