### PR TITLE
Changing sentence in UI that could suggest a private key is not 100% private

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -159,7 +159,7 @@ void OverviewPage::UpdateTip()
         tr("Make sure to keep your wallet updated."),
         tr("Backup your private key to recover your coins, using 'File' > 'Backup Wallet'"),
         tr("Always do your own research before using an external cryptocurrency service"),
-        tr("Never share your private key to an untrustworthy person."),
+        tr("Never share your private key with anyone"),
         tr("Who owns the private keys owns the coins."),
         tr("To see ongoing development and contribute, checkout Dogecoin repository on GitHub!"),
         tr("Services that claim to double your dogecoins are always ponzi schemes")


### PR DESCRIPTION
Well, I did not ask the community before about this change, but I strongly believe that there are many ways to share funds or securities without sharing a pk with anyone. I believe a pk must be own and knows by 1 entity only.... thank you for your comments! :)