### PR TITLE
Fix Char as Bool in interfaces

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -238,7 +238,7 @@ public:
      * on this bitcoin node, and set to 0 for transactions that were created
      * externally and came in through the network or sendrawtransaction RPC.
      */
-    char fFromMe;
+    bool fFromMe;
     std::string strFromAccount;
     int64_t nOrderPos; //!< position in ordered transaction list
 
@@ -309,7 +309,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         if (ser_action.ForRead())
             Init(NULL);
-        char fSpent = false;
+        bool fSpent = false;
 
         if (!ser_action.ForRead())
         {


### PR DESCRIPTION
Backport of https://github.com/bitcoin/bitcoin/pull/16572/commits/2dbfb37b407ed23b517f507d78fb77334142dce5

While `fSpent` is renamed in later versions, here it's under its original name.
