### PR TITLE
backport: Fail instead of truncate command name in CMessageHeader constructor

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -87,8 +87,13 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-    memset(pchCommand, 0, sizeof(pchCommand));
-    strncpy(pchCommand, pszCommand, COMMAND_SIZE);
+
+    // Copy the command name, zero-padding to COMMAND_SIZE bytes
+    size_t i = 0;
+    for (; i < COMMAND_SIZE && pszCommand[i] != 0; ++i) pchCommand[i] = pszCommand[i];
+    assert(pszCommand[i] == 0); // Assert that the command name passed in is not longer than COMMAND_SIZE
+    for (; i < COMMAND_SIZE; ++i) pchCommand[i] = 0;
+
     nMessageSize = nMessageSizeIn;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -39,7 +39,12 @@ public:
     };
     typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
 
+
     CMessageHeader(const MessageStartChars& pchMessageStartIn);
+
+    /** Construct a P2P message header from message-start characters, a command and the size of the message.
+     * @note Passing in a `pszCommand` longer than COMMAND_SIZE will result in a run-time assertion error.
+     */
     CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn);
 
     std::string GetCommand() const;


### PR DESCRIPTION
Cherry-picked from: b837b33

This removes a warning when compiling. The runtime assert can be safely used because:

1. This constructor is only used by `CConman::PushMessage`
2. All calls to `CConman::PushMessage()` are using `NetMsgType` constants.