### PR TITLE
Fix warning in dbwrapper test

### DIFF
--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -275,11 +275,11 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 
     boost::filesystem::path ph = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
-    for (int x=0x00; x<10; ++x) {
-        for (int y = 0; y < 10; y++) {
+    for (uint32_t x=0x00; x<10; ++x) {
+        for (uint32_t y = 0; y < 10; y++) {
             sprintf(buf, "%d", x);
             StringContentsSerializer key(buf);
-            for (int z = 0; z < y; z++)
+            for (uint32_t z = 0; z < y; z++)
                 key += key;
             uint32_t value = x*x;
             BOOST_CHECK(dbw.Write(key, value));
@@ -287,8 +287,8 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     }
 
     std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper*>(&dbw)->NewIterator());
-    for (int c=0; c<2; ++c) {
-        int seek_start;
+    for (uint32_t c=0; c<2; ++c) {
+        uint32_t seek_start;
         if (c == 0)
             seek_start = 0;
         else
@@ -296,11 +296,11 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
         sprintf(buf, "%d", seek_start);
         StringContentsSerializer seek_key(buf);
         it->Seek(seek_key);
-        for (int x=seek_start; x<10; ++x) {
-            for (int y = 0; y < 10; y++) {
+        for (uint32_t x=seek_start; x<10; ++x) {
+            for (uint32_t y = 0; y < 10; y++) {
                 sprintf(buf, "%d", x);
                 std::string exp_key(buf);
-                for (int z = 0; z < y; z++)
+                for (uint32_t z = 0; z < y; z++)
                     exp_key += exp_key;
                 StringContentsSerializer key;
                 uint32_t value;


### PR DESCRIPTION
While `buf` isn't going to overflow with the values written to it, the compiler can't prove that, because the integers used for the contents of the buffer could possibly be too large.

Fortunately, these integers only need a couple of bits.

`uint8_t` would be enough but it might be better to be more consistent with other types in this function.