### PR TITLE
Linux Snap Packaging for v1.14.6

### DIFF
--- a/contrib/snap/README.md
+++ b/contrib/snap/README.md
@@ -1,24 +1,37 @@
-All the commands I used for building and pushing to Snapcraft. I've only tested the amd64 .snap package, but anyone on amd64, arm64, or i686 should be able to build and/or install it for themselves with these instructions.
+# Dogecoin Snap Packaging
 
----
+Commands for building and uploading a Dogecoin Core Snap to the Snap Store. Anyone on amd64 (x86_64), arm64 (aarch64), or i386 (i686) should be able to build it themselves with these instructions. This would pull the official Dogecoin binaries from the releases page, verify them, and install them on a user's machine.
 
 ## Building Locally
-
 ```
 sudo apt install snapd
 sudo snap install --classic snapcraft
-snapcraft
+sudo snapcraft
 ```
 
-### To Install Locally
+### Installing Locally
 ```
 snap install \*.snap --devmode
 ```
 
-### To Push to Snapcraft
+### To Upload to the Snap Store
 ```
 snapcraft login
 snapcraft register dogecoin-core
-snapcraft push \*.snap --release=edge
-sudo snap install dogecoin-core --channel=edge
+snapcraft upload \*.snap
+sudo snap install dogecoin-core
+```
+
+### Usage
+```
+dogecoin-unofficial.cli # for dogecoin-cli
+dogecoin-unofficial.d # for dogecoind
+dogecoin-unofficial.qt # for dogecoin-qt
+dogecoin-unofficial.test # for test_dogecoin
+dogecoin-unofficial.tx # for dogecoin-tx
+```
+
+### Uninstalling
+```
+sudo snap remove dogecoin-unofficial
 ```

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -1,24 +1,31 @@
-name: dogecoin-core # you probably want to 'snapcraft register <name>'
-version: '1.14.5'
+name: dogecoin-core
+# Running 'snapcraft register <name>' is advised
+version: '1.14.6'
 summary: Reference client of Dogecoin, a peer-to-peer digital currency like Bitcoin.
 description: |
-  Dogecoin is a cryptocurrency like Bitcoin, although it does not use SHA256 as its proof of work (POW). Taking development cues from Tenebrix and Litecoin, Dogecoin currently employs a simplified variant of scrypt. MIT licenced.
+  Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu meme. The Dogecoin Core software allows anyone to operate a node in the Dogecoin blockchain networks and uses the Scrypt hashing method for Proof of Work. It is adapted from Bitcoin Core and other cryptocurrencies.
 
-base: core18
 grade: stable
 confinement: strict
+base: core18
+compression: lzo
 architectures:
-  - build-on: [amd64, i386, arm64]
+  - build-on: amd64
+    run-on: amd64
+  - build-on: arm64
+    run-on: arm64
+  - build-on: i386
+    run-on: i386
 
 apps:
   d:
     command: dogecoind
     plugs: [home, removable-media, network, network-bind]
     environment:
-    # Override HOME so the datadir is located at ~/snap/dogecoin-core/common/.dogecoin/ instead of ~/snap/dogecoin-core/current/.dogecoin/, and each new version of the snap won't have a different data directory: https://docs.snapcraft.io/environment-variables/7983
+      # Override HOME so the datadir is located at ~/snap/dogecoin-core/common/.dogecoin/ instead of ~/snap/dogecoin-core/current/.dogecoin/, and each new version of the snap won't have a different data directory: https://docs.snapcraft.io/environment-variables/7983
       HOME: $SNAP_USER_COMMON
   qt:
-    command: qt4-launch dogecoin-qt
+    command: desktop-launch dogecoin-qt
     plugs: [home, removable-media, network, network-bind, desktop, x11, unity7]
     environment:
       HOME: $SNAP_USER_COMMON
@@ -28,24 +35,69 @@ apps:
     plugs: [home, removable-media, network]
     environment:
       HOME: $SNAP_USER_COMMON
+  tx:
+    command: dogecoin-tx
+    plugs: [home, removable-media, network]
+    environment:
+      HOME: $SNAP_USER_COMMON
+  test:
+    command: test_dogecoin
+    plugs: [home, removable-media, network]
+    environment:
+      HOME: $SNAP_USER_COMMON
 
 parts:
