### PR TITLE
Guix: build on all targets

### DIFF
--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -104,7 +104,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
                                  --container \
                                  --pure \
                                  --no-cwd \
-                                 --share="$PWD"=/bitcoin \
+                                 --share="$PWD"=/dogecoin \
                                  --expose="$(git rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
@@ -113,7 +113,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
                                         SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
                                         ${V:+V=1} \
                                         ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+                                      bash -c "cd /dogecoin && bash contrib/guix/libexec/build.sh"
     )
 
 done

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,6 +3,7 @@ $(package)_version=2.1.12-stable
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+$(package)_patches = glibc_compatibility.patch
 
 # When building for Windows, we set _WIN32_WINNT to target the same Windows
 # version as we do in configure. Due to quirks in libevents build system, this
@@ -14,6 +15,10 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
   $(package)_config_opts_android=--with-pic
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 -i $($(package)_patch_dir)/glibc_compatibility.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/libevent/glibc_compatibility.patch
+++ b/depends/patches/libevent/glibc_compatibility.patch
@@ -1,0 +1,14 @@
+Avoid getrandom@GLIBC_2.25 symbol.
+
+--- old/config.h.in
++++ new/config.h.in
+@@ -101,9 +101,6 @@
+ /* Define to 1 if you have the `getprotobynumber' function. */
+ #undef HAVE_GETPROTOBYNUMBER
+ 
+-/* Define to 1 if you have the `getrandom' function. */
+-#undef HAVE_GETRANDOM
+-
+ /* Define to 1 if you have the `getservbyname' function. */
+ #undef HAVE_GETSERVBYNAME
+ 


### PR DESCRIPTION
I did this awhile ago but it still should work.  Guix builds on all targets listed in `guix-build.sh` with the included patch from upstream.  

Successful builds include:
```
x86_64-linux-gnu 
arm-linux-gnueabihf 
aarch64-linux-gnu 
riscv64-linux-gnu 
x86_64-w64-mingw32
```
