### PR TITLE
Update the linux custom build guides

### DIFF
--- a/doc/build-archlinux.md
+++ b/doc/build-archlinux.md
@@ -1,20 +1,17 @@
 Arch Linux build guide
------------------------------------
+----------------------
 
-***NOTE: This documentation is outdated and needs to be updated***
+**Last tested with:** 1.14.6-dev (as of 22884709)
+**Test date:** 2022/07/15
 
-This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
+This example lists the steps necessary to setup and build a command line only
+dogecoind on archlinux:
 
-    pacman -S git base-devel boost libevent python
-    git clone https://github.com/bitcoin/bitcoin.git
-    cd bitcoin/
-    ./autogen.sh
-    ./configure --disable-wallet --without-gui --without-miniupnpc
-    make check
-
-Note:
-Enabling wallet support requires either compiling against a Berkeley DB newer than 4.8 (package `db`) using `--with-incompatible-bdb`,
-or building and depending on a local version of Berkeley DB 4.8. The readily available Arch Linux packages are currently built using
-`--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
-As mentioned above, when maintaining portability of the wallet between the standard Dogecoin Core distributions and independently built
-node software is desired, Berkeley DB 4.8 must be used.
+```sh
+pacman -S git base-devel boost libevent python db
+git clone https://github.com/dogecoin/dogecoin.git
+cd dogecoin/
+./autogen.sh
+./configure --without-gui --without-miniupnpc
+make
+```

--- a/doc/build-fedora.md
+++ b/doc/build-fedora.md
@@ -1,20 +1,45 @@
-Fedora build dependencies
---------------------------
+Fedora build guide
+------------------
 
-***NOTE: This documentation is outdated and needs to be updated***
+**Last tested with:** 1.14.6-dev (as of 22884709)
+**Tested on:** Fedora 35,35,36
 
-Build requirements:
+### Build requirements
 
-    sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel
+**Fedora < 36:**
 
-Optional:
+```sh
+sudo dnf install gcc-c++ libtool which diffutils make autoconf automake \
+                 openssl-devel libevent-devel boost-devel libdb-cxx-devel
+```
 
-    sudo dnf install miniupnpc-devel
+**Fedora >= 36:**
 
-To build with Qt 5 (recommended) you need the following:
+```sh
+sudo dnf install gcc-c++ libtool which diffutils make autoconf automake \
+                 openssl1.1-devel libevent-devel boost-devel libdb-cxx-devel
+```
 
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
+### Optional elements
 
-libqrencode (optional) can be installed with:
+#### MiniUPNP
 
-    sudo dnf install qrencode-devel
+Useful when your node is running behind a NAT router.
+
+```sh
+sudo dnf install miniupnpc-devel
+```
+
+#### ZeroMQ
+
+```sh
+sudo dnf install zeromq-devel
+```
+
+#### GUI requirements
+
+To build the GUI with Qt 5 you need the following:
+
+```sh
+sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel qrencode-devel
+```


### PR DESCRIPTION
Updates the guides for Archlinux and Fedora.

### Testing

I have used the following Dockerfiles to test. For Fedora < 36, simply take a different image tag and replace `openssl1.1-devel` with `openssl-devel`

##### Dockerfile for testing fedora 36 headless, minimal

```Dockerfile
FROM fedora:36

ARG REF=1.14.6-dev
ARG REPO=https://github.com/dogecoin/dogecoin.git
ARG MAKE_OPTS=-j4

WORKDIR /testbuild

# install requirements (added git)
RUN dnf -y install gcc-c++ libtool which make autoconf automake \
                 openssl1.1-devel libevent-devel boost-devel libdb-cxx-devel git

# clone and checkout ref
RUN git clone $REPO && \
    cd dogecoin && \
    git checkout $REF

WORKDIR /testbuild/dogecoin

# build: only disable bench, to save cycles
RUN ./autogen.sh && \
    ./configure --disable-bench && \
    make $MAKE_OPTS    

# test
RUN make check $MAKE_OPTS VERBOSE=1
```

##### Dockerfile for testing fedora 36 with UI and all optional packages

```Dockerfile
FROM fedora:36

ARG REF=1.14.6-dev
ARG REPO=https://github.com/dogecoin/dogecoin.git
ARG MAKE_OPTS=-j4

WORKDIR /testbuild

# install requirements (added git)
RUN dnf -y install gcc-c++ libtool which make autoconf automake \
                 openssl1.1-devel libevent-devel boost-devel libdb-cxx-devel git \
                 miniupnpc-devel zeromq-devel qt5-qttools-devel qt5-qtbase-devel \
                 protobuf-devel qrencode-devel

# clone and checkout ref
RUN git clone $REPO && \
    cd dogecoin && \
    git checkout $REF

WORKDIR /testbuild/dogecoin

# build: only disable bench, to save cycles
RUN ./autogen.sh && \
    ./configure --disable-bench && \
    make $MAKE_OPTS    

# test
RUN make check $MAKE_OPTS VERBOSE=1
```

##### Dockerfile for testing Archlinux

```Dockerfile
FROM archlinux:latest

ARG REF=1.14.6-dev
ARG REPO=https://github.com/dogecoin/dogecoin.git
ARG MAKE_OPTS=-j4

WORKDIR /testbuild

RUN pacman -Sy && \
    pacman --noconfirm -S git base-devel python boost libevent db

RUN git clone $REPO && \
    cd dogecoin && \
    git checkout $REF

WORKDIR /testbuild/dogecoin

RUN ./autogen.sh && \
    ./configure --disable-bench && \
    make $MAKE_OPTS

RUN make check $MAKE_OPTS VERBOSE=1
```