### PR TITLE
remove openssl header includes in scrypt sources

### DIFF
--- a/src/crypto/scrypt-sse2.cpp
+++ b/src/crypto/scrypt-sse2.cpp
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <openssl/sha.h>
 
 #include <emmintrin.h>
 

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <openssl/sha.h>
 
 #if defined(USE_SSE2) && !defined(USE_SSE2_ALWAYS)
 #ifdef _MSC_VER


### PR DESCRIPTION
fixes #3058 

OpenSSL headers are included in scrypt source. However, no linked OpenSSL code is actually used in the scrypt routines, so this turned out to just be trivial cleanup.