### PR TITLE
build: change minimum boost to 1_60_0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -631,10 +631,10 @@ fi
 if test x$use_boost = xyes; then
 
 dnl Minimum required Boost version
-define(MINIMUM_REQUIRED_BOOST, 1.47.0)
+define(MINIMUM_REQUIRED_BOOST, 1.60.0)
 
 dnl Check for boost libs
-AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
+AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST], AC_MSG_RESULT(ok), AC_MSG_ERROR(Need at least boost 1.60.0))
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS

--- a/configure.ac
+++ b/configure.ac
@@ -640,27 +640,6 @@ AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_THREAD
 AX_BOOST_CHRONO
-
-
-if test x$use_reduce_exports = xyes; then
-  AC_MSG_CHECKING([for working boost reduced exports])
-  TEMP_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
-  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
-      @%:@include <boost/version.hpp>
-    ]], [[
-      #if BOOST_VERSION >= 104900
-      // Everything is okay
-      #else
-      #  error Boost version is too old
-      #endif
-    ]])],[
-      AC_MSG_RESULT(yes)
-    ],[
-    AC_MSG_ERROR([boost versions < 1.49 are known to be broken with reduced exports. Use --disable-reduce-exports.])
-  ])
-  CPPFLAGS="$TEMP_CPPFLAGS"
-fi
 fi
 
 if test x$use_reduce_exports = xyes; then
@@ -703,93 +682,6 @@ fi
 if test x$use_boost = xyes; then
 
 BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_PROGRAM_OPTIONS_LIB $BOOST_THREAD_LIB $BOOST_CHRONO_LIB"
-
-
-dnl If boost (prior to 1.57) was built without c++11, it emulated scoped enums
-dnl using c++98 constructs. Unfortunately, this implementation detail leaked into
-dnl the abi. This was fixed in 1.57.
-
-dnl When building against that installed version using c++11, the headers pick up
-dnl on the native c++11 scoped enum support and enable it, however it will fail to
-dnl link. This can be worked around by disabling c++11 scoped enums if linking will
-dnl fail.
-dnl BOOST_NO_SCOPED_ENUMS was changed to BOOST_NO_CXX11_SCOPED_ENUMS in 1.51.
-
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_MSG_CHECKING([for mismatched boost c++11 scoped enums])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include "boost/config.hpp"
-  #include "boost/version.hpp"
-  #if !defined(BOOST_NO_SCOPED_ENUMS) && !defined(BOOST_NO_CXX11_SCOPED_ENUMS) && BOOST_VERSION < 105700
-  #define BOOST_NO_SCOPED_ENUMS
-  #define BOOST_NO_CXX11_SCOPED_ENUMS
-  #define CHECK
-  #endif
-  #include "boost/filesystem.hpp"
-  ]],[[
-  #if defined(CHECK)
-    boost::filesystem::copy_file("foo", "bar");
-  #else
-    choke;
-  #endif
-  ]])],
-  [AC_MSG_RESULT(mismatched); BOOST_CPPFLAGS="$BOOST_CPPFLAGS -DBOOST_NO_SCOPED_ENUMS -DBOOST_NO_CXX11_SCOPED_ENUMS"], [AC_MSG_RESULT(ok)])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-
-dnl Boost >= 1.50 uses sleep_for rather than the now-deprecated sleep, however
-dnl it was broken from 1.50 to 1.52 when backed by nanosleep. Use sleep_for if
-dnl a working version is available, else fall back to sleep. sleep was removed
-dnl after 1.56.
-dnl If neither is available, abort.
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/thread/thread.hpp>
-  #include <boost/version.hpp>
-  ]],[[
-  #if BOOST_VERSION >= 105000 && (!defined(BOOST_HAS_NANOSLEEP) || BOOST_VERSION >= 105200)
-      boost::this_thread::sleep_for(boost::chrono::milliseconds(0));
-  #else
-   choke me
-  #endif
-  ]])],
-  [boost_sleep=yes;
-     AC_DEFINE(HAVE_WORKING_BOOST_SLEEP_FOR, 1, [Define this symbol if boost sleep_for works])],
-  [boost_sleep=no])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-
-if test x$boost_sleep != xyes; then
-TEMP_LIBS="$LIBS"
-LIBS="$BOOST_LIBS $LIBS"
-TEMP_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-  #include <boost/version.hpp>
-  #include <boost/thread.hpp>
-  #include <boost/date_time/posix_time/posix_time_types.hpp>
-  ]],[[
-  #if BOOST_VERSION <= 105600
-      boost::this_thread::sleep(boost::posix_time::milliseconds(0));
-  #else
-   choke me
-  #endif
-  ]])],
-  [boost_sleep=yes; AC_DEFINE(HAVE_WORKING_BOOST_SLEEP, 1, [Define this symbol if boost sleep works])],
-  [boost_sleep=no])
-LIBS="$TEMP_LIBS"
-CPPFLAGS="$TEMP_CPPFLAGS"
-fi
-
-if test x$boost_sleep != xyes; then
-  AC_MSG_ERROR(No working boost sleep implementation found.)
-fi
 
 fi
 

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -30,14 +30,7 @@ static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delt
 
 static void MicroSleep(uint64_t n)
 {
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
     boost::this_thread::sleep_for(boost::chrono::microseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::microseconds(n));
-#else
-    //should never get here
-    #error missing boost sleep implementation
-#endif
 }
 
 BOOST_AUTO_TEST_CASE(manythreads)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -61,20 +61,7 @@ int64_t GetLogTimeMicros()
 
 void MilliSleep(int64_t n)
 {
-
-/**
- * Boost's sleep_for was uninterruptible when backed by nanosleep from 1.50
- * until fixed in 1.52. Use the deprecated sleep method for the broken case.
- * See: https://svn.boost.org/trac/boost/ticket/7238
- */
-#if defined(HAVE_WORKING_BOOST_SLEEP_FOR)
     boost::this_thread::sleep_for(boost::chrono::milliseconds(n));
-#elif defined(HAVE_WORKING_BOOST_SLEEP)
-    boost::this_thread::sleep(boost::posix_time::milliseconds(n));
-#else
-//should never get here
-#error missing boost sleep implementation
-#endif
 }
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)


