### PR TITLE
qa: fix ltc-scrypt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - name: i686-linux
             host: i686-pc-linux-gnu
             os: ubuntu-18.04
-            packages: g++-multilib bc python3-zmq
+            packages: g++-multilib bc python3-pip python3-setuptools python3-zmq
             run-bench: true
             test-script: |
               make check $MAKEJOBS VERBOSE=1
@@ -119,7 +119,7 @@ jobs:
           - name: x86_64-linux-dbg
             host: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
-            packages: bc python3-zmq
+            packages: bc python3-pip python3-setuptools python3-zmq
             run-bench: true
             test-script: |
               make check $MAKEJOBS VERBOSE=1
@@ -199,7 +199,7 @@ jobs:
           - name: x86_64-linux-experimental
             host: x86_64-linux-gnu
             os: ubuntu-18.04
-            packages: bc python3-zmq
+            packages: bc python3-pip python3-setuptools python3-zmq
             run-bench: true
             test-script: |
               make check $MAKEJOBS VERBOSE=1

--- a/qa/README.md
+++ b/qa/README.md
@@ -13,8 +13,9 @@ Unix
 ----
 `python3-zmq` and `ltc_scrypt` are required. On Ubuntu or Debian they can be installed via:
 ```
-sudo apt-get update && apt-get install -y curl python3-zmq python3-dev gcc
-cd qa/pull-tester/ && ./install-deps.sh
+sudo apt-get update
+sudo apt-get install -y curl gcc python3-pip python3-setuptools python3-zmq
+./qa/pull-tester/install-deps.sh
 ```
 
 OS X
@@ -22,7 +23,7 @@ OS X
 ```
 brew install curl
 pip3 install pyzmq
-cd qa/pull-tester && ./install-deps.sh
+./qa/pull-tester/install-deps.sh
 ```
 
 Running tests

--- a/qa/pull-tester/install-deps.sh
+++ b/qa/pull-tester/install-deps.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 # installs test dependencies
-
-curl -L https://github.com/langerhans/ltc-scrypt/archive/master.tar.gz --output master.tar.gz
-echo "ade3cdf498927990b6d153d74f0da104114e838584be5a81bef8972accd03341 master.tar.gz" | sha256sum -c
-tar zxf master.tar.gz
-pushd ltc-scrypt-master
-python3 setup.py install --user
-popd
+file=v1.0.1.tar.gz
+curl -L -O https://github.com/dogecoin/ltc-scrypt/archive/refs/tags/$file
+echo "e866ade37fb27439ae0ca32f1ee4ad32be428c1fdac9bcc988b36c68648ff0de  $file" | sha256sum -c
+python3 -m pip install $file --user
+rm -rf $file


### PR DESCRIPTION
-update install-deps.sh so it will clean up after itself and can be invoked from root directory while unpacking to correct location (qa/pull-tester/ltc-scrypt-master/).
-forked langerhans fork and updated ltc-scrypt-master to define PY_SSIZE_T_CLEAN macro prior to #include <Python.h> and updated scrypt_getpowhash variables inputlen and outbuflen to Py_ssize_t types.
-updated qa/README.md to include sudo prior to apt-get install directive and add instructions to invoke script from root dir.
-updated mininode.py with custom ripemd160 (otherwise bumpfee.py fails).