### PR TITLE
bench: remove erroring components and integrate with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             host: i686-pc-linux-gnu
             os: ubuntu-18.04
             packages: g++-multilib bc python3-zmq
+            run-bench: true
             run-tests: true
             check-security: true
             check-symbols: true
@@ -53,6 +54,7 @@ jobs:
             host: arm-linux-gnueabihf
             os: ubuntu-18.04
             packages: g++-arm-linux-gnueabihf
+            run-bench: false
             run-tests: false
             check-security: true
             check-symbols: false
@@ -63,6 +65,7 @@ jobs:
             host: aarch64-linux-gnu
             os: ubuntu-18.04
             packages: g++-aarch64-linux-gnu
+            run-bench: false
             run-tests: false
             check-security: true
             check-symbols: false
@@ -73,6 +76,7 @@ jobs:
             host: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
             packages: python3
+            run-bench: true
             run-tests: true
             check-security: true
             check-symbols: true
@@ -83,6 +87,7 @@ jobs:
             host: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
             packages: bc python3-zmq
+            run-bench: true
             run-tests: true
             check-security: true
             check-symbols: false
@@ -98,6 +103,7 @@ jobs:
               sudo update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
               sudo update-alternatives --set i686-w64-mingw32-g++  /usr/bin/i686-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
+            run-bench: false
             run-tests: true
             check-security: true
             check-symbols: false
@@ -113,6 +119,7 @@ jobs:
               sudo update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
+            run-bench: false
             run-tests: true
             check-security: true
             check-symbols: false
@@ -123,6 +130,7 @@ jobs:
             host: x86_64-apple-darwin11
             os: ubuntu-18.04
             packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libtiff-tools libtinfo5 python3-setuptools xorriso libtinfo5
+            run-bench: false
             run-tests: false
             check-security: false
             check-symbols: false
@@ -134,6 +142,7 @@ jobs:
             host: x86_64-unknown-linux-gnu
             os: ubuntu-20.04
             packages: bc python3-zmq
+            run-bench: true
             run-tests: true
             dep-opts: "AVX2=1"
             config-opts: "--with-intel-avx2 --enable-gui=qt5 --enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
@@ -204,6 +213,12 @@ jobs:
           ./configure --prefix=`pwd`/depends/${{ matrix.host }} ${{ matrix.config-opts }} --enable-reduce-exports || ( cat config.log && false)
           make $MAKEJOBS ${{ matrix.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.goal }} V=1 ; false )
 
+      - name: Run benchmark
+        if: ${{ matrix.run-bench }}
+        run: |
+          src/bench/bench_dogecoin > ${{ matrix.name }}-bench.csv
+          cat ${{ matrix.name }}-bench.csv
+
       - name: Run tests
         if: ${{ matrix.run-tests }}
         run: |
@@ -226,3 +241,4 @@ jobs:
           path: |
             depends/${{ matrix.host }}/bin/dogecoin*
             dist/Dogecoin-Qt.app
+            ${{ matrix.name }}-bench.csv

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -14,18 +14,20 @@ bench_bench_dogecoin_SOURCES = \
   bench/bench_bitcoin.cpp \
   bench/bench.cpp \
   bench/bench.h \
-  bench/checkblock.cpp \
   bench/checkqueue.cpp \
   bench/Examples.cpp \
   bench/rollingbloom.cpp \
   bench/crypto_hash.cpp \
   bench/ccoins_caching.cpp \
   bench/mempool_eviction.cpp \
-  bench/verify_script.cpp \
   bench/base58.cpp \
   bench/lockedpool.cpp \
   bench/perf.cpp \
   bench/perf.h
+
+# bench_bench_dogecoin_SOURCES_DISABLED = \
+#   bench/checkblock.cpp \        # disabled because this checks a specific bitcoin block
+#   bench/verify_script.cpp \     # disabled because this checks a segwit transaction
 
 nodist_bench_bench_dogecoin_SOURCES = $(GENERATED_TEST_FILES)
 


### PR DESCRIPTION
*Follow-up from https://github.com/dogecoin/dogecoin/pull/2491#issuecomment-932804275*

Removes 2 bitcoin-specific benchmark scripts so that we don't segfault:

- `bench/checkblock.cpp` checks against a dumped bitcoin block, so this doesn't work
- `bench/verify_script.cpp` checks a segwit tx, so that doesn't work either.

We can bring those back with Dogecoin-specific benchmarks that include scrypt, AuxPoW, and regular tx, in subsequent PRs.

I have added the benchmark run to the CI so that this gets checked with all PRs, and we get to collect some data. The CI artifacts contain a csv file with the benchmark results when ran. This is currently enabled for all Intel Linux builds.

Note that this PR conflicts with #2660, so whichever gets ready for merge last will probably need a rebase.