### PR TITLE
build: work around ubuntu:focal libgcc-9-dev-arm64-cross issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         name:
           - aarch64-linux
           - aarch64-linux-experimental
+          - aarch64-linux-sha512-experimental
           - armhf-linux
           - i686-linux
           - i686-win
@@ -71,6 +72,16 @@ jobs:
             check-symbols: false
             dep-opts: "NO_QT=1"
             config-opts: "--with-armv8-crypto --enable-zmq --enable-glibc-back-compat --disable-tests LDFLAGS=-static-libstdc++"
+            goal: install
+          - name: aarch64-linux-sha512-experimental
+            host: aarch64-linux-gnu
+            os: ubuntu-20.04
+            packages: g++-aarch64-linux-gnu
+            run-tests: false
+            check-security: true
+            check-symbols: false
+            dep-opts: "NO_QT=1"
+            config-opts: "--with-armv82-crypto --enable-zmq --enable-glibc-back-compat --disable-tests LDFLAGS=-static-libstdc++"
             goal: install
           - name: aarch64-linux
             host: aarch64-linux-gnu

--- a/src/compat/arm_acle_patched.h
+++ b/src/compat/arm_acle_patched.h
@@ -1,0 +1,173 @@
+/* AArch64 Non-NEON ACLE intrinsics include file.
+
+   Copyright (C) 2014-2019 Free Software Foundation, Inc.
+   Contributed by ARM Ltd.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published
+   by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   Under Section 7 of GPL version 3, you are granted additional
+   permissions described in the GCC Runtime Library Exception, version
+   3.1, as published by the Free Software Foundation.
+
+   You should have received a copy of the GNU General Public License and
+   a copy of the GCC Runtime Library Exception along with this program;
+   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _GCC_ARM_ACLE_H
+#define _GCC_ARM_ACLE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma GCC push_options
+#pragma GCC target ("arch=armv8.3-a")
+__extension__ static __inline int32_t __attribute__ ((__always_inline__))
+__jcvt (double __a)
+{
+  return __builtin_aarch64_jcvtzs (__a);
+}
+
+#pragma GCC push_options
+#pragma GCC target ("arch=armv8.5-a")
+__extension__ static __inline float __attribute__ ((__always_inline__))
+__rint32zf (float __a)
+{
+  return __builtin_aarch64_frint32zsf (__a);
+}
+
+__extension__ static __inline double __attribute__ ((__always_inline__))
+__rint32z (double __a)
+{
+  return __builtin_aarch64_frint32zdf (__a);
+}
+
+__extension__ static __inline float __attribute__ ((__always_inline__))
+__rint64zf (float __a)
+{
+  return __builtin_aarch64_frint64zsf (__a);
+}
+
+__extension__ static __inline double __attribute__ ((__always_inline__))
+__rint64z (double __a)
+{
+  return __builtin_aarch64_frint64zdf (__a);
+}
+
+__extension__ static __inline float __attribute__ ((__always_inline__))
+__rint32xf (float __a)
+{
+  return __builtin_aarch64_frint32xsf (__a);
+}
+
+__extension__ static __inline double __attribute__ ((__always_inline__))
+__rint32x (double __a)
+{
+  return __builtin_aarch64_frint32xdf (__a);
+}
+
+__extension__ static __inline float __attribute__ ((__always_inline__))
+__rint64xf (float __a)
+{
+  return __builtin_aarch64_frint64xsf (__a);
+}
+
+__extension__ static __inline double __attribute__ ((__always_inline__))
+__rint64x (double __a)
+{
+  return __builtin_aarch64_frint64xdf (__a);
+}
+#pragma GCC pop_options
+
+#pragma GCC pop_options
+
+#pragma GCC push_options
+
+#pragma GCC target ("+nothing+crc")
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32b (uint32_t __a, uint8_t __b)
+{
+  return __builtin_aarch64_crc32b (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32cb (uint32_t __a, uint8_t __b)
+{
+  return __builtin_aarch64_crc32cb (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32ch (uint32_t __a, uint16_t __b)
+{
+  return __builtin_aarch64_crc32ch (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32cw (uint32_t __a, uint32_t __b)
+{
+  return __builtin_aarch64_crc32cw (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32cd (uint32_t __a, uint64_t __b)
+{
+  return __builtin_aarch64_crc32cx (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32h (uint32_t __a, uint16_t __b)
+{
+  return __builtin_aarch64_crc32h (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32w (uint32_t __a, uint32_t __b)
+{
+  return __builtin_aarch64_crc32w (__a, __b);
+}
+
+__extension__ static __inline uint32_t __attribute__ ((__always_inline__))
+__crc32d (uint32_t __a, uint64_t __b)
+{
+  return __builtin_aarch64_crc32x (__a, __b);
+}
+
+#pragma GCC pop_options
+
+#pragma GCC push_options
+#pragma GCC target ("+nothing+rng")
+__extension__ static __inline int __attribute__ ((__always_inline__))
+__rndr (uint64_t *__res)
+{
+  return __builtin_aarch64_rndr (__res);
+}
+
+__extension__ static __inline int __attribute__ ((__always_inline__))
+__rndrrs (uint64_t *__res)
+{
+  return __builtin_aarch64_rndrrs (__res);
+}
+
+#pragma GCC pop_options
+
+#ifdef __cplusplus
+}
+#endif
+
+#pragma GCC pop_options
+
+#endif

--- a/src/compat/arm_acle_selector.h
+++ b/src/compat/arm_acle_selector.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Replace the broken arm_acle.h included in Ubuntu's package
+// libgcc-9-dev-arm64-cross (9.4.0-1ubuntu1~20.04.1cross2)
+// with the patched version from 8c92fcb13a4979232787f0476bf7469ccbb03617
+// at https://gcc.gnu.org/git/?p=gcc.git
+#if (__GNUC__ == 9 && __GNUC_MINOR__ == 4)
+# include "compat/arm_acle_patched.h"
+#else
+# include <arm_acle.h>
+#endif

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -24,7 +24,7 @@
 /** GCC and LLVM Clang, but not Apple Clang */
 # if defined(__GNUC__) && !defined(__apple_build_version__)
 #  if defined(__ARM_ACLE) || defined(__ARM_FEATURE_CRYPTO)
