### PR TITLE
depends: port dependency location changes to 1.21

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -64,7 +64,7 @@ export BASE_OUTDIR=${BASE_OUTDIR:-$BASE_SCRATCH_DIR/out/$HOST}
 # Folder where the build is done (dist and out-of-tree build).
 export BASE_BUILD_DIR=${BASE_BUILD_DIR:-$BASE_SCRATCH_DIR/build}
 export PREVIOUS_RELEASES_DIR=${PREVIOUS_RELEASES_DIR:-$BASE_ROOT_DIR/releases/$HOST}
-export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
+export SDK_URL=${SDK_URL:-https://depends.dogecoincore.org}
 export DOCKER_PACKAGES=${DOCKER_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 python3-dev rsync git procps}
 export GOAL=${GOAL:-install}
 export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -38,7 +38,7 @@ NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
 MULTIPROCESS ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://depends.dogecoincore.org
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -28,10 +28,12 @@ define fetch_file_inner
     rm -rf $$($(1)_download_dir) )
 endef
 
+# Dogecoin: fetch the target filename from our mirror instead of the source,
+#           because some of the tag archives from github are identical
 define fetch_file
     ( test -f $$($(1)_source_dir)/$(4) || \
     ( $(call fetch_file_inner,$(1),$(2),$(3),$(4),$(5)) || \
-      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(3),$(4),$(5))))
+      $(call fetch_file_inner,$(1),$(FALLBACK_DOWNLOAD_PATH),$(4),$(4),$(5))))
 endef
 
 define int_get_build_recipe_hash


### PR DESCRIPTION
Applies dependency location changes that were done for 1.14 in #2842 and #2843 to 1.21-dev, allowing both development branches to reduce reliance on and added traffic to bitcoincore.org.

Cherry-picked:
- 2c7772e - for the depends system
- 556c586 - for sdk usage in CI (cirrus for 1.21)
