### PR TITLE
Depends: Update zlib to 1.2.12

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,8 +1,8 @@
 package=zlib
-$(package)_version=1.2.11
+$(package)_version=1.2.12
 $(package)_download_path=http://www.zlib.net
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+$(package)_sha256_hash=91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 
 define $(package)_set_vars
 $(package)_build_opts= CC="$($(package)_cc)"


### PR DESCRIPTION
The link to `zlib 1.2.11` does not exist anymore causing depends to fail (if not cached).

Old link (1.2.11): http://www.zlib.net/zlib-1.2.11.tar.gz (Returns 404 Not Found)
New link (1.2.12): http://www.zlib.net/zlib-1.2.12.tar.gz
