### PR TITLE
add blockhashbyheight to rest interface

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -30,6 +30,11 @@ With the /notxdetails/ option JSON response will only contain the transaction ha
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 
+#### Blockhash by height
+ `GET /rest/blockhashbyheight/<HEIGHT>.<bin|hex|json>`
+
+ Given a height: returns hash of block in best-block-chain at height provided.
+
 ####Chaininfos
 `GET /rest/chaininfo.json`
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -602,6 +602,53 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     return true; // continue to process further HTTP reqs on this cxn
 }
 
+static bool rest_blockhash_by_height(HTTPRequest* req,
+                        const std::string& str_uri_part)
+ {
+     if (!CheckWarmup(req)) return false;
+     std::string height_str;
+     const RetFormat rf = ParseDataFormat(height_str, str_uri_part);
+
+     int32_t blockheight;
+     if (!ParseInt32(height_str, &blockheight) || blockheight < 0) {
+         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid height: " + SanitizeString(height_str));
+     }
+
+     CBlockIndex* pblockindex = nullptr;
+     {
+         LOCK(cs_main);
+         if (blockheight > chainActive.Height()) {
+             return RESTERR(req, HTTP_NOT_FOUND, "Block height out of range");
+         }
+         pblockindex = chainActive[blockheight];
+     }
+     switch (rf) {
+     case RF_BINARY: {
+         CDataStream ss_blockhash(SER_NETWORK, PROTOCOL_VERSION);
+         ss_blockhash << pblockindex->GetBlockHash();
+         req->WriteHeader("Content-Type", "application/octet-stream");
+         req->WriteReply(HTTP_OK, ss_blockhash.str());
+         return true;
+     }
+     case RF_HEX: {
+         req->WriteHeader("Content-Type", "text/plain");
+         req->WriteReply(HTTP_OK, pblockindex->GetBlockHash().GetHex() + "\n");
+         return true;
+     }
+     case RF_JSON: {
+         req->WriteHeader("Content-Type", "application/json");
+         UniValue resp = UniValue(UniValue::VOBJ);
+         resp.pushKV("blockhash", pblockindex->GetBlockHash().GetHex());
+         req->WriteReply(HTTP_OK, resp.write() + "\n");
+         return true;
+     }
+     default: {
+         return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: " + AvailableDataFormatsString() + ")");
+     }
+     }
+ }
+
+
 static const struct {
     const char* prefix;
     bool (*handler)(HTTPRequest* req, const std::string& strReq);
@@ -614,6 +661,7 @@ static const struct {
       {"/rest/mempool/contents", rest_mempool_contents},
       {"/rest/headers/", rest_headers},
       {"/rest/getutxos", rest_getutxos},
+      {"/rest/blockhashbyheight/", rest_blockhash_by_height},
 };
 
 bool StartREST()


### PR DESCRIPTION
This PR add the possibility to get the block hash by height on rest interface, like on bitcoin rest interface