### PR TITLE
rpc: Fix data race (UB) in InterruptRPC()

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -29,7 +29,7 @@
 using namespace RPCServer;
 using namespace std;
 
-static bool fRPCRunning = false;
+static std::atomic<bool> g_rpc_running{false};
 static bool fRPCInWarmup = true;
 static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
@@ -325,7 +325,7 @@ bool CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
 bool StartRPC()
 {
     LogPrint("rpc", "Starting RPC\n");
-    fRPCRunning = true;
+    g_rpc_running = true;
     g_rpcSignals.Started();
     return true;
 }
@@ -334,7 +334,7 @@ void InterruptRPC()
 {
     LogPrint("rpc", "Interrupting RPC\n");
     // Interrupt e.g. running longpolls
-    fRPCRunning = false;
+    g_rpc_running = false;
 }
 
 void StopRPC()
@@ -347,7 +347,7 @@ void StopRPC()
 
 bool IsRPCRunning()
 {
-    return fRPCRunning;
+    return g_rpc_running;
 }
 
 void SetRPCWarmupStatus(const std::string& newStatus)


### PR DESCRIPTION
Changes `fRPCRunning` into an `std:atomic<bool>` to prevent any race conditions.

Cherry-picked from: 6c10037

Fixes item 6 in #2744