### PR TITLE
net: implement a mockable micro time

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -25,6 +25,12 @@ int64_t GetTime()
     return now;
 }
 
+int64_t GetMockableTimeMicros()
+{
+    if (nMockTime) return nMockTime * 1000000;
+    return GetTimeMicros();
+}
+
 void SetMockTime(int64_t nMockTimeIn)
 {
     nMockTime = nMockTimeIn;

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -24,6 +24,7 @@ int64_t GetTimeMillis();
 int64_t GetTimeMicros();
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 int64_t GetLogTimeMicros();
+int64_t GetMockableTimeMicros();
 void SetMockTime(int64_t nMockTimeIn);
 void MilliSleep(int64_t n);
 


### PR DESCRIPTION
While I was working further on the `addr` message processing in the network stack, I noticed that `setmocktime` is not having any effect on `addr` message timing. This is caused by mocked time only being applied to `GetTime`, and not things like `GetTimeMicros`. This is not bad, as the latter is used for event queue ticks and should not be mocked everywhere, so I introduced a new function that returns mocked time in microseconds. This only affects `regtest` as `setmocktime` is disallowed on mainnet and testnet.

Throughout the code, we use mockable time in places where we want to test things that are subject to timing constraints, but don't want to wait for great amounts of time when we use the regtest network to ensure nothing gets broken. Mockable time is a system time override that is only enabled on chains that have the `fMineBlocksOnDemand` parameter set (currently: `regtest`).

Currently, only time expressed in seconds is able to be mocked, but we have a couple of places where time is evaluated in microseconds, one of them being the time between sending out `addr` messages.

This introduces a mockable time in microseconds (`GetMockableTimeMicros`) and refactors the time evaluation for `addr` messages to be mocked, so that we can more reliably (and faster) test that.

Other protocol features may want to use this too, but currently the sending of `addr` messages is the only place we test. Bitcoin Core nowadays has a much better time system that we inherit in future versions, but for the current scope I found this not worth the effort of backporting, as these would impact a much larger part of the code base.

Inspired by: 1a8f0d5a from Amiti Uttarwar