### PR TITLE
qt: Rename signals for peer dialog

### DIFF
--- a/src/qt/peerdialog.cpp
+++ b/src/qt/peerdialog.cpp
@@ -95,7 +95,7 @@ AddPeerDialog::AddPeerDialog(QWidget *parent) :
 
     ui->peerPort->setValidator( new QIntValidator(1, 65535, this) );
 
-    connect(ui->pushButton, SIGNAL(clicked()), this, SLOT(on_addPeer_clicked()));
+    connect(ui->pushButton, SIGNAL(clicked()), this, SLOT(on_addPeerClicked()));
 }
 
 AddPeerDialog::~AddPeerDialog()
@@ -103,7 +103,7 @@ AddPeerDialog::~AddPeerDialog()
     delete ui;
 }
 
-void AddPeerDialog::on_addPeer_clicked()
+void AddPeerDialog::on_addPeerClicked()
 {
     QString address = ui->peerAddress->text();
     QString port = ui->peerPort->text();
@@ -142,7 +142,7 @@ TestPeerDialog::TestPeerDialog(QWidget *parent) :
 
     ui->peerPort->setValidator( new QIntValidator(1, 65535, this) );
 
-    connect(ui->pushButton, SIGNAL(clicked()), this, SLOT(on_testPeer_clicked()));
+    connect(ui->pushButton, SIGNAL(clicked()), this, SLOT(on_testPeerClicked()));
 }
 
 TestPeerDialog::~TestPeerDialog()
@@ -150,7 +150,7 @@ TestPeerDialog::~TestPeerDialog()
     delete ui;
 }
 
-void TestPeerDialog::on_testPeer_clicked()
+void TestPeerDialog::on_testPeerClicked()
 {
     QString address = ui->peerAddress->text();
     QString port = ui->peerPort->text();

--- a/src/qt/peerdialog.h
+++ b/src/qt/peerdialog.h
@@ -43,7 +43,7 @@ public:
 private:
     Ui::AddPeerDialog *ui;
 private Q_SLOTS:
-    void on_addPeer_clicked();
+    void on_addPeerClicked();
 };
 
 /** "Test peer" dialog box */
@@ -57,7 +57,7 @@ public:
 private:
     Ui::TestPeerDialog *ui;
 private Q_SLOTS:
-    void on_testPeer_clicked();
+    void on_testPeerClicked();
 };
 
 #endif

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -450,13 +450,13 @@ RPCConsole::RPCConsole(const PlatformStyle *_platformStyle, QWidget *parent) :
     connect(ui->btnClearTrafficGraph, SIGNAL(clicked()), ui->trafficGraph, SLOT(clear()));
 
     // Allow user to add new peer
-    connect(ui->peerAdd, SIGNAL(clicked()), this, SLOT(on_addPeer_clicked()));
+    connect(ui->peerAdd, SIGNAL(clicked()), this, SLOT(on_addPeerClicked()));
 
     // Allow user to remove peer
-    connect(ui->peerRemove, SIGNAL(clicked()), this, SLOT(on_removePeer_clicked()));
+    connect(ui->peerRemove, SIGNAL(clicked()), this, SLOT(on_removePeerClicked()));
 
     // Allow user to test peer
-    connect(ui->peerTest, SIGNAL(clicked()), this, SLOT(on_testPeer_clicked()));
+    connect(ui->peerTest, SIGNAL(clicked()), this, SLOT(on_testPeerClicked()));
 
     // set library version labels
 #ifdef ENABLE_WALLET
@@ -927,7 +927,7 @@ void RPCConsole::on_openDebugLogfileButton_clicked()
     GUIUtil::openDebugLogfile();
 }
 
-void RPCConsole::on_addPeer_clicked() 
+void RPCConsole::on_addPeerClicked() 
 {
 
     QWidget *win = new AddPeerDialog(0);
@@ -942,7 +942,7 @@ void RPCConsole::on_addPeer_clicked()
     win->move(global.x() - win->width() / 2, global.y() - win->height() / 2);
 }
 
-void RPCConsole::on_removePeer_clicked() 
+void RPCConsole::on_removePeerClicked() 
 {    
     QList<QModelIndex> ips = GUIUtil::getEntryData(ui->peerWidget, PeerTableModel::Address);
 
@@ -961,7 +961,7 @@ void RPCConsole::on_removePeer_clicked()
     }
 }
 
-void RPCConsole::on_testPeer_clicked() 
+void RPCConsole::on_testPeerClicked() 
 {
     QWidget *win = new TestPeerDialog(0);
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -70,11 +70,11 @@ private Q_SLOTS:
     /** open the debug.log from the current datadir */
     void on_openDebugLogfileButton_clicked();
     /** open dialog to add new peer */
-    void on_addPeer_clicked();
+    void on_addPeerClicked();
     /** open dialog to remove peer */
-    void on_removePeer_clicked();
+    void on_removePeerClicked();
     /** open dialog to test peer */
-    void on_testPeer_clicked();
+    void on_testPeerClicked();
     /** change the time range of the network traffic graph */
     void on_sldGraphRange_valueChanged(int value);
     /** update traffic statistics */


### PR DESCRIPTION
This renames signals for peer dialog to remove misleading logging. Fixes #3062 

Renamed:
- `on_addPeer_clicked()` -> `on_addPeerClicked()`
- `on_removePeer_clicked()` -> `on_removePeerClicked()`
- `on_testPeer_clicked()` -> `on_testPeerClicked()`

Peer dialog and buttons work as expected.
