### PR TITLE
qa: change download location and harden process for SDKs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       PYTHON_DEBUG: "1"
       CACHE_NONCE: "1"
       WINEDEBUG: fixme-all
-      SDK_URL: https://bitcoincore.org/depends-sources/sdks
+      SDK_URL: https://depends.dogecoincore.org
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
             config-opts: "--enable-gui=qt5 --disable-tests"
             goal: deploy
             sdk: 10.11
+            sdk-shasum: "bec9d089ebf2e2dd59b1a811a38ec78ebd5da18cbbcd6ab39d1e59f64ac5033f"
           - name: x86_64-linux-experimental
             host: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
@@ -198,15 +199,19 @@ jobs:
           cache-name: sdk
         with:
           path: ./depends/sdk-sources
-          key: ${{ matrix.name }}-${{ env.cache-name }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
       - name: Install SDK
         if: ${{ matrix.sdk }}
+        env:
+          sdk-filename: MacOSX${{ matrix.sdk }}.sdk.tar.gz
         run: |
           mkdir -p ./depends/sdk-sources
           mkdir -p ./depends/SDKs
-          curl --location --fail $SDK_URL/MacOSX${{ matrix.sdk }}.sdk.tar.gz -o depends/sdk-sources/MacOSX${{ matrix.sdk }}.sdk.tar.gz
-          tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${{ matrix.sdk }}.sdk.tar.gz
+          echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c || \
+          curl --location --fail $SDK_URL/${{ env.sdk-filename }} -o depends/sdk-sources/${{ env.sdk-filename }} &&\
+          echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c
+          tar -C depends/SDKs -xf depends/sdk-sources/${{ env.sdk-filename }}
 
       - name: Dependency cache
         uses: actions/cache@v2


### PR DESCRIPTION
Improves SDK usage in the GH Actions CI

- Changes the location the CI uses to download the SDK file from `bitcoincore.org` to `depends.dogecoincore.org` to further reduce dependencies on the former. 
- Hardens the CI caching and SDK verification process to defend against supply-chain attacks

**Important:** There was no checksum used in our CI process before. Testers can compare the `sha256sum` proposed here against [the one proposed in PR 2579](https://github.com/dogecoin/dogecoin/pull/2579/files#diff-b432dce31f6590825c67a1e793d13eede15888fbf58462071244e0bf56adbee9R24) and the bitcoincore.org mirror:

```console
$ curl -L https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz | sha256sum
bec9d089ebf2e2dd59b1a811a38ec78ebd5da18cbbcd6ab39d1e59f64ac5033f  -
```