### PR TITLE
release notes: bring back mailing list

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -10,10 +10,13 @@ Please report bugs using the issue tracker at github:
 
   <https://github.com/dogecoin/dogecoin/issues>
 
-To receive security and update notifications, please watch reddit:
+To receive notifications about updates, subscribe to the release mailing list:
 
-  * https://www.reddit.com/r/dogecoindev/
-  * [mailing list]
+  <https://sourceforge.net/projects/dogecoin/lists/dogecoin-releases>
+
+Releases are also announced on reddit:
+
+  <https://www.reddit.com/r/dogecoindev/>
 
 Compatibility
 ==============


### PR DESCRIPTION
Brings back the release announcement list - hasn't been used for 1.14, but it makes sense to make this the primary source of notifications for release, because it can be kept clean and to-the-point. Keeps `r/dogecoindev` on Reddit as an alternative source, but that is much less clean.

Marked urgent per [proposed process](https://github.com/dogecoin/dogecoin/pull/3035).