### PR TITLE
qa: fixup codeql path scope

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
-      - 'contrib'
-      - 'doc'
-      - 'share'
-      - 'qa'
+      - 'contrib/**'
+      - 'doc/**'
+      - 'share/**'
+      - 'qa/**'
 
 jobs:
   analyze:


### PR DESCRIPTION
CodeQL is currently triggering on sub-paths under `contrib` and `qa`. This change makes it in line with how the CI excludes files. 