### PR TITLE
qa: update ltc_scrypt installation script and documentation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,12 @@ Before tests can be run locally, Bitcoin Core must be built.  See the [building 
 
 #### Dependencies
 
+`ltc_scrypt` is required. On an OS with `curl`, `python3`, `python3-pip` and `python3-setuptools` it can be installed via:
+
+```
+./test/functional/install-deps.sh
+```
+
 The ZMQ functional test requires a python ZMQ library. To install it:
 
 - on Unix, run `sudo apt-get install python3-zmq`

--- a/test/functional/install-deps.sh
+++ b/test/functional/install-deps.sh
@@ -1,12 +1,9 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
 export LC_ALL=C
 
 # installs test dependencies
-
-curl --location --fail -O https://github.com/langerhans/ltc-scrypt/archive/master.tar.gz
-echo "ade3cdf498927990b6d153d74f0da104114e838584be5a81bef8972accd03341 master.tar.gz" | sha256sum -c
-tar zxf master.tar.gz
-pushd ltc-scrypt-master || exit
-python3 setup.py install --user
-popd || exit
+file=v1.0.1.tar.gz
+curl -L -O https://github.com/dogecoin/ltc-scrypt/archive/refs/tags/$file
+echo "e866ade37fb27439ae0ca32f1ee4ad32be428c1fdac9bcc988b36c68648ff0de  $file" | sha256sum -c
+python3 -m pip install $file --user
+rm -rf $file


### PR DESCRIPTION
-per 3afaf90 our test framework requires ltc_scrypt as found on [L26](https://github.com/dogecoin/dogecoin/blob/1.21-dev/test/functional/test_framework/messages.py#L26) of test/functional/test_framework/messages.py, therefore i've updated the install-deps script to use v1.0.1 and added script invocation instructions on the test dirs README.md.