### PR TITLE
qa: remove experimental ci for aarch64 sha512

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         name:
           - aarch64-linux
           - aarch64-linux-experimental
-          - aarch64-linux-sha512-experimental
           - armhf-linux
           - i686-linux
           - i686-win
@@ -72,16 +71,6 @@ jobs:
             check-symbols: false
             dep-opts: "NO_QT=1"
             config-opts: "--with-armv8-crypto --enable-zmq --enable-glibc-back-compat --disable-tests LDFLAGS=-static-libstdc++"
-            goal: install
-          - name: aarch64-linux-sha512-experimental
-            host: aarch64-linux-gnu
-            os: ubuntu-20.04
-            packages: g++-aarch64-linux-gnu
-            run-tests: false
-            check-security: true
-            check-symbols: false
-            dep-opts: "NO_QT=1"
-            config-opts: "--with-armv82-crypto --enable-zmq --enable-glibc-back-compat --disable-tests LDFLAGS=-static-libstdc++"
             goal: install
           - name: aarch64-linux
             host: aarch64-linux-gnu


### PR DESCRIPTION
Removes the CI for aarch64-linux-sha512-experimental because it errors out due to #2879. 

This can be a temporary measure that can be reverted with #2882, after that gets the testing it needs. Best solution I can come up with to keep the progress going, as merging anything will fail CI right now.