### PR TITLE
Force `verifychain` RPC args to be positive

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) 2014-2016 The Bitcoin Core developers
+# Copyright (c) 2022 The Dogecoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,6 +52,7 @@ class BlockchainTest(BitcoinTestFramework):
         self._test_gettxoutsetinfo()
         self._test_getblockheader()
         self._test_getblockchaininfo()
+        self._test_verifychain_args()
         self.nodes[0].verifychain(4, 0)
 
     # PL backported this entire test from upstream 0.16 to 1.14.3
@@ -135,6 +137,33 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(header['version'], int)
         assert isinstance(int(header['versionHex'], 16), int)
         assert isinstance(header['difficulty'], Decimal)
+
+    def _test_verifychain_args(self):
+        node = self.nodes[0]
+
+        try:
+            node.verifychain(-1)
+            raise AssertionError("Must check for validity of checklevel parameter")
+        except JSONRPCException as e:
+            assert("Error: checklevel must be >= 0 and <= 4" in e.error["message"])
+
+        try:
+            node.verifychain(5)
+            raise AssertionError("Must check for validity of checklevel parameter")
+        except JSONRPCException as e:
+            assert("Error: checklevel must be >= 0 and <= 4" in e.error["message"])
+
+        try:
+            node.verifychain(0, -100)
+            raise AssertionError("Must check for validity of nblocks parameter")
+        except JSONRPCException as e:
+            assert("Error: nblocks must be >= 0" in e.error["message"])
+
+        try:
+            node.verifychain(0, -1000)
+            raise AssertionError("Must check for validity of nblocks parameter")
+        except JSONRPCException as e:
+            assert("Error: nblocks must be >= 0" in e.error["message"])
 
 if __name__ == '__main__':
     BlockchainTest().main()

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1051,8 +1051,13 @@ UniValue verifychain(const JSONRPCRequest& request)
 
     if (request.params.size() > 0)
         nCheckLevel = request.params[0].get_int();
+    if (nCheckLevel < 0 || nCheckLevel > 4)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: checklevel must be >= 0 and <= 4");
+
     if (request.params.size() > 1)
         nCheckDepth = request.params[1].get_int();
+    if (nCheckDepth < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Error: nblocks must be >= 0");
 
     return CVerifyDB().VerifyDB(Params(), pcoinsTip, nCheckLevel, nCheckDepth);
 }


### PR DESCRIPTION
Verification levels must be between 0 and 4 inclusive, and block heights should always be positive. While code in the scan process handles the latter case with a default value, it's better to verify and reject invalid input where it first enters the system.