### PR TITLE
doc: formalize pull request review timelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,25 @@ discussed extensively, be accompanied by widely discussed documentation and have
 a generally widely perceived technical consensus of being a worthwhile change,
 based on the judgement of the maintainers.
 
+
+### Merging pull requests
+
+Maintainers can only merge pull requests after any maintainer, other than the
+author of a pull request, has approved the code according to the decision
+making process outlined above.
+
+Maintainers must keep pull requests open for at least 24 hours after approval
+to merge is given, to allow anyone to voice a concern that may have been missed
+in review, or request more time to investigate a suspected issue. If a situation
+arises where more time has been requested but cannot be granted, at maintainer
+discretion, a new issue or pull request should be opened to address the defect
+or discuss improved alternatives. Requests for time and maintainer decision
+making are expected to be clearly documented on the pull request discussion on
+Github.
+
+Maintenance tasks and time-critical patches can be exempted from this rule if
+these are clearly marked as such, at maintainer discretion.
+
 ## Copyright
 
 By contributing to this repository, you agree to license your work under the 


### PR DESCRIPTION
Over the past month, you may have noticed that we've been keeping pull requests open a little longer between approval and merge, to allow for any reactions to come in after maintainer approval, that may possibly save rework or anyone feeling left out of the review process. It is not always needed, but since we don't know _when_ it would be needed upfront, I feel it reasonable to allow for this in the process. This PR proposes to formalize that change, making development more transparent and inclusive.

The process prescribes a lag time between maintainer approval and merge of minimally 24 hours because that creates a workable balance between maintaining development momentum and transparency. Maintenance tasks are exempt from the lag time requirement.

All wording, proposed timing and exceptions are open to suggestions. This change is not urgent so I propose to keep this open for at least 14 days, pending feedback.