+  desktop-qt5:
+    # So desktop-launch from qt5 is udsable
+    # Adapted from https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-depth: 1
+    source-subdir: qt
+    source-commit: ec861254c2a1d2447b2c589446e6cdf04c75c260
+    plugin: make
+    make-parameters: ["FLAVOR=qt5"]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - try: [appmenu-qt5] # not available on core18
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
+
   dogecoin-core:
     plugin: nil
     override-build: |
+      echo "This script is viewable at https://github.com/dogecoin/dogecoin/blob/master/contrib/snap/snapcraft.yaml"
       echo "Downloading files..."
-      wget https://github.com/dogecoin/dogecoin/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
-      wget https://github.com/dogecoin/gitian.sigs/archive/refs/heads/master.zip
-      unzip master.zip
+      if [ "$SNAPCRAFT_ARCH_TRIPLET" = "i386-linux-gnu" ]; then # snap designates 32-bit as i386, but dogecoin designates it as i686
+        BUILD_ARCH_TRIPLET=i686-pc-linux-gnu
+      else
+        BUILD_ARCH_TRIPLET=$SNAPCRAFT_ARCH_TRIPLET
+      fi
+      wget https://github.com/dogecoin/dogecoin/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${BUILD_ARCH_TRIPLET}.tar.gz
+      wget https://github.com/dogecoin/gitian.sigs/archive/refs/heads/master.tar.gz
+      tar -xvf master.tar.gz
       echo "Verifying secure hash matches signed values..."
-      checksum=$(sha256sum dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz)
-      if ! (grep -r $checksum * | grep dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz); then
+      checksum=$(sha256sum dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${BUILD_ARCH_TRIPLET}.tar.gz)
+      if ! (grep -r $checksum * | grep dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${BUILD_ARCH_TRIPLET}.tar.gz); then
         echo "Secure hash not verified."
         return
       else
         echo "Secure hash verified."
       fi
-      tar -xvf dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${SNAPCRAFT_ARCH_TRIPLET}.tar.gz
+      tar -xvf dogecoin-${SNAPCRAFT_PROJECT_VERSION}-${BUILD_ARCH_TRIPLET}.tar.gz
       echo "Running tests..."
       if ! (dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_dogecoin); then
         echo "Dogecoin tests failed."
@@ -53,23 +105,20 @@ parts:
       else
         echo "Dogecoin tests passed."
       fi
-      echo "Installing Dogecoin..."
+      wget https://raw.githubusercontent.com/dogecoin/dogecoin/v${SNAPCRAFT_PROJECT_VERSION}/doc/release-notes.md
+      cat release-notes.md
+      echo "Installing Dogecoin Core..."
+      echo "Version ${SNAPCRAFT_PROJECT_VERSION}"
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoind
-      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-qt
+      if ! ([ "$BUILD_ARCH_TRIPLET" = "aarch64-linux-gnu" ]); then # there is no official dogecoin-qt build on arm64
+        install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-qt
+      fi
       install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-cli
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/dogecoin-tx
+      install -m 0755 -D -t $SNAPCRAFT_PART_INSTALL/bin dogecoin-${SNAPCRAFT_PROJECT_VERSION}/bin/test_dogecoin
       wget https://raw.githubusercontent.com/dogecoin/dogecoin/master/share/pixmaps/dogecoin128.png
       install -m 0644 -D -t $SNAPCRAFT_PART_INSTALL/share/pixmaps dogecoin128.png
     build-packages:
-      - unzip
       - wget
-    stage-packages:
-      - libfreetype6
-      - libpng16-16
-      - libx11-xcb1
-      - libx11-6
-      - libfontconfig
-  qt4conf:
-    build-packages:
-      - dpkg-dev
-    plugin: make
-    source: https://github.com/kyrofa/qt4conf.git
+    after:
+      - desktop-qt5


### PR DESCRIPTION
Got bored late yesterday and decided to resume working on https://github.com/dogecoin/dogecoin/pull/2726, which is much easier now that the new release has come out—I would love it if we could continue to work on decoupling this from the release cycle.

Changes:
- Extra testing for i386 and arm64
- Adds the tx and test binaries
- Uses lzo to speed up launch times
- Uses qt5 instead of qt4 to launch
- Simplifies installation process

I've built it successfully with Ubuntu 22.04 LTS (amd64) and Multipass, and launchpad's automatic build boxes have also built it on arm64 and i386 systems, though those were using 16.04. I've also unofficially uploaded it to the Snap Store, so anyone on a Linux box with Snap can test it with `sudo snap install dogecoin-unofficial`.