### PR TITLE
Avoid leaking locktime fingerprint when anti-fee-sniping 

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -166,6 +166,7 @@ testScripts = [
     'p2p-leaktests.py',
     'replace-by-fee.py',
     'p2p-policy.py',
+    'wallet_create_tx.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -55,7 +55,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Construct a clone of tx1, to be malleated 
         rawtx1 = self.nodes[0].getrawtransaction(txid1,1)
-        clone_inputs = [{"txid":rawtx1["vin"][0]["txid"],"vout":rawtx1["vin"][0]["vout"]}]
+        clone_inputs = [{"txid":rawtx1["vin"][0]["txid"],"vout":rawtx1["vin"][0]["vout"], "sequence": rawtx1["vin"][0]["sequence"]}]
         clone_outputs = {rawtx1["vout"][0]["scriptPubKey"]["addresses"][0]:rawtx1["vout"][0]["value"],
                          rawtx1["vout"][1]["scriptPubKey"]["addresses"][0]:rawtx1["vout"][1]["value"]}
         clone_locktime = rawtx1["locktime"]

--- a/qa/rpc-tests/wallet_create_tx.py
+++ b/qa/rpc-tests/wallet_create_tx.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class CreateTxWalletTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def run_test(self):
+        # Check that we have some (old) blocks and that anti-fee-sniping is disabled
+        assert_equal(self.nodes[0].getblockchaininfo()['blocks'], 120)
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
+        assert_equal(tx['locktime'], 0)
+
+        # Check that anti-fee-sniping is enabled when we mine a recent block
+        self.nodes[0].generate(1)
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(txid)['hex'])
+        assert 0 < tx['locktime'] <= 121
+
+
+if __name__ == '__main__':
+    CreateTxWalletTest().main()


### PR DESCRIPTION
Reduces traceability for wallets that are behind when sending transactions, eg, after solving issues that took the wallet offline and pushing out a lot of transactions at once.

Cherry-picked from: 453803a and fa48baf

**Note: I kept the Bitcoin default of maximum 8 hours behind and 0-100 blocks randomization, but note that we may want to tune this to reflect Dogecoin block timing, to further enhance this.** Possible enhancement would be to enlarge the maximum random height subtraction to be between 540 and 1000 blocks, or change the threshold to be somewhere between 48 minutes and 8 hours. I'm open to ideas.

fixes item 5 of #2744 