### PR DESCRIPTION
*Follow-up from #2690* 

This changes the minimum required boost to 1_60_0 because of the `boost::placeholders` namespace that was introduced with that version, and that we use that since 1.14.3 / #1655. Packaged dependencies are 1_63_0 so this has no impact on the released binaries, but configuring this correctly helps preventing issues when shibes self-build their Dogecoin Core.

Also cleans up boost conditionals / macros that will never trigger because they check for issues with boost versions < 1_60

Packaged versions with main distros we touch:

```console
patrick@build:~$ for suite in trusty bionic focal; do
>   docker run --rm -e DEBIAN_FRONTEND=noninteractive ubuntu:$suite \
>   /bin/sh -c 'apt-get update -q -q && apt-get install -y -q -q libboost-all-dev && grep "define BOOST_LIB_VERSION" /usr/include/boost/version.hpp' |
>   tail -n 1 | xargs -n 3 echo $suite:;
> done 2>/dev/null
trusty: #define BOOST_LIB_VERSION 1_54
bionic: #define BOOST_LIB_VERSION 1_65_1
focal: #define BOOST_LIB_VERSION 1_71

patrick@build:~$ for suite in jessie stretch buster bullseye; do
>   docker run --rm -e DEBIAN_FRONTEND=noninteractive debian:$suite \
>   /bin/sh -c 'apt-get update -q -q && apt-get install -y -q -q libboost-all-dev && grep "define BOOST_LIB_VERSION" /usr/include/boost/version.hpp' |
>   tail -n 1 | xargs -n 3 echo $suite:;
> done 2>/dev/null
jessie: #define BOOST_LIB_VERSION 1_55
stretch: #define BOOST_LIB_VERSION 1_62
buster: #define BOOST_LIB_VERSION 1_67
bullseye: #define BOOST_LIB_VERSION 1_74

patrick@build:~$ docker run --rm archlinux \
> /bin/sh -c 'pacman -Sy --noconfirm boost && grep "define BOOST_LIB_VERSION" /usr/include/boost/version.hpp' |
> tail -n 1 | xargs -n 3 echo arch:
arch: #define BOOST_LIB_VERSION 1_76

patrick@build:~$ for version in 7 8; do 
>   docker run --rm centos:$version /bin/sh -c 'yum install -q -y boost-devel && grep "define BOOST_LIB_VERSION" /usr/include/boost/version.hpp' |
>   tail -n 1 | xargs -n 3 echo centos $version:; 
> done 2>/dev/null
centos 7: #define BOOST_LIB_VERSION 1_53
centos 8: #define BOOST_LIB_VERSION 1_66

patrick@build:~$ for version in {22..35}; do 
>   docker run --rm fedora:$version /bin/sh -c 'dnf install -q -y boost-devel && grep "define BOOST_LIB_VERSION" /usr/include/boost/version.hpp' | 
>   tail -n 1 |xargs -n 3 echo fedora $version:; 
> done 2>/dev/null
fedora 22: #define BOOST_LIB_VERSION 1_57
fedora 23: #define BOOST_LIB_VERSION 1_58
fedora 24: #define BOOST_LIB_VERSION 1_60
fedora 25: #define BOOST_LIB_VERSION 1_60
fedora 26: #define BOOST_LIB_VERSION 1_63
fedora 27: #define BOOST_LIB_VERSION 1_64
fedora 28: #define BOOST_LIB_VERSION 1_66
fedora 29: #define BOOST_LIB_VERSION 1_66
fedora 30: #define BOOST_LIB_VERSION 1_69
fedora 31: #define BOOST_LIB_VERSION 1_69
fedora 32: #define BOOST_LIB_VERSION 1_69
fedora 33: #define BOOST_LIB_VERSION 1_73
fedora 34: #define BOOST_LIB_VERSION 1_75
fedora 35: #define BOOST_LIB_VERSION 1_76
```

This means that out of the box, self-building Dogecoin Core with system libraries on the following platforms has not been possible since 1.14.3:

- Ubuntu Trusty
- Debian Jessie
- Centos 7
- Fedora 22 and 23

Those are pretty old, and with the exception of Centos 7, formally end-of-life.