### PR TITLE
[qa] run the experimental builds on bionic too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
             sdk: 10.11
           - name: x86_64-linux-experimental
             host: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             packages: bc python3-zmq
             run-tests: true
             dep-opts: "AVX2=1"


### PR DESCRIPTION
Sets the linux experimental build to bionic, to be in line with the rest of the CI and not have any unexpected surprises when moving features from experimental to release.

This was caused by the bionic downgrade for the CI with #2501 crossing the introduction of the experimental CI for AVX2 in #2491.