### PR TITLE
1.21: Clone entire bitcoin-core/qa-assets repo only when fuzzing

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -78,8 +78,17 @@ fi
 DOCKER_EXEC echo "Free disk space:"
 DOCKER_EXEC df -h
 
-if [ ! -d ${DIR_QA_ASSETS} ]; then
-  DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+if [ "$RUN_FUZZ_TESTS" = "true" ]; then
+  export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
+  if [ ! -d "$DIR_FUZZ_IN" ]; then
+    DOCKER_EXEC git clone --depth=1 https://github.com/bitcoin-core/qa-assets "${DIR_QA_ASSETS}"
+  fi
+elif [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
+  export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/
+  if [ ! -d "$DIR_UNIT_TEST_DATA" ]; then
+    DOCKER_EXEC mkdir -p "$DIR_UNIT_TEST_DATA"
+    DOCKER_EXEC curl --location --fail https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json -o "${DIR_UNIT_TEST_DATA}/script_assets_test.json"
+  fi
 fi
 export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/


### PR DESCRIPTION
The entire collection of QA assets downloaded from the bitcoincore/qa-assets repo are about 4.2Gb and this is downloaded with every cirrus-ci job execution on 1.21-dev (PRs and merges)

This PR only downloads it when needed, which is in our case never, because we currently don't have any fuzzing jobs. Instead, it fetches the relevant testcase json file (https://github.com/bitcoin-core/qa-assets/raw/main/unit_test_data/script_assets_test.json) which is only 9MB, when we need it.

This saves time and unnecessary data transfer from GitHub to Cirrus servers

Cherry-picked from: bitcoin/bitcoin 0b7c55f1