### PR TITLE
trivial: remove empty pixmap tag in overviewpage.ui

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -446,7 +446,6 @@
                <string></string>
               </property>
               <property name="pixmap">
-                <pixmap/>
               </property>
               <property name="scaledContents">
                <bool>false</bool>


### PR DESCRIPTION
QT complains about this, removing the tag removes the warning.