### PR TITLE
build: explicitly disable libsecp256k1 openssl tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1746,7 +1746,7 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --with-bignum=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --with-bignum=no --enable-module-recovery --enable-module-schnorrsig --enable-experimental --disable-openssl-tests"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
-There are a few libsecp256k1 tests that fail when running make check on systems with openssl 3. This commit disables those tests as they've been removed upstream.