### PR TITLE
ci: force remove mono from windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
             os: ubuntu-18.04
             packages: python3 nsis g++-mingw-w64-i686 wine-stable bc wine-binfmt
             postinstall: |
+              sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
               sudo update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
               sudo update-alternatives --set i686-w64-mingw32-g++  /usr/bin/i686-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
@@ -138,6 +139,7 @@ jobs:
             os: ubuntu-18.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
+              sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
               sudo update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine


### PR DESCRIPTION
Fixes the win64 CI.

After a bionic update on 2022/06/03, Github Actions images have a `mono-runtime` installation that takes precedence over `wine`, which we need for running the tests.

This PR removes `mono-runtime` from both windows CI jobs if it exists, so that it doesn't bother us anymore in any way thinkable. We do not need mono there, as we do not .net. Although the issue only manifested on `x86_64-w64-mingw32` builds, this also removes it from the `i686-w64-mingw32` build as a precaution.