### PR TITLE
fix function rename in secp256k1

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -236,7 +236,7 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
     }
     memcpy(ccChild.begin(), vout.data()+32, 32);
     memcpy((unsigned char*)keyChild.begin(), begin(), 32);
-    bool ret = secp256k1_ec_privkey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
+    bool ret = secp256k1_ec_seckey_tweak_add(secp256k1_context_sign, (unsigned char*)keyChild.begin(), vout.data());
     keyChild.fCompressed = true;
     keyChild.fValid = ret;
     return ret;


### PR DESCRIPTION
Follow-up on #3082

`secp256k1_ec_privkey_tweak_add` was renamed and is now `secp256k1_ec_seckey_tweak_add` in upstream bitcoin-core/secp256k1@41fc785602 and bitcoin-core/secp256k1@22911ee6da. This removes a warning.

Perhaps we should put this on hold a little until we're sure that we won't revert the subtree update - but it's good to have the PR here regardless - prevent potential double work.