### PR TITLE
1.21: make wallet/load path compatible with boost 1.78+

### DIFF
--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -22,7 +22,7 @@ bool VerifyWallets(interfaces::Chain& chain)
         fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
-        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
+        fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error).remove_trailing_separator();
         if (error || !fs::exists(wallet_dir)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
             return false;


### PR DESCRIPTION
1.21 CI is broken due to Homebrew updating to boost 1.78 by default, which no longer strips trailing path separators with `fs::canonical`. This patches the issue by back porting part of the Bitcoin Core fix for 23.0.

This PR imports the fix for Bitcoin Core for boost 1.78, minus all the enhancements that were created between 0.21.1 and 0.23, as this is a one-liner. Backport conflict pressure will remain one line too, so future backporting should not be hurt by this too much. Bitcoin Core 23.0 has not been released yet, making it risky to import all the `fs` work done there.

Taken from: [dc5d6b0d](https://github.com/bitcoin/bitcoin/commit/dc5d6b0d4793ca978f71f69ef7d6b818794676c2)
