### PR TITLE
Give QApplication dummy arguments

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -197,7 +197,7 @@ class BitcoinApplication: public QApplication
 {
     Q_OBJECT
 public:
-    explicit BitcoinApplication(int &argc, char **argv);
+    explicit BitcoinApplication();
     ~BitcoinApplication();
 
 #ifdef ENABLE_WALLET
@@ -312,8 +312,11 @@ void BitcoinCore::shutdown()
     }
 }
 
-BitcoinApplication::BitcoinApplication(int &argc, char **argv):
-    QApplication(argc, argv),
+static int qt_argc = 1;
+static const char* qt_argv = "dogecoin-qt";
+
+BitcoinApplication::BitcoinApplication():
+    QApplication(qt_argc, const_cast<char **>(&qt_argv)),
     coreThread(0),
     optionsModel(0),
     clientModel(0),
@@ -550,7 +553,7 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(bitcoin);
     Q_INIT_RESOURCE(bitcoin_locale);
 
-    BitcoinApplication app(argc, argv);
+    BitcoinApplication app;
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -33,6 +33,9 @@ Q_IMPORT_PLUGIN(qkrcodecs)
 
 extern void noui_connect();
 
+static int qt_argc = 1;
+static const char* qt_argv = "dogecoin-qt";
+
 // This is all you need to run all the tests
 int main(int argc, char *argv[])
 {
@@ -46,7 +49,7 @@ int main(int argc, char *argv[])
 
     // Don't remove this, it's needed to access
     // QCoreApplication:: in the tests
-    QCoreApplication app(argc, argv);
+    QCoreApplication app(qt_argc, const_cast<char **>(&qt_argv));
     app.setApplicationName("Bitcoin-Qt-test");
 
     SSL_library_init();


### PR DESCRIPTION
Discards any Qt built-in command line arguments and replaces them with dummy argv that only contains the binary name. Solves #2665 / CVE-2021-3401.

Manually ported from bitcoin/bitcoin@a2714a5c

Contains a repetition of the consts in `qt/test/test_main.cpp` because we do not have the class extraction from qt/bitcoin.cpp into qt/bitcoin.h yet - I toyed with doing that but there's a number of things we'd need in that case, and this simple fix is more straight-forward. We can clean this up further with 1.14.6

Verified that this fixes the vulnerability on Intel MacOS Big Sur.