-#   include <arm_acle.h>
+#   include "compat/arm_acle_selector.h"
 #  endif
 # endif
 #endif  /** ARM Headers */

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -24,7 +24,7 @@
 /** GCC and LLVM Clang, but not Apple Clang */
 # if defined(__GNUC__) && !defined(__apple_build_version__)
 #  if defined(__ARM_ACLE) || defined(__ARM_FEATURE_CRYPTO)
-#   include <arm_acle.h>
+#   include "compat/arm_acle_selector.h"
 #  endif
 # endif
 #endif  /** ARM Headers */

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -24,7 +24,7 @@
 /** GCC and LLVM Clang, but not Apple Clang */
 # if defined(__GNUC__) && !defined(__apple_build_version__)
 #  if defined(__ARM_ACLE) || defined(__ARM_FEATURE_CRYPTO)
-#   include <arm_acle.h>
+#   include "compat/arm_acle_selector.h"
 #  endif
 # endif
 #endif  /** ARM Headers */
@@ -492,4 +492,3 @@ CSHA512& CSHA512::Reset()
     sha512::Initialize(s);
     return *this;
 }
-


### PR DESCRIPTION
Ubuntu's `libgcc-9-dev-arm64-cross` on focal is broken: it misses patch [8c92fcb13a4979232787f0476bf7469ccbb03617](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=8c92fcb13a4979232787f0476bf7469ccbb03617) that fixes a mismatched "extern C" block in `arm_acle.h`.

This PR provides the patched header file in `src/compat` and includes a selector for it. Whenever we detect GCC 9.4, we include the imported header rather than the system provided, (possibly) broken header.

This patch can be reverted when Ubuntu has a fixed [libgcc-9-dev-arm64-cross](https://packages.ubuntu.com/focal-updates/libgcc-9-dev-arm64-cross).

New files:
- `src/compat/arm_acle_patched.h`: the patched file from https://gcc.gnu.org/git/?p=gcc.git
- `src/compat/arm_acle_selector.h`: simple selector that includes the correct header based on the gcc version. 

Note: The split off into a selector and original header file is done to not have to write the macro in all three `src/crypto/sha*.cpp` files, and at the same time not change the copy of the gcc-provided header file, because that's GPL3 licensed.
