### PR TITLE
qa: remove test-local dependencies on enable_mocktime

### DIFF
--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -19,15 +19,28 @@ def txFromHex(hexstring):
 class ListTransactionsTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
+        self.num_nodes = 2
+        self.setup_clean_chain = True
 
-    def setup_nodes(self):
-        #This test requires mocktime
-        enable_mocktime()
-        return start_nodes(self.num_nodes, self.options.tmpdir)
+    def setup_nodes(self, split=False):
+        nodes = []
+        for i in range(self.num_nodes):
+            nodes.append(start_node(i, self.options.tmpdir, ["-debug=net"]))
+        return nodes
+
+    def setup_network(self, split = False):
+        self.nodes = self.setup_nodes()
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
 
     def run_test(self):
+        # mine some blocks to each node and then generate 60 more to mature cb
+        self.nodes[0].generate(10)
+        self.nodes[1].generate(10)
+        self.nodes[0].generate(60)
+        self.sync_all()
+
         # Simple send, 0 to 1:
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 100)
         self.sync_all()

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -28,15 +28,26 @@ class ReceivedByTest(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
+        self.num_nodes = 2
+        self.setup_clean_chain = True
 
-    def setup_nodes(self):
-        #This test requires mocktime
-        enable_mocktime()
-        return start_nodes(self.num_nodes, self.options.tmpdir)
+    def setup_nodes(self, split=False):
+        nodes = []
+        for i in range(self.num_nodes):
+            nodes.append(start_node(i, self.options.tmpdir, ["-debug=net"]))
+        return nodes
+
+    def setup_network(self, split = False):
+        self.nodes = self.setup_nodes()
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
 
     def run_test(self):
+        # Mine 61 blocks to get spendable coin
+        self.nodes[0].generate(61)
+        self.sync_all()
+
         '''
         listreceivedbyaddress Test
         '''


### PR DESCRIPTION
Tests that depend on `enable_mocktime()` because they use the cached chain are testing things that need actual time. Because we're mocking time more often when we are processing messages, these tests fail (because to the node, no time expires unless mocktime is explicitly set whenever time is tested to be expired.)

This PR rewrites these tests to no longer use the cached chain.

Tests affected:
- listtransactions.py
- receivedby.py

Note that there are still many tests that use the cached chain, but they operate in real time (they do not call `enable_mocktime()` inside the test) 

Marking this as `urgent`, because this blocks #2989 and the test itself didn't change.