### PR TITLE
qa: nuke caches on CI descriptor change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       CCACHE_TEMPDIR: /tmp/.ccache-temp
       CCACHE_COMPRESS: "1"
       PYTHON_DEBUG: "1"
+      CACHE_NONCE: "1"
       WINEDEBUG: fixme-all
       SDK_URL: https://bitcoincore.org/depends-sources/sdks
 
@@ -182,7 +183,7 @@ jobs:
           cache-name: depends
         with:
           path: ./depends/built
-          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*') }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('depends/packages/*', '.github/workflows/ci.yml') }}
 
       - name: Build depends
         run: |
@@ -194,7 +195,7 @@ jobs:
           cache-name: ccache
         with:
           path: ~/.ccache
-          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('**/configure.ac') }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('**/configure.ac', '.github/workflows/ci.yml') }}
 
       - name: Build Dogecoin
         run: |


### PR DESCRIPTION
- Nukes caches automatically when the CI descriptor changes
- Adds a nonce field to manually nuke the cache

Changing the CI workflow descriptor can invalidate dependencies and ccache caches by introducing different compilers or base OS, but as GH Actions does not let us update an existing cache, this would cause every subsequent CI run to rebuild everything until a nuke is triggered.

#2660 would introduce above scenario, after this, that won't happen.


