### PR TITLE
net: rework transaction download scheduling

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -129,6 +129,7 @@ testScripts = [
     'rawtransactions.py',
     'reindex.py',
     'p2p-addr.py',
+    'p2p-tx-download.py',
     # vv Tests less than 30s vv
     'p2p_invalid_locator.py',
     'mempool_resurrect_test.py',

--- a/qa/rpc-tests/p2p-tx-download.py
+++ b/qa/rpc-tests/p2p-tx-download.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import * #NodeConnCB, NODE_NETWORK, NetworkThread, NodeConn, wait_until, CAddress, msg_addr, msg_ping, msg_pong
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+
+'''
+TxDownload -- test transaction download logic
+'''
+
+GETDATA_TX_INTERVAL = 30  # seconds
+TX_EXPIRY_INTERVAL = 10 * GETDATA_TX_INTERVAL # 5 minutes
+INBOUND_PEER_TX_DELAY = 2  # seconds
+TXID_RELAY_DELAY = 2 # seconds
+MAX_GETDATA_IN_FLIGHT = 100
+
+class TxDownloadTestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.tx_getdata_received = []
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def send_tx_inv(self, hashes):
+        invs = []
+        for hash in hashes:
+            invs.append(CInv(1, hash))
+        self.connection.send_message(msg_inv(invs))
+
+    def send_tx_notfound(self, hashes):
+        vec = []
+        for hash in hashes:
+            vec.append(CInv(1, hash))
+        self.connection.send_message(msg_notfound(vec))
+
+    def on_getdata(self, conn, message):
+        for entry in message.inv:
+            if entry.type == 1:
+                self.tx_getdata_received.append(entry.hash)
+
+    def wait_for_disconnect(self):
+        if self.connection == None:
+            return True
+        def is_closed():
+            return self.connection.state == "closed"
+        return wait_until(is_closed, timeout=30)
+
+    def disconnect(self):
+        self.connection.disconnect_node()
+        return self.wait_for_disconnect()
+
+class TxDownloadTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.counter = 0
+        self.mocktime = int(time.time())
+        self.is_network_split = False
+
+        # very fake txid that can be incremented
+        self.fake_txid = 0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+
+        # valid regtest address that no one has the key to
+        self.tgtAddr = "mkwDHkWXF8x6aFtdGVm5E9PVC7yPY8cb4r"
+
+    def run_test(self):
+        self.nodes[1].generate(1)
+        self.sync_all()
+        self.nodes[0].generate(100)
+        self.sync_all()
+
+        self.test_tx_request()
+        self.test_invblock_resolution()
+        self.test_max_inflight()
+        self.test_disconnect_fallback()
+        self.test_notfound_fallback()
+
+    def setup_network(self):
+        # set up full nodes
+        self.nodes = []
+        # Node 0 is going to be our testsubject that is connected to a bunch of nasty peers
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug=net", "-debug=mempool", "-peertimeout=999999999"]))
+        # Node 1 is going to be our honest peer
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=net", "-debug=mempool", "-peertimeout=999999999"]))
+
+        # Connect Node 0 to Node 1 as outgoing
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+
+        # set up incoming (non-honest) peers
+        self.incoming_peers = []
+        for i in range(8):
+            self.incoming_peers.append(self.create_testnode())
+
+        NetworkThread().start()
+        for peer in self.incoming_peers:
+            peer.wait_for_verack()
+
+    def create_testnode(self, node_idx=0):
+        node = TxDownloadTestNode()
+        conn = NodeConn('127.0.0.1', p2p_port(node_idx), self.nodes[node_idx], node)
+        node.add_connection(conn)
+        return node
+
+    def any_received_getdata(self, hash, peers):
+        for peer in peers:
+            if hash in peer.tx_getdata_received:
+                return True
+        return False
+
+    def all_received_getdata(self, hash, peers):
+        for peer in peers:
+            if not hash in peer.tx_getdata_received:
+                return False
+        return True
+
+    def wait_for_getdata(self, hashes, peers):
+        def getdata_received():
+            for hash in hashes:
+                if not self.all_received_getdata(hash, peers):
+                    return False
+            return True
+        return wait_until(getdata_received, timeout=10)
+
+    def find_winning_peer(self, peers, hash):
+        # detect which peer won a race for getting a getdata hash
+        selected = None
+        fallback = None
+        for peer in peers:
+            if hash in peer.tx_getdata_received:
+                selected = peer
+            else:
+                fallback = peer
+
+        assert selected is not None
+        assert fallback is not None
+
+        return selected, fallback
+
+    def forward_mocktime(self, delta_time):
+        self.mocktime += delta_time
+        for node in self.nodes:
+            node.setmocktime(self.mocktime)
+        # give the nodes some time to process the new mocktime
+        # can be removed when we have getmocktime
+        time.sleep(0.1)
+
+    def forward_mocktime_step2(self, iterations):
+        # forward mocktime in steps of 2 seconds to allow the nodes
+        # time to recognize they have to do something
+        for i in range(iterations):
+            self.forward_mocktime(2)
+
+    def next_fake_txid(self):
+        self.fake_txid += 1
+        return self.fake_txid
+
+    def test_tx_request(self):
+        txid = self.next_fake_txid()
+        self.forward_mocktime(0)
+
+        # use incoming peers 0 and 1
+        peerset = self.incoming_peers[0:4]
+        for peer in peerset:
+            peer.send_tx_inv([txid])
+
+        # To make sure we eventually ask the tx from all 4 nodes that announced
+        # to us, we're now jumping 4 * (2 + 2 + 30) = 136 seconds to the future
+        warp = 4 * (INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + GETDATA_TX_INTERVAL)
+        self.forward_mocktime_step2(warp//2)
+
+        # All peers that sent the inv should now have received a getdata request
+        assert self.wait_for_getdata([txid], peerset)
+
+        # Make sure the other peers did not receive the getdata because they
+        # didn't indicate they have the tx
+        assert not self.any_received_getdata(txid, self.incoming_peers[4:8])
+
+    def test_invblock_resolution(self):
+        inputs = [self.nodes[1].listunspent()[0]]
+        outputs = { self.tgtAddr: inputs[0]['amount'] - 1 }
+        unsigned_tx = self.nodes[1].createrawtransaction(inputs, outputs)
+        tx_hex = self.nodes[1].signrawtransaction(unsigned_tx)['hex']
+        tx = FromHex(CTransaction(), tx_hex)
+        tx.rehash()
+        txid = int(tx.hash, 16)
+
+        self.forward_mocktime(0)
+
+        # make sure that node 1 is outbound for node 0
+        assert self.nodes[0].getpeerinfo()[0]['inbound'] == False
+
+        # use all peers that only inv but never respond to getdata
+        for peer in self.incoming_peers:
+            peer.send_tx_inv([txid])
+
+        # send from our honest node last
+        self.nodes[1].sendrawtransaction(tx_hex)
+
+        # We jump forward 2x (2 + 2) + 30 + 2 (margin) = 40 seconds to make sure
+        # that we get to the point where we re-evaluate the transaction in 2
+        # second steps
+        warp = 2 * (INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY) + GETDATA_TX_INTERVAL + 2
+        self.forward_mocktime_step2(warp//2)
+
+        assert tx.hash in self.nodes[0].getrawmempool()
+
+    def test_max_inflight(self):
+        # First, forward time by 2x inflight timeout, so that we have clean
+        # registers for each peer
+        self.forward_mocktime(2 * TX_EXPIRY_INTERVAL)
+
+        # now send MAX_GETDATA_IN_FLIGHT (=100) invs with peer 0
+        peer = self.incoming_peers[0]
+        invd = []
+        for i in range(MAX_GETDATA_IN_FLIGHT):
+            txid = self.next_fake_txid()
+            peer.send_tx_inv([txid])
+            invd.append(txid)
+
+        # warp forward 2 + 2 + 2 (margin) = 6 seconds in steps of 2
+        warp = INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        # test that we got all the getdatas
+        assert self.wait_for_getdata(invd, [peer])
+
+        # send one more inv with our now maxed out peer
+        txid_failed = self.next_fake_txid()
+        peer.send_tx_inv([txid_failed])
+        # and send one inv with another peer
+        txid_success = self.next_fake_txid()
+        self.incoming_peers[1].send_tx_inv([txid_success])
+
+        # warp forward 2 + 2 + 2 (margin) = 6 seconds in steps of 2
+        warp = INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        # test that we got a getdata for the successful tx with peer 1
+        assert self.wait_for_getdata([txid_success], [self.incoming_peers[1]])
+        # test that we did not get a getdata for the failed txid with peer 0
+        assert not self.any_received_getdata(txid_failed, [peer])
+
+        # clear out the inflight register by expiring all requests
+        self.forward_mocktime(TX_EXPIRY_INTERVAL)
+
+        # send one inv with 4 txs
+        txids = []
+        for i in range(4):
+            txids.append(self.next_fake_txid())
+        peer.send_tx_inv(txids)
+
+        # warp forward 2 + 2 + 2 (margin) = 6 seconds in steps of 2
+        warp = INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        # test that we got a getdata for the final inv with peer 0
+        assert self.wait_for_getdata(txids, [peer])
+
+    def test_notfound_fallback(self):
+        # use peer 4 and 5 to concurrently send 2 invs
+        peers = self.incoming_peers[4:6]
+        txid = self.next_fake_txid()
+        self.forward_mocktime(1)
+
+        for peer in peers:
+            peer.send_tx_inv([txid])
+
+        # warp forward 2 + 2 + 2 (margin) = 6 seconds in steps of 2
+        warp = INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        winner, loser = self.find_winning_peer(peers, txid)
+
+        # send a reject message from the peer that won the race
+        winner.send_tx_notfound([txid])
+
+        # warp forward 30 + 2 + 2 + 2 (margin) = 36 seconds in steps of 2
+        warp = GETDATA_TX_INTERVAL + INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        # the losing peer is now the fallback and received a getdata message
+        assert self.wait_for_getdata([txid], [loser])
+
+    def test_disconnect_fallback(self):
+        # use peer 6 and 7 to concurrently send 2 invs
+        peers = self.incoming_peers[6:8]
+        txid = self.next_fake_txid()
+        self.forward_mocktime(1)
+
+        for peer in peers:
+            peer.send_tx_inv([txid])
+
+        # warp forward 2 + 2 + 2 (margin) = 6 seconds in steps of 2
+        warp = INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        winner, loser = self.find_winning_peer(peers, txid)
+
+        # drop connection from the peer that won the race
+        assert winner.disconnect()
+
+        # warp forward 30 + 2 + 2 + 2 (margin) = 36 seconds in steps of 2
+        warp = GETDATA_TX_INTERVAL + INBOUND_PEER_TX_DELAY + TXID_RELAY_DELAY + 2
+        self.forward_mocktime_step2(warp//2)
+
+        # the losing peer is now the fallback and received a getdata message
+        assert self.wait_for_getdata([txid], [loser])
+
+if __name__ == '__main__':
+    TxDownloadTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1106,6 +1106,20 @@ class msg_getdata(object):
     def __repr__(self):
         return "msg_getdata(inv=%s)" % (repr(self.inv))
 
+class msg_notfound:
+    command = b"notfound"
+
+    def __init__(self, vec=None):
+        self.vec = vec or []
+
+    def deserialize(self, f):
+        self.vec = deser_vector(f, CInv)
+
+    def serialize(self):
+        return ser_vector(self.vec)
+
+    def __repr__(self):
+        return "msg_notfound(vec=%s)" % (repr(self.vec))
 
 class msg_getblocks(object):
     command = b"getblocks"

--- a/src/net.h
+++ b/src/net.h
@@ -74,10 +74,6 @@ static const bool DEFAULT_UPNP = USE_UPNP;
 #else
 static const bool DEFAULT_UPNP = false;
 #endif
-/** The maximum number of entries in mapAskFor */
-static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
-/** The maximum number of entries in setAskFor (larger due to getdata latency)*/
-static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -479,8 +475,6 @@ extern bool fDiscover;
 extern bool fListen;
 extern bool fRelayTxes;
 
-extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
-
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;
 
@@ -658,8 +652,6 @@ public:
     // and in the order requested.
     std::vector<uint256> vInventoryBlockToSend;
     CCriticalSection cs_inventory;
-    std::set<uint256> setAskFor;
-    std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory
@@ -808,8 +800,6 @@ public:
         LOCK(cs_inventory);
         vBlockHashesToAnnounce.push_back(hash);
     }
-
-    void AskFor(const CInv& inv);
 
     void CloseSocketDisconnect();
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -47,6 +47,21 @@ struct IteratorComparator
     }
 };
 
+/** Maximum number of in-flight transactions from a peer */
+static constexpr int32_t MAX_PEER_TX_IN_FLIGHT = 100;
+/** Maximum number of announced transactions from a peer */
+static constexpr int32_t MAX_PEER_TX_ANNOUNCEMENTS = 2 * MAX_INV_SZ;
+/** How many microseconds to delay requesting transactions from inbound peers */
+static constexpr int64_t INBOUND_PEER_TX_DELAY = 2 * 1000000;
+/** How long to wait (in microseconds) before downloading a transaction from an additional peer */
+static constexpr int64_t GETDATA_TX_INTERVAL = 60 * 1000000;
+/** Maximum delay (in microseconds) for transaction requests to avoid biasing some peers over others. */
+static constexpr int64_t MAX_GETDATA_RANDOM_DELAY = 2 * 1000000;
+static_assert(INBOUND_PEER_TX_DELAY >= MAX_GETDATA_RANDOM_DELAY,
+"To preserve security, MAX_GETDATA_RANDOM_DELAY should not exceed INBOUND_PEER_DELAY");
+/** Limit to avoid sending big packets. Not used in processing incoming GETDATA for compatibility */
+static const unsigned int MAX_GETDATA_SZ = 1000;
+
 struct COrphanTx {
     // When modifying, adapt the copy of this definition in tests/DoS_tests.
     CTransactionRef tx;
@@ -199,6 +214,67 @@ struct CNodeState {
      */
     bool fSupportsDesiredCmpctVersion;
 
+    /*
+     * State associated with transaction download.
+     *
+     * Tx download algorithm:
+     *
+     *   When inv comes in, queue up (process_time, txid) inside the peer's
+     *   CNodeState (m_tx_process_time) as long as m_tx_announced for the peer
+     *   isn't too big (MAX_PEER_TX_ANNOUNCEMENTS).
+     *
+     *   The process_time for a transaction is set to nNow for outbound peers,
+     *   nNow + 2 seconds for inbound peers. This is the time at which we'll
+     *   consider trying to request the transaction from the peer in
+     *   SendMessages(). The delay for inbound peers is to allow outbound peers
+     *   a chance to announce before we request from inbound peers, to prevent
+     *   an adversary from using inbound connections to blind us to a
+     *   transaction (InvBlock).
+     *
+     *   When we call SendMessages() for a given peer,
+     *   we will loop over the transactions in m_tx_process_time, looking
+     *   at the transactions whose process_time <= nNow. We'll request each
+     *   such transaction that we don't have already and that hasn't been
+     *   requested from another peer recently, up until we hit the
+     *   MAX_PEER_TX_IN_FLIGHT limit for the peer. Then we'll update
+     *   g_already_asked_for for each requested txid, storing the time of the
+     *   GETDATA request. We use g_already_asked_for to coordinate transaction
+     *   requests amongst our peers.
+     *
+     *   For transactions that we still need but we have already recently
+     *   requested from some other peer, we'll reinsert (process_time, txid)
+     *   back into the peer's m_tx_process_time at the point in the future at
+     *   which the most recent GETDATA request would time out (ie
+     *   GETDATA_TX_INTERVAL + the request time stored in g_already_asked_for).
+     *   We add an additional delay for inbound peers, again to prefer
+     *   attempting download from outbound peers first.
+     *   We also add an extra small random delay up to 2 seconds
+     *   to avoid biasing some peers over others. (e.g., due to fixed ordering
+     *   of peer processing in ThreadMessageHandler).
+     *
+     *   When we receive a transaction from a peer, we remove the txid from the
+     *   peer's m_tx_in_flight set and from their recently announced set
+     *   (m_tx_announced).  We also clear g_already_asked_for for that entry, so
+     *   that if somehow the transaction is not accepted but also not added to
+     *   the reject filter, then we will eventually redownload from other
+     *   peers.
+     */
+
+    struct TxDownloadState {
+        /* Track when to attempt download of announced transactions (process
+         * time in micros -> txid)
+         */
+        std::multimap<int64_t, uint256> m_tx_process_time;
+
+        //! Store all the transactions a peer has recently announced
+        std::set<uint256> m_tx_announced;
+
+        //! Store transactions which were requested by us
+        std::set<uint256> m_tx_in_flight;
+    };
+
+    TxDownloadState m_tx_download;
+
     CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn), name(addrNameIn) {
         fCurrentlyConnected = false;
         nMisbehavior = 0;
@@ -223,6 +299,9 @@ struct CNodeState {
         fSupportsDesiredCmpctVersion = false;
     }
 };
+
+// Keeps track of the time (in microseconds) when transactions were requested last time
+limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ);
 
 /** Map maintaining per-node state. Requires cs_main. */
 std::map<NodeId, CNodeState> mapNodeState;
@@ -555,6 +634,59 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
             }
         }
     }
+}
+
+void EraseTxRequest(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    g_already_asked_for.erase(txid);
+}
+
+int64_t GetTxRequestTime(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    auto it = g_already_asked_for.find(txid);
+    if (it != g_already_asked_for.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+void UpdateTxRequestTime(const uint256& txid, int64_t request_time) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    auto it = g_already_asked_for.find(txid);
+
+    if (it == g_already_asked_for.end()) {
+        g_already_asked_for.insert(std::make_pair(txid, request_time));
+    } else {
+        g_already_asked_for.update(it, request_time);
+    }
+}
+
+void RequestTx(CNodeState* state, const uint256& txid, int64_t nNow) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    CNodeState::TxDownloadState& peer_download_state = state->m_tx_download;
+    if (peer_download_state.m_tx_announced.size() >= MAX_PEER_TX_ANNOUNCEMENTS || peer_download_state.m_tx_announced.count(txid)) {
+        // Too many queued announcements from this peer, or we already have
+        // this announcement
+        return;
+    }
+    peer_download_state.m_tx_announced.insert(txid);
+
+    int64_t process_time;
+    int64_t last_request_time = GetTxRequestTime(txid);
+
+    // First time requesting this tx
+    if (last_request_time == 0) {
+        process_time = nNow;
+    } else {
+        // Randomize the delay to avoid biasing some peers over others (such as due to
+        // fixed ordering of peer processing in ThreadMessageHandler)
+        process_time = last_request_time + GETDATA_TX_INTERVAL + GetRand(MAX_GETDATA_RANDOM_DELAY);
+    }
+
+    // We delay processing announcements from non-preferred (eg inbound) peers
+    if (!state->fPreferredDownload) process_time += INBOUND_PEER_TX_DELAY;
+
+    peer_download_state.m_tx_process_time.emplace(process_time, txid);
 }
 
 } // anon namespace
@@ -1543,6 +1675,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LOCK(cs_main);
 
         uint32_t nFetchFlags = GetFetchFlags(pfrom, chainActive.Tip(), chainparams.GetConsensus(chainActive.Height()));
+        int64_t nNow = GetTimeMicros();
 
         std::vector<CInv> vToFetch;
 
@@ -1579,7 +1712,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 if (fBlocksOnly)
                     LogPrint("net", "transaction (%s) inv sent in violation of protocol peer=%d\n", inv.hash.ToString(), pfrom->id);
                 else if (!fAlreadyHave && !fImporting && !fReindex && !IsInitialBlockDownload())
-                    pfrom->AskFor(inv);
+                    RequestTx(State(pfrom->GetId()), inv.hash, nNow);
             }
 
         }
@@ -1815,8 +1948,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         bool fMissingInputs = false;
         CValidationState state;
 
-        pfrom->setAskFor.erase(inv.hash);
-        mapAlreadyAskedFor.erase(inv.hash);
+        CNodeState* nodestate = State(pfrom->GetId());
+        nodestate->m_tx_download.m_tx_announced.erase(inv.hash);
+        nodestate->m_tx_download.m_tx_in_flight.erase(inv.hash);
+        EraseTxRequest(inv.hash);
 
         std::list<CTransactionRef> lRemovedTxn;
 
@@ -1906,10 +2041,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
             if (!fRejectedParents) {
                 uint32_t nFetchFlags = GetFetchFlags(pfrom, chainActive.Tip(), chainparams.GetConsensus(chainActive.Height()));
+                int64_t nNow = GetMockableTimeMicros();
+
                 BOOST_FOREACH(const CTxIn& txin, tx.vin) {
                     CInv _inv(MSG_TX | nFetchFlags, txin.prevout.hash);
                     pfrom->AddInventoryKnown(_inv);
-                    if (!AlreadyHave(_inv)) pfrom->AskFor(_inv);
+                    if (!AlreadyHave(_inv)) RequestTx(State(pfrom->GetId()), _inv.hash, nNow);
                 }
                 AddOrphanTx(ptx, pfrom->GetId());
 
@@ -3288,25 +3425,39 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
         //
         // Message: getdata (non-blocks)
         //
-        while (!pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
-        {
-            const CInv& inv = (*pto->mapAskFor.begin()).second;
-            if (!AlreadyHave(inv))
-            {
-                if (fDebug)
-                    LogPrint("net", "Requesting %s peer=%d\n", inv.ToString(), pto->id);
-                vGetData.push_back(inv);
-                if (vGetData.size() >= 1000)
-                {
-                    connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
-                    vGetData.clear();
+        auto& tx_process_time = state.m_tx_download.m_tx_process_time;
+        while (!tx_process_time.empty() && tx_process_time.begin()->first <= current_time && state.m_tx_download.m_tx_in_flight.size() < MAX_PEER_TX_IN_FLIGHT) {
+            const uint256& txid = tx_process_time.begin()->second;
+            CInv inv(MSG_TX | GetFetchFlags(pto, chainActive.Tip(), consensusParams), txid);
+            if (!AlreadyHave(inv)) {
+                // If this transaction was last requested more than 1 minute ago,
+                // then request.
+                int64_t last_request_time = GetTxRequestTime(inv.hash);
+                if (last_request_time <= current_time - GETDATA_TX_INTERVAL) {
+                    LogPrint("net", "Requesting %s peer=%d\n", inv.ToString(), pto->GetId());
+                    vGetData.push_back(inv);
+                    if (vGetData.size() >= MAX_GETDATA_SZ) {
+                        connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
+                        vGetData.clear();
+                    }
+                    UpdateTxRequestTime(inv.hash, current_time);
+                    state.m_tx_download.m_tx_in_flight.insert(inv.hash);
+                } else {
+                    // This transaction is in flight from someone else; queue
+                    // up processing to happen after the download times out
+                    // (with a slight delay for inbound peers, to prefer
+                    // requests to outbound peers).
+                    RequestTx(&state, txid, current_time);
                 }
             } else {
-                //If we're not going to ask, don't expect a response.
-                pto->setAskFor.erase(inv.hash);
+                // We have already seen this transaction, no need to download.
+                state.m_tx_download.m_tx_announced.erase(inv.hash);
+                state.m_tx_download.m_tx_in_flight.erase(inv.hash);
             }
-            pto->mapAskFor.erase(pto->mapAskFor.begin());
+            tx_process_time.erase(tx_process_time.begin());
         }
+
+
         if (!vGetData.empty())
             connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -54,7 +54,7 @@ static constexpr int32_t MAX_PEER_TX_ANNOUNCEMENTS = 2 * MAX_INV_SZ;
 /** How many microseconds to delay requesting transactions from inbound peers */
 static constexpr int64_t INBOUND_PEER_TX_DELAY = 2 * 1000000; // 2 seconds
 /** How long to wait (in microseconds) before downloading a transaction from an additional peer */
-static constexpr int64_t GETDATA_TX_INTERVAL = 60 * 1000000; // 1 minute
+static constexpr int64_t GETDATA_TX_INTERVAL = 30 * 1000000; // 30 seconds
 /** Maximum delay (in microseconds) for transaction requests to avoid biasing some peers over others. */
 static constexpr int64_t MAX_GETDATA_RANDOM_DELAY = 2 * 1000000; // 2 seconds
 /** How long to wait (in microseconds) before expiring an in-flight getdata request to a peer */
@@ -3483,9 +3483,9 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                     ++it;
                 }
             }
-            // On average, we do this check every TX_EXPIRY_INTERVAL. Randomize
+            // On average, we do this check every TX_EXPIRY_INTERVAL/3.75. Randomize
             // so that we're not doing this for all peers at the same time.
-            state.m_tx_download.m_check_expiry_timer = current_time + TX_EXPIRY_INTERVAL/2 + GetRand(TX_EXPIRY_INTERVAL);
+            state.m_tx_download.m_check_expiry_timer = current_time + TX_EXPIRY_INTERVAL/5 + GetRand(TX_EXPIRY_INTERVAL/5);
         }
 
         auto& tx_process_time = state.m_tx_download.m_tx_process_time;


### PR DESCRIPTION
This is work on top of #2989 by @alamshafil.

### What this PR does

1. Mitigates weaknesses mentioned in #2735 by speeding up recovery from slow peers failing to give us the transactions we don't have, and prioritizing outgoing nodes over incoming ones.
2. Reduces the memory needed to deal with slow peers by explicitly setting limits to how many transactions we will process from said peers.
3. Tightly manage timeouts to prevent situations where a connection to a peer is temporary slow from being stale for a longer time.
4. Sends and honors `notfound` messages, that until now were ignored.
 
### What this PR contains

1. Fixes for mentioned issue by taking the work done by Shafil and then backporting Bitcoin Core's bugfixes on top. These have been cherry-picked 1-on-1, and then squashed to ease segregation between Bitcoin Core code and bespoke changes for Dogecoin Core.
6. A change to make all the inv-related scheduling mockable so that we can test fast
7. Tunes the parametrization of the scheduling to be more suitable for Dogecoin and recover faster
8. Adds a QA test to make sure that we spot regressions on this in the future, and of course to prove the current functionality

