### PR TITLE
Network Tab Maximum Granularity.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -968,36 +968,14 @@ QString formatPingTime(double dPingTime)
     return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(dPingTime * 1000), 10));
 }
 
-QString formatDataSizeValue(uint64_t uValue)
+QString formatBytes(uint64_t bytes)
 {
-    // Why handle these comparisons directly, instead of a clever algorithm?
-    // This is likely to be called in a tight loop, so avoid the overhead of
-    // setting up a constant list and walking an iterator.
-    static const uint64_t TERABYTE_SIZE = UINT64_C(1024*1024*1024*1024);
-    static const uint64_t GIGABYTE_SIZE = UINT64_C(1024*1024*1024);
-    static const uint64_t MEGABYTE_SIZE = UINT64_C(1024*1024);
-    static const uint64_t KILOBYTE_SIZE = UINT64_C(1024);
+    if (bytes < 1000)
+        return QObject::tr("%1 B").arg(bytes);
+    if (bytes < 1000000)
+        return QObject::tr("%1 kB").arg(bytes / 1000);
 
-    QString unitFormat = QObject::tr("%1 B");
-
-    if (uValue == std::numeric_limits<int64_t>::max()/1e6 || uValue == 0)
-        return QObject::tr("N/A");
-
-    if (uValue > TERABYTE_SIZE) {
-        unitFormat = QObject::tr("%1 TB");
-        uValue /= TERABYTE_SIZE;
-    } else if (uValue > GIGABYTE_SIZE) {
-        unitFormat = QObject::tr("%1 GB");
-        uValue /= GIGABYTE_SIZE;
-    } else if (uValue > MEGABYTE_SIZE) {
-        unitFormat = QObject::tr("%1 MB");
-        uValue /= MEGABYTE_SIZE;
-    } else if (uValue > KILOBYTE_SIZE) {
-        unitFormat = QObject::tr("%1 KB");
-        uValue /= KILOBYTE_SIZE;
-    }
-
-    return QString(unitFormat).arg(QString::number(uValue), 10);
+    return QObject::tr("%1 MB").arg(bytes / 1000000);
 }
 
 QString formatTimeOffset(int64_t nTimeOffset)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -201,8 +201,7 @@ namespace GUIUtil
     /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
     QString formatPingTime(double dPingTime);
 
-    /* Format a uint64_t into a user-readable data size string (KB, MB, GB, TB) or display N/A, if 0*/
-    QString formatDataSizeValue(uint64_t uValue);
+    QString formatBytes(uint64_t bytes);
 
     /* Format a CNodeCombinedStats.nTimeOffset into a user-readable string. */
     QString formatTimeOffset(int64_t nTimeOffset);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -179,9 +179,9 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case Ping:
             return GUIUtil::formatPingTime(rec->nodeStats.dMinPing);
         case BytesSent:
-            return GUIUtil::formatDataSizeValue(rec->nodeStats.nSendBytes);
+            return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
         case BytesReceived:
-            return GUIUtil::formatDataSizeValue(rec->nodeStats.nRecvBytes);
+            return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
         }
     } else if (role == Qt::TextAlignmentRole) {
         if (index.column() == Ping)


### PR DESCRIPTION
Do not try to display network volume in gigabytes. Rather stick to a maximum size granularity of MB.

See the issue associated with this for discussion.
https://github.com/dogecoin/dogecoin/issues/2523.