### PR TITLE
bench: add scrypt

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -23,7 +23,8 @@ bench_bench_dogecoin_SOURCES = \
   bench/base58.cpp \
   bench/lockedpool.cpp \
   bench/perf.cpp \
-  bench/perf.h
+  bench/perf.h \
+  bench/scrypt.cpp
 
 # bench_bench_dogecoin_SOURCES_DISABLED = \
 #   bench/checkblock.cpp \        # disabled because this checks a specific bitcoin block

--- a/src/bench/scrypt.cpp
+++ b/src/bench/scrypt.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <vector>
+
+#include "bench.h"
+#include "crypto/scrypt.h"
+#include "uint256.h"
+#include "utiltime.h"
+#include "utilstrencodings.h"
+
+// 80 bytes input, size of CPureBlockHeader
+static const uint64_t BUFFER_SIZE = 80;
+
+static void Scrypt(benchmark::State& state)
+{
+    uint256 output;
+    std::vector<char> in(BUFFER_SIZE, 0);
+
+#ifdef USE_SSE2
+    scrypt_detect_sse2();
+#endif // USE_SSE2
+
+    while (state.KeepRunning())
+    {
+        scrypt_1024_1_1_256(in.data(), BEGIN(output));
+    }
+}
+
+BENCHMARK(Scrypt);


### PR DESCRIPTION
Add an scrypt benchmark that hashes 80 byte inputs (size of a `CPureHeader`).

This prepares for re-enabling SSE2 as that implementation is currently broken, and allows intrinsics efforts to further tune scrypt too. By having the benchmark available first, we can track actual performance improvements. 

Note that although I use the `USE_SSE2` flag here, it will only work once we PR a fixed scrypt-sse2, which I will propose separately, after this PR.