### PR TITLE
net: avoid uninitialized reads on counters

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2217,8 +2217,6 @@ NodeId CConnman::GetNewNodeId()
 
 bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options connOptions)
 {
-    nTotalBytesRecv = 0;
-    nTotalBytesSent = 0;
     nMaxOutboundTotalBytesSentInCycle = 0;
     nMaxOutboundCycleStartTime = 0;
 

--- a/src/net.h
+++ b/src/net.h
@@ -339,8 +339,8 @@ private:
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;
     CCriticalSection cs_totalBytesSent;
-    uint64_t nTotalBytesRecv;
-    uint64_t nTotalBytesSent;
+    uint64_t nTotalBytesRecv = 0;
+    uint64_t nTotalBytesSent = 0;
 
     // outbound limit & stats
     uint64_t nMaxOutboundTotalBytesSentInCycle;


### PR DESCRIPTION
Initialize CConnman byte counters during construction, so that GetTotalBytesRecv() and GetTotalBytesSent() methods don't return garbage before Start() is called, in QT.

Backported from: 8313fa8e

Fixes item 1 in #2744 