### PR TITLE
net: rate limit the processing of incoming addr messages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -659,6 +659,8 @@ void CNode::copyStats(CNodeStats &stats)
     }
     X(fWhitelisted);
     X(minFeeFilter);
+    X(nProcessedAddrs);
+    X(nRatelimitedAddrs);
 
     // It is common for nodes with good ping times to suddenly become lagged,
     // due to a new block arriving or other large transfer.
@@ -2735,6 +2737,10 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fGetAddr = false;
     nNextLocalAddrSend = 0;
     nNextAddrSend = 0;
+    nAddrTokenBucket = 1; // initialize to 1 to allow self-announcement
+    nAddrTokenTimestamp = GetTimeMicros();
+    nProcessedAddrs = 0;
+    nRatelimitedAddrs = 0;
     nNextInvSend = 0;
     fRelayTxes = false;
     fSentAddr = false;

--- a/src/net.h
+++ b/src/net.h
@@ -520,6 +520,8 @@ public:
     std::string addrLocal;
     CAddress addr;
     CAmount minFeeFilter;
+    uint64_t nProcessedAddrs;
+    uint64_t nRatelimitedAddrs;
 };
 
 
@@ -647,6 +649,14 @@ public:
     std::set<uint256> setKnown;
     int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
+
+    /** Number of addresses that can be processed from this peer. */
+    double nAddrTokenBucket;
+    /** When nAddrTokenBucket was last updated, in microseconds */
+    int64_t nAddrTokenTimestamp;
+
+    std::atomic<uint64_t> nProcessedAddrs;
+    std::atomic<uint64_t> nRatelimitedAddrs;
 
     // inventory based relay
     CRollingBloomFilter filterInventoryKnown;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -26,6 +26,16 @@ static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER = 1000; // 1ms/head
  * is set to 1 second.
  */
 static constexpr int64_t MIN_BLOCK_DOWNLOAD_MULTIPLIER = 10; // 10 seconds
+
+/** The maximum rate of address records we're willing to process on average.
+ * Is bypassed for whitelisted connections. */
+static constexpr double MAX_ADDR_RATE_PER_SECOND{0.1};
+
+/** The soft limit of the address processing token bucket (the regular MAX_ADDR_RATE_PER_SECOND
+ *  based increments won't go above this, but the MAX_ADDR_TO_SEND increment following GETADDR
+ *  is exempt from this limit. */
+static constexpr size_t MAX_ADDR_PROCESSING_TOKEN_BUCKET{MAX_ADDR_TO_SEND};
+
 /** Register with a network node to receive its signals */
 void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -135,7 +135,9 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
             "       n,                        (numeric) The heights of blocks we're currently asking from this peer\n"
             "       ...\n"
             "    ],\n"
-            "    \"whitelisted\": true|false, (boolean) Whether the peer is whitelisted\n"					
+            "    \"addr_processed\": n,       (numeric) The total number of addresses processed, excluding those dropped due to rate limiting\n"
+            "    \"addr_rate_limited\": n,    (numeric) The total number of addresses dropped due to rate limiting\n"
+            "    \"whitelisted\": true|false, (boolean) Whether the peer is whitelisted\n"
             "    \"bytessent_per_msg\": {\n"
             "       \"addr\": n,              (numeric) The total bytes sent aggregated by message type\n"
             "       ...\n"
@@ -201,6 +203,8 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
             }
             obj.pushKV("inflight", heights);
         }
+        obj.pushKV("addr_processed", stats.nProcessedAddrs);
+        obj.pushKV("addr_rate_limited", stats.nRatelimitedAddrs);
         obj.pushKV("whitelisted", stats.fWhitelisted);
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);


### PR DESCRIPTION
On the p2p network, sometimes custom nodes are sending us lots of peer addresses, the processing of which costs us CPU time and some data transfer (we try to announce every address we receive to 1-2 peers to keep network discovery going.) This was recently addressed on Bitcoin Core 22.0 by limiting the rate at which a node processes addresses received, helping to keep resource usage in check a little bit better.

This PR backports the relevant Bitcoin Core code (from `0d64b8f7`, `5648138f`, `f424d601` and `d930c7f5`) with the following:

1. Introduce a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) that keeps track of how many addresses our node will process for each peer. When a peer sends us too many addresses, we simply don't process the additional ones and move on.
2. The maximum amount of tokens to accumulate is 1000; the same as the maximum entries in an `addr` message.
3. The rate, 1-on-1 copied from Bitcoin Core, is currently set to 1 per 10 seconds, which is approximately 5x the amount that we see honest nodes do in the wild.
4. Because an `addr` message can contain up to 1000 addresses, we randomize the list order before processing, to make it unpredictable which addresses will go through and which won't.
5. Because our node can explicitly ask a peer for addresses using the `getaddr` message (i.e. when we are actively in search of peers to connect to), we assign these peers that we've requested the data from an additional 1000 tokens on top of the already allocated tokens once, temporarily increasing past the limit of 1000. Since our node controls when we send out `getaddr`, this is fully controlled by us, not the peer.
6. The number of processed and rate limited addresses are added to the output of `getpeerinfo`, allowing node operators to identify misbehaving peers.

