### PR TITLE
depends: only use explicit CC for mingw32 in intel-ipsec-mb

### DIFF
--- a/depends/packages/intel-ipsec-mb.mk
+++ b/depends/packages/intel-ipsec-mb.mk
@@ -7,7 +7,7 @@ $(package)_patches=remove_digest_init.patch
 $(package)_dependencies=native_nasm
 
 define $(package)_set_vars
-$(package)_build_opts=CC=$(host)-gcc
+$(package)_build_opts_mingw32+=CC=$(host)-gcc
 $(package)_build_opts+=LDFLAGS="-fstack-protector"
 endef
 


### PR DESCRIPTION
The `CC` override in `intel-ipsec-mb.mk` fails for linux builds when done in a docker container due to it inserting "pc" into the host variable when not otherwise specified.

This fixes it by only overriding if we're building with mingw.

Note 1: this is the laziest solution I could come up with - ideally we'd figure out why intel-ipsec-mb doesn't grab the correct CC - I'd yield this PR to one that does that instead in case someone is interested in figuring that out.
Note 2: I'll mark this as do-not-merge and blocked until #3136 is in.