### PR TITLE
depends: change fallback to depends.dogecoincore.org

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -7,7 +7,7 @@ NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
 AVX2 ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://depends.dogecoincore.org
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -28,10 +28,12 @@ define fetch_file_inner
     rm -rf $$($(1)_download_dir) )
 endef
 
+# Dogecoin: fetch the target filename from our mirror instead of the source,
+#           because some of the tag archives from github are identical
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
     ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(4),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash


### PR DESCRIPTION
This changes the fallback dependency source repository from Bitcoin's `bitcoincore.org` to `depends.dogecoincore.org`. Both are centrally hosted, as a fallback to the original sources that are used by default. Ideally this would be utilizing a decentralized protocol like IPFS, but this is harder to integrate with the CI tooling.

_Note: because some dependencies have identical filenames in their source URLs (currently ds_store and mac_alias) we host the target filename on the mirror, to prevent conflicts._
