### PR TITLE
ci: drop extraneous libtinfo5 from x86_64-apple-darwin11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
           - name: x86_64-macos
             host: x86_64-apple-darwin11
             os: ubuntu-18.04
-            packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libtiff-tools libtinfo5 python3-setuptools xorriso libtinfo5
+            packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libtiff-tools libtinfo5 python3-setuptools xorriso
             run-bench: false
             check-security: false
             check-symbols: false


### PR DESCRIPTION
-drop duplicate of libtinfo5 in `x86_64-apple-darwin` specific continuous integration packages