### PR TITLE
improve some user-facing strings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -325,7 +325,7 @@ std::string HelpMessage(HelpMessageMode mode)
     std::string strUsage = HelpMessageGroup(_("Options:"));
     strUsage += HelpMessageOpt("-?", _("Print this help message and exit"));
     strUsage += HelpMessageOpt("-version", _("Print version and exit"));
-    strUsage += HelpMessageOpt("-alertnotify=<cmd>", _("Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)"));
+    strUsage += HelpMessageOpt("-alertnotify=<cmd>", _("Execute command when we see a really long fork (%s in cmd is replaced by message)"));
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash, %i is replaced by block number)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -614,7 +614,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     else {
         dFeeVary = (double)std::max(CWallet::GetRequiredFee(1000), mempool.estimateSmartFee(nTxConfirmTarget).GetFeePerK()) / 1000;
     }
-    QString toolTip4 = tr("Can vary +/- %1 koinu(s) per input.").arg(dFeeVary);
+    QString toolTip4 = tr("Can vary +/- %1 koinu per input.").arg(dFeeVary);
 
     l3->setToolTip(toolTip4);
     l4->setToolTip(toolTip4);

--- a/src/qt/forms/importkeysdialog.ui
+++ b/src/qt/forms/importkeysdialog.ui
@@ -128,7 +128,7 @@
      <item>
       <widget class="QPushButton" name="resetButton">
        <property name="toolTip">
-        <string>Reset all key management options to default.</string>
+        <string>Reset this form.</string>
        </property>
        <property name="text">
         <string>&amp;Reset</string>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -762,7 +762,7 @@
           <item>
            <widget class="QLabel" name="fallbackFeeWarningLabel">
             <property name="toolTip">
-             <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until your have validated the complete chain.</string>
+             <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
             </property>
             <property name="font">
             <font>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -153,15 +153,15 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
 void OverviewPage::UpdateTip()
 {
     QStringList tips = {
-        tr("Never share your wallet.dat file/your private key with anyone"),
-        tr("For more advanced settings use the console in 'Help' -> 'Debug Window'"),
+        tr("Never share your wallet.dat file with anyone"),
+        tr("For advanced operations, use the console in 'Help' -> 'Debug Window'"),
         tr("Encrypt your wallet with a strong passphrase for maximum security"),
-        tr("Make sure to keep your wallet updated."),
+        tr("Make sure to keep your wallet software updated"),
         tr("Backup your private key to recover your coins, using 'File' > 'Backup Wallet'"),
         tr("Always do your own research before using an external cryptocurrency service"),
         tr("Never share your private key with anyone"),
-        tr("Who owns the private keys owns the coins."),
-        tr("To see ongoing development and contribute, checkout Dogecoin repository on GitHub!"),
+        tr("Who owns the private keys, owns the coins"),
+        tr("To see ongoing development and contribute, check out the Dogecoin Core repository on GitHub"),
         tr("Services that claim to double your dogecoins are always ponzi schemes")
     };
 


### PR DESCRIPTION
A very small collection of minor textual fixes I saved up over the past few weeks, for user-facing string that I found needed clarification or fixing, to be updated prior to string freeze

- improves conciseness of tips displayed in Qt
- makes the function of the reset button on the importkeydialog describe reality
- describe `-alertnotify` to match the new reality after 565280f4
- make sure that "koinu" is not expressed as "koinus"
- fix typo in advanced send screen