### PR TITLE
doc: add link to fee recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Select language: EN | [CN](./README_zh_CN.md)
 
 Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu meme. The Dogecoin Core software allows anyone to operate a node in the Dogecoin blockchain networks and uses the Scrypt hashing method for Proof of Work. It is adapted from Bitcoin Core and other cryptocurrencies.
 
+For information about the default fees used on the Dogecoin network, please
+refer to the [fee recommendation](doc/fee-recommendation.md).
+
 **Website:** [dogecoin.com](https://dogecoin.com)
 
 ## Installation 💻


### PR DESCRIPTION
Adds a link to the fee recommendation in the main readme, in lieu of #2648, which we'll move to 1.14.6.