### PR TITLE
Fix and enable scrypt sse2 integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
             run-bench: true
             run-tests: true
             dep-opts: "AVX2=1"
-            config-opts: "--with-intel-avx2 --enable-gui=qt5 --enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
+            config-opts: "--enable-scrypt-sse2 --with-intel-avx2 --enable-gui=qt5 --enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
             goal: install
 
     runs-on: ${{ matrix.os }}

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,12 @@ AC_ARG_ENABLE([zmq],
   [use_zmq=$enableval],
   [use_zmq=yes])
 
+AC_ARG_ENABLE([scrypt-sse2],
+  [AS_HELP_STRING([--enable-scrypt-sse2],
+  [Build with scrypt sse2 implementation (default is no)])],
+  [use_scrypt_sse2=$enableval],
+  [use_scrypt_sse2=no])
+
 AC_ARG_WITH([intel-avx2],
   [AS_HELP_STRING([--with-intel-avx2],
   [Build with intel avx2 (default is no)])],
@@ -725,6 +731,11 @@ BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_PROGRA
 
 fi
 
+# Configure Scrypt SSE2
+if test x$use_scrypt_sse2 = xyes; then
+  AC_DEFINE(USE_SSE2, 1, [Define this symbol if SSE2 works])
+fi
+
 if test x$intel_avx2 = xyes; then
   case $host in
      x86_64-*-linux*)
@@ -1028,6 +1039,7 @@ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 AM_CONDITIONAL([WORDS_BIGENDIAN],[test x$ac_cv_c_bigendian = xyes])
+AM_CONDITIONAL([USE_SCRYPT_SSE2], [test x$use_scrypt_sse2 = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -267,6 +267,11 @@ crypto_libdogecoin_crypto_a_SOURCES = \
   crypto/sha512.cpp \
   crypto/sha512.h
 
+# only include SSE2 scrypt sources if USE_SCRYPT_SSE2 is defined
+if USE_SCRYPT_SSE2
+crypto_libdogecoin_crypto_a_SOURCES += crypto/scrypt-sse2.cpp
+endif
+
 # consensus: shared between all executables that validate any consensus rules.
 libdogecoin_consensus_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libdogecoin_consensus_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -222,10 +222,11 @@ void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scrat
 // By default, set to generic scrypt function. This will prevent crash in case when scrypt_detect_sse2() wasn't called
 void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, char *scratchpad) = &scrypt_1024_1_1_256_sp_generic;
 
-void scrypt_detect_sse2()
+bool scrypt_detect_sse2()
 {
+    bool fUsingSSE2;
 #if defined(USE_SSE2_ALWAYS)
-    printf("scrypt: using scrypt-sse2 as built.\n");
+    fUsingSSE2 = true;
 #else // USE_SSE2_ALWAYS
     // 32bit x86 Linux or Windows, detect cpuid features
     unsigned int cpuid_edx=0;
@@ -243,14 +244,16 @@ void scrypt_detect_sse2()
     if (cpuid_edx & 1<<26)
     {
         scrypt_1024_1_1_256_sp_detected = &scrypt_1024_1_1_256_sp_sse2;
-        printf("scrypt: using scrypt-sse2 as detected.\n");
+        fUsingSSE2 = true;
     }
     else
     {
         scrypt_1024_1_1_256_sp_detected = &scrypt_1024_1_1_256_sp_generic;
-        printf("scrypt: using scrypt-generic, SSE2 unavailable.\n");
+        fUsingSSE2 = false;
     }
 #endif // USE_SSE2_ALWAYS
+
+    return fUsingSSE2;
 }
 #endif
 

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -16,7 +16,7 @@ void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scrat
 #define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_detected((input), (output), (scratchpad))
 #endif
 
-void scrypt_detect_sse2();
+bool scrypt_detect_sse2();
 void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad);
 extern void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, char *scratchpad);
 #else

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -1,7 +1,11 @@
-#ifndef SCRYPT_H
-#define SCRYPT_H
+#ifndef BITCOIN_CRYPTO_SCRYPT_H
+#define BITCOIN_CRYPTO_SCRYPT_H
 #include <stdlib.h>
 #include <stdint.h>
+
+#if defined(HAVE_CONFIG_H)
+#include "bitcoin-config.h" // for USE_SSE2
+#endif
 
 static const int SCRYPT_SCRATCHPAD_SIZE = 131072 + 63;
 
@@ -44,4 +48,4 @@ static inline void le32enc(void *pp, uint32_t x)
         p[3] = (x >> 24) & 0xff;
 }
 #endif
-#endif
+#endif // BITCOIN_CRYPTO_SCRYPT_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include "checkpoints.h"
 #include "compat/sanity.h"
 #include "consensus/validation.h"
+#include "crypto/scrypt.h" // for scrypt_detect_sse2
 #include "httpserver.h"
 #include "httprpc.h"
 #include "key.h"
@@ -1231,7 +1232,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     int64_t nStart;
 
 #if defined(USE_SSE2)
-    scrypt_detect_sse2();
+    if (scrypt_detect_sse2()) {
+        LogPrintf("scrypt: using SSE2 implementation\n");
+    } else {
+        LogPrintf("scrypt: using generic implementation\n");
+    }
 #endif
 
     // ********************************************************* Step 5: verify wallet database integrity


### PR DESCRIPTION
Currently the SSE2 scrypt implementation is broken. The underlying SHA256 is working with SSE2 by inheritance from Bitcoin, but notoriously the `xor_salsa8` is always using the generic function. This PR fixes and enables it by:

1. Removing the `printf` calls in the autodetection routine because we use it in more places than just the daemon. I am aware that the current Litecoin implementation [returns a string that tells us what to log](https://github.com/litecoin-project/litecoin/blob/fa0cdba24a0818c4a7206f282c86f0eac6767e72/src/crypto/scrypt.cpp#L317), but I replaced it with a boolean instead, so that, like everything else, the log message is defined in the context the function is called in. I initially played with the idea to make this a little bitmap to be able to indicate whether we are enforcing SSE2 (for x86_64) or not, but left that out, because I think that we should look into a more unified approach to runtime capability detection. [Bitcoin already does something like that for SHA256/x86 in the version we have ported into 1.21](https://github.com/dogecoin/dogecoin/blob/e73ab3f90fcd8bcb20727e2c324744cd4911c82a/src/crypto/sha256.cpp#L562) - but since we have a lot more to consider than just SHA256 and x86, we may want to build a little bit upon that later. I'll do a separate proposal for that.
2. Remove the reliance on passing `-DUSE_SSE2` into `CPPFLAGS` and instead neatly autoconf into `config/bitcoin-config.h`. I kept the `USE_SSE2` flag the same in the source code right now, but this should really be `USE_SCRYPT_SSE2` - there's more than just scrypt using SSE2 and it's confusing. Since the Bitcoin code makes assumptions about SSE2 availability already, I made the build flag `--enable-scrypt-sse2`. Note that it is disabled by default just like all the other intrinsics enhancements, so we can incubate this as an experimental optimization first. I think this is important because frankly, the implementation looks messy after all these years, and we could use some more refactoring on this. If someone wants to do a proposal, be my guest. Otherwise, I'll try to do one myself.
3. Enable sse2 in the x86_64 experimental build.

Test guidance: if you want to test locally, make sure you have a clean build directory, and you can then select this to be included with `./configure --enable-scrypt-sse2`.