### PR TITLE
qa: add tests for `addr` messages

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -127,6 +127,7 @@ testScripts = [
     # 'bip68-112-113-p2p.py',
     'rawtransactions.py',
     'reindex.py',
+    'p2p-addr.py',
     # vv Tests less than 30s vv
     'mempool_resurrect_test.py',
     'txn_doublespend.py --mineblock',

--- a/qa/rpc-tests/p2p-addr.py
+++ b/qa/rpc-tests/p2p-addr.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import * #NodeConnCB, NODE_NETWORK, NetworkThread, NodeConn, wait_until, CAddress, msg_addr, msg_ping, msg_pong
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+
+'''
+AddrTest -- test processing of addr messages
+'''
+
+class AddrTestNode(SingleNodeConnCB):
+    def __init__(self, name):
+        SingleNodeConnCB.__init__(self)
+        self.ports_received = []
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def getaddr(self):
+        self.connection.send_message(msg_getaddr())
+
+    def on_addr(self, conn, message):
+        for addr in message.addrs:
+            self.ports_received.append(addr.port)
+
+    def on_getaddr(self, conn, message):
+        self.getaddr_msg_received += 1
+
+    def wait_for_disconnect(self):
+        if self.connection == None:
+            return True
+        def is_closed():
+            return self.connection.state == "closed"
+        return wait_until(is_closed, timeout=30)
+
+    def disconnect(self):
+        self.connection.disconnect_node()
+        return self.wait_for_disconnect()
+
+class AddrTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.counter = 0
+        self.mocktime = int(time.time())
+        self.start_port = 10000
+
+    def run_test(self):
+        self.nodes[0].generate(1)
+
+        self.simple_relay_test()
+        self.oversized_addr_test()
+
+        self.send_node.disconnect()
+        for recv_node in self.recv_nodes:
+            recv_node.disconnect()
+
+    def setup_network(self):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug=net", "-peertimeout=999999999"]))
+
+        self.send_node = self.create_testnode()
+        self.recv_nodes = []
+        for i in range(4):
+            self.recv_nodes.append(self.create_testnode())
+
+        NetworkThread().start()
+        self.send_node.wait_for_verack()
+        for recv_node in self.recv_nodes:
+            recv_node.wait_for_verack()
+
+    def create_testnode(self, send_getaddr=False, node_idx=0):
+        node = AddrTestNode(send_getaddr)
+        conn = NodeConn('127.0.0.1', p2p_port(node_idx), self.nodes[node_idx], node)
+        node.add_connection(conn)
+        return node
+
+    def index_to_port(self, idx):
+        return self.start_port + idx
+
+    def last_port_sent(self):
+        assert self.counter > 0
+        return self.index_to_port(self.counter - 1)
+
+    def have_received_port(self, port):
+        for peer in self.recv_nodes:
+            if port in peer.ports_received:
+                return True
+        return False
+
+    def wait_for_specific_port(self, port):
+        def port_received():
+            return self.have_received_port(port)
+        return wait_until(port_received, timeout=600)
+
+    def create_addr_msg(self, num, services):
+        addrs = []
+        for i in range(num):
+            addr = CAddress()
+            addr.time = self.mocktime + random.randrange(-100, 100)
+            addr.nServices = services
+            assert self.counter < 256 ** 2  # Don't allow the returned ip addresses to wrap.
+            addr.ip = f"123.123.{self.counter // 256}.{self.counter % 256}"
+            addr.port = self.index_to_port(self.counter)
+            self.counter += 1
+            addrs.append(addr)
+
+        msg = msg_addr()
+        msg.addrs = addrs
+        return msg
+
+    def send_addr_msg(self, msg):
+        self.send_node.connection.send_message(msg)
+        time.sleep(0.5) # sleep half a second to prevent mocktime racing the msg
+
+        # invoke m_next_addr_send timer:
+        # `addr` messages are sent on an exponential distribution with mean interval of 30s.
+        # Setting the mocktime 600s forward gives a probability of (1 - e^-(600/30)) that
+        # the event will occur (i.e. this fails once in ~500 million repeats).
+        self.mocktime += 60 * 10
+        self.nodes[0].setmocktime(self.mocktime)
+
+        time.sleep(0.5) # sleep half a second to prevent pings racing mocktime
+        for peer in self.recv_nodes:
+            peer.sync_with_ping()
+
+    def create_and_send_addr_msg(self, num, services=NODE_NETWORK):
+        self.send_addr_msg(self.create_addr_msg(num, services))
+
+    def simple_relay_test(self):
+        # send a message with 2 addresses
+        self.create_and_send_addr_msg(2)
+
+        # make sure we received the last addr record
+        assert self.wait_for_specific_port(self.last_port_sent())
+
+    def oversized_addr_test(self):
+        # create message with 1010 entries and
+        # confirm that the node discarded the entries
+
+        # send one valid message, keep track of the port it contains
+        valid_port_before = self.index_to_port(self.counter)
+        self.create_and_send_addr_msg(1)
+
+        # send a too large message that will be ignored
+        self.create_and_send_addr_msg(1010)
+
+        # finish with a valid message, keep track of the port it contains
+        valid_port_after = self.index_to_port(self.counter)
+        self.create_and_send_addr_msg(1)
+
+        # wait until both valid addresses were propagated
+        assert self.wait_for_specific_port(valid_port_before)
+        assert self.wait_for_specific_port(valid_port_after)
+
+        # make sure that all addresses from the invalid message were discarded
+        # by making sure that none of them were propagated
+        for port in range(valid_port_before+1, valid_port_after):
+            assert not self.have_received_port(port)
+
+if __name__ == '__main__':
+    AddrTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -219,19 +219,24 @@ def ToHex(obj):
 
 class CAddress(object):
     def __init__(self):
+        self.time = 0
         self.nServices = 1
         self.pchReserved = b"\x00" * 10 + b"\xff" * 2
         self.ip = "0.0.0.0"
         self.port = 0
 
-    def deserialize(self, f):
+    def deserialize(self, f, with_time=True):
+        if with_time:
+            self.time = struct.unpack("<I", f.read(4))[0]
         self.nServices = struct.unpack("<Q", f.read(8))[0]
         self.pchReserved = f.read(12)
         self.ip = socket.inet_ntoa(f.read(4))
         self.port = struct.unpack(">H", f.read(2))[0]
 
-    def serialize(self):
+    def serialize(self, with_time=True):
         r = b""
+        if with_time:
+            r += struct.pack("<I", self.time)
         r += struct.pack("<Q", self.nServices)
         r += self.pchReserved
         r += socket.inet_aton(self.ip)
@@ -239,8 +244,9 @@ class CAddress(object):
         return r
 
     def __repr__(self):
-        return "CAddress(nServices=%i ip=%s port=%i)" % (self.nServices,
-                                                         self.ip, self.port)
+        return "CAddress(time=%i, nServices=%i ip=%s port=%i)" % (
+          self.time, self.nServices, self.ip, self.port
+        )
 
 MSG_WITNESS_FLAG = 1<<30
 
@@ -967,11 +973,11 @@ class msg_version(object):
         self.nServices = struct.unpack("<Q", f.read(8))[0]
         self.nTime = struct.unpack("<q", f.read(8))[0]
         self.addrTo = CAddress()
-        self.addrTo.deserialize(f)
+        self.addrTo.deserialize(f, False)
 
         if self.nVersion >= 106:
             self.addrFrom = CAddress()
-            self.addrFrom.deserialize(f)
+            self.addrFrom.deserialize(f, False)
             self.nNonce = struct.unpack("<Q", f.read(8))[0]
             self.strSubVer = deser_string(f)
         else:
@@ -999,8 +1005,8 @@ class msg_version(object):
         r += struct.pack("<i", self.nVersion)
         r += struct.pack("<Q", self.nServices)
         r += struct.pack("<q", self.nTime)
-        r += self.addrTo.serialize()
-        r += self.addrFrom.serialize()
+        r += self.addrTo.serialize(False)
+        r += self.addrFrom.serialize(False)
         r += struct.pack("<Q", self.nNonce)
         r += ser_string(self.strSubVer)
         r += struct.pack("<i", self.nStartingHeight)


### PR DESCRIPTION
Currently, `addr` message handling isn't tested at all and the test framework doesn't support the CAddress format introduced in Bitcoin Core v0.3.15 from 2010!

This PR introduces the test and adapts the test framework, to create a baseline for future work on addr messages.

1. Adds the time field to addr messages from protocol version 31402, but serialize/deserialize without it for version messages. This allows us to test p2p addr messages from the python test framework.
2. Implements a straight-forward test that tests simple relay of newly announced peers, and one that makes sure we do not process messages that are over 1000 entries, per `MAX_ADDR_TO_SEND` in `net.h`

Besides testing on 1.14.6-dev, I have also ran this with 1.14.4 and 1.14.5, because we simply wouldn't have known if we'd introduced an issue.

Note to testers: please run this a couple of times. I believe that I reworked all race conditions and haven't been able to reproduce them, but I still rely on a 500ms sleep when doing setmocktime (because we don't have `getmocktime` and I didn't want to make this PR too big while we're working towards release) 