### PR TITLE
update checkpoints, chainwork, assumevalid for mainnet and testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,10 +110,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 0; // Disabled
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000141a39e783aad4f660f");
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000007dc8ab65fc32f953c4a"); // 4,303,965
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x77e3f4a4bcb4a2c15e8015525e3d15b466f6c022f6ca82698f329edef7d9777e"); // 2,510,150
+        consensus.defaultAssumeValid = uint256S("0xed7d266dcbd8bb8af80f9ccb8deb3e18f9cc3f6972912680feeb37b090f8cee0"); // 4,303,965
 
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
@@ -199,15 +199,16 @@ public:
             ( 3606083, uint256S("0x954c7c66dee51f0a3fb1edb26200b735f5275fe54d9505c76ebd2bcabac36f1e"))
             ( 3854173, uint256S("0xe4b4ecda4c022406c502a247c0525480268ce7abbbef632796e8ca1646425e75"))
             ( 3963597, uint256S("0x2b6927cfaa5e82353d45f02be8aadd3bfd165ece5ce24b9bfa4db20432befb5d"))
+            ( 4303965, uint256S("0xed7d266dcbd8bb8af80f9ccb8deb3e18f9cc3f6972912680feeb37b090f8cee0"))
         };
 
         chainTxData = ChainTxData{
-            // Data as of block e4b4ecda4c022406c502a247c0525480268ce7abbbef632796e8ca1646425e75 (height 3854173).
-            // Tx estimate based on average of year 2021 (~40k transactions per day)
-            1635884188, // * UNIX timestamp of last checkpoint block
-            79560907,   // * total number of transactions between genesis and last checkpoint
+            // Data as of block ed7d266dcbd8bb8af80f9ccb8deb3e18f9cc3f6972912680feeb37b090f8cee0 (height 4303965).
+            // Tx estimate based on average between 2021-07-01 (3793538) and 2022-07-01 (4288126)
+            1657646310, // * UNIX timestamp of last checkpoint block
+            86433645,   // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            0.46        // * estimated number of transactions per second after checkpoint
+            0.29        // * estimated number of transactions per second after checkpoint
         };
     }
 };
@@ -263,10 +264,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 0; // Disabled
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000000001030d1382ade");
+        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000003e3c33bc605e5d"); // 3,976,284
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x6943eaeaba98dc7d09f7e73398daccb4abcabb18b66c8c875e52b07638d93951"); // 900,000
+        consensus.defaultAssumeValid = uint256S("0xaf23c3e750bb4f2ce091235f006e7e4e2af453d4c866282e7870471dcfeb4382"); // 3,976,284
 
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
@@ -352,12 +353,13 @@ public:
             ( 3062910, uint256S("0x113c41c00934f940a41f99d18b2ad9aefd183a4b7fe80527e1e6c12779bd0246"))
             ( 3286675, uint256S("0x07fef07a255d510297c9189dc96da5f4e41a8184bc979df8294487f07fee1cf3"))
             ( 3445426, uint256S("0x70574db7856bd685abe7b0a8a3e79b29882620645bd763b01459176bceb58cd1"))
+            ( 3976284, uint256S("0xaf23c3e750bb4f2ce091235f006e7e4e2af453d4c866282e7870471dcfeb4382"))
         };
 
         chainTxData = ChainTxData{
-            // Data as of block 07fef07a255d510297c9189dc96da5f4e41a8184bc979df8294487f07fee1cf3 (height 3286675)
-            1635884142, // * UNIX timestamp of last checkpoint block
-            4780345,    // * total number of transactions between genesis and last checkpoint
+            // Data as of block af23c3e750bb4f2ce091235f006e7e4e2af453d4c866282e7870471dcfeb4382 (height 3976284)
+            1657647467, // * UNIX timestamp of last checkpoint block
+            5353803,    // * total number of transactions between genesis and last checkpoint
             0.02        // * estimated number of transactions per second after that timestamp
         };
 


### PR DESCRIPTION
Opening this earlier than usual, so that we can keep an eye on this, because hash rate has significantly dropped the past few months [according to bitinfocharts](https://bitinfocharts.com/comparison/dogecoin-hashrate.html#3m) and I have confirmed this to be consistent with what my own monitoring indicates:

<img width="1434" alt="3-mo hashrate estimate from bitinfocharts" src="https://user-images.githubusercontent.com/1410115/178575221-54df4f27-d886-4bd6-84f5-f35aa1928822.png">

This means that we have to be a little bit more careful when setting a checkpoint. We can easily, if the proposed checkpoint from this PR does not turn out to be optimal, go back further in time and use an earlier block. However, it's always good to have an as-recent-as-possible checkpoint, so let's try this one first.

### mainnet

`ed7d266dcbd8bb8af80f9ccb8deb3e18f9cc3f6972912680feeb37b090f8cee0` is the new mainnet checkpoint at height `4303965`, with a total tx count of `86433645`.

Calculated the tx volume between block 3793538 and 4288126 which is exactly 1 year of volume to be 0.29 tx/s. It's recently been going up a bit again, but the long-term trend is definitely downward rather than upward.

Cumulative chainwork is `0x07dc8ab65fc32f953c4a`

### testnet

`af23c3e750bb4f2ce091235f006e7e4e2af453d4c866282e7870471dcfeb4382` is the new testnet checkpoint at height `3976284`, with a total tx count of `5353803`.

The tx volume did not significantly change (0.024 to 0.026) so that remains unchanged.

Cumulative chainwork is `0x3e3c33bc605e5d`

### Note to reviewers

Things that need to be checked:

1. You can check the correctness of my proposal by doing `dogecoin-cli getblock <blockhash>`, which will contain everything except the cumulative transaction count. The easiest way to get the tx count is by searching your debug.log for the `UpdateTip` containing the mentioned hash, which will list the cumulative transaction count under `tx=<number>`.
2. Make sure that the checkpoint is on the active chain. Normally I'd wait for 1440 confirmations, but I propose to wait a little longer this time in the light of the drop in hash power, and aim for 3x that - 4320 confirmations.
3. We have to make sure that there are no big chaintip forks between this checkpoint and merge of the PR, you can do this by inspecting `dogecoin-cli getchaintips`. Look for alternative chaintips longer than 1-2 blocks, as the most common ones are simply occurring when there is a timing issue between miners and happen a couple of times per day usually.

If any of these conditions are not satisfied after 4320 confirmations, I can prepare a new proposal.