### PR TITLE
Set the wallet's discard threshold to 0.01 DOGE

### DIFF
--- a/doc/fee-recommendation.md
+++ b/doc/fee-recommendation.md
@@ -15,7 +15,7 @@ parametrized. The recommended defaults, as implemented in the Dogecoin Core
 wallet, are:
 
 - **0.01 DOGE per kilobyte** transaction fee
-- **1.00 DOGE** dust limit (discard threshold)
+- **0.01 DOGE** dust limit (discard threshold)
 - **0.001 DOGE** replace-by-fee increments
 
 The wallet rejects transactions that have outputs under the dust limit, and

--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -279,7 +279,7 @@ def test_locked_wallet_fails(rbf_node, dest_address):
 
 def test_dogecoin_wallet_minchange(rbf_node, dest_address):
     input = Decimal("10.00000000")
-    discard_threshold = Decimal("1.00000000")    # DEFAULT_DISCARD_THRESHOLD
+    discard_threshold = Decimal("0.01000000")    # DEFAULT_DISCARD_THRESHOLD
     min_fee = Decimal("0.01000000")              # DEFAULT_TRANSACTION_FEE
     min_change = discard_threshold + 2 * min_fee # MIN_CHANGE
     bumpfee = Decimal("0.001")                   # WALLET_INCREMENTAL_RELAY_FEE

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -524,6 +524,9 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     // Confirm dust penalty fees are added on
     // Because this is ran by the wallet, this takes the discardThreshold,
     // not the dust limit
+    
+    CWallet::discardThreshold = COIN;
+
     CAmount nDustPenalty = COIN;
 
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 963, 0, pool), nDustPenalty + (nMinTxFee * 0.963));
@@ -540,7 +543,7 @@ BOOST_AUTO_TEST_CASE(GetMinimumFee_dust_test)
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1000, 0, pool), nMinTxFee * 1.000);
     BOOST_CHECK_EQUAL(CWallet::GetMinimumFee(tx, 1999, 0, pool), nMinTxFee * 1.999);
 
-    CWallet::discardThreshold = COIN;
+    CWallet::discardThreshold = COIN / 100;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -62,7 +62,10 @@ static const CAmount DEFAULT_TRANSACTION_MINFEE = RECOMMENDED_MIN_TX_FEE;
  *         value can be changed when a significant portion of the relay network
  *         and miners have adopted a different hard dust limit.
  */
-static const CAmount DEFAULT_DISCARD_THRESHOLD = COIN;
+/* 1.14.6: set the wallet's discard threshold to 0.01 DOGE. Very network
+ *         adoption of new hard dust limit
+ */
+static const CAmount DEFAULT_DISCARD_THRESHOLD = COIN / 100;
 
 //! minimum recommended increment for BIP 125 replacement txs
 /*


### PR DESCRIPTION
At this point, of the 1203 nodes online, 752 of them are already running version 1.14.5 or higher (62.5%), which means that the hard and soft dust limit are already widely adopted and, in my view, it is safe to update the discart threshold of 1 DOGE to 0.01 DOGE.

I've already tested sending a value equal to 0.01 DOGE paying only a small fee, without the dust penalty, and I was successful.