### PR TITLE
build: follow up to experimental feature guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build-aux/test-driver
 config.log
 config.status
 configure
+configure~
 libtool
 src/config/bitcoin-config.h
 src/config/bitcoin-config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -203,47 +203,48 @@ if test x$use_scrypt_sse2 = xyes; then
 fi
 
 AC_ARG_WITH([intel-avx2],
-  [AS_HELP_STRING([--enable-intel-avx2],
+  [AS_HELP_STRING([--with-intel-avx2],
   [Build with intel avx2 (default is no)])],
-  [use_intel_avx2=$enableval],
-  [use_intel_avx2=no])
+  [intel_avx2=$withval],
+  [intel_avx2=no])
 
-if test x$use_intel_avx2 = xyes; then
+if test x$intel_avx2 = xyes; then
   DOGECOIN_REQUIRE_EXPERIMENTAL
+  AC_MSG_CHECKING([whether to build with intel avx2 crypto])
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(INTEL_AVX2, 1, [Define this symbol if intel axv2 works])
   case $host in
   *x86_64-*-linux*)
-      AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_DEFINE(USE_INTEL_AVX2, 1, [Define this symbol if intel axv2 works])
-     ;;
+    AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    ;;
   *mingw*)
-      AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-      AC_CHECK_LIB([Qt5PlatformSupport],[main],LIBS+=" -lQt5PlatformSupport", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([mingwthrd],         [main],LIBS+=" -lmingwthrd", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([kernel32],          [main],LIBS+=" -lkernel32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([user32],            [main],LIBS+=" -luser32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([gdi32],             [main],LIBS+=" -lgdi32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([comdlg32],          [main],LIBS+=" -lcomdlg32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([winspool],          [main],LIBS+=" -lwinspool", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([winmm],             [main],LIBS+=" -lwinmm", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([shell32],           [main],LIBS+=" -lshell32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([comctl32],          [main],LIBS+=" -lcomctl32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([ole32],             [main],LIBS+=" -lole32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([oleaut32],          [main],LIBS+=" -loleaut32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([uuid],              [main],LIBS+=" -luuid", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([rpcrt4],            [main],LIBS+=" -lrpcrt4", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([advapi32],          [main],LIBS+=" -ladvapi32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([ws2_32],            [main],LIBS+=" -lws2_32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([mswsock],           [main],LIBS+=" -lmswsock", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([shlwapi],           [main],LIBS+=" -lshlwapi", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([iphlpapi],          [main],LIBS+=" -liphlpapi", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([crypt32],           [main],LIBS+=" -lcrypt32", AC_MSG_ERROR(lib missing))
-      AC_CHECK_LIB([ssp],               [main],LIBS+=" -lssp", AC_MSG_ERROR(lib missing))
-      AC_DEFINE(USE_INTEL_AVX2, 1, [Define this symbol if intel axv2 works])
-     ;;
+    AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+    AC_CHECK_LIB([Qt5PlatformSupport],[main],LIBS+=" -lQt5PlatformSupport", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([mingwthrd],         [main],LIBS+=" -lmingwthrd", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([kernel32],          [main],LIBS+=" -lkernel32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([user32],            [main],LIBS+=" -luser32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([gdi32],             [main],LIBS+=" -lgdi32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([comdlg32],          [main],LIBS+=" -lcomdlg32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([winspool],          [main],LIBS+=" -lwinspool", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([winmm],             [main],LIBS+=" -lwinmm", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([shell32],           [main],LIBS+=" -lshell32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([comctl32],          [main],LIBS+=" -lcomctl32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([ole32],             [main],LIBS+=" -lole32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([oleaut32],          [main],LIBS+=" -loleaut32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([uuid],              [main],LIBS+=" -luuid", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([rpcrt4],            [main],LIBS+=" -lrpcrt4", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([advapi32],          [main],LIBS+=" -ladvapi32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([ws2_32],            [main],LIBS+=" -lws2_32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([mswsock],           [main],LIBS+=" -lmswsock", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([shlwapi],           [main],LIBS+=" -lshlwapi", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([iphlpapi],          [main],LIBS+=" -liphlpapi", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([crypt32],           [main],LIBS+=" -lcrypt32", AC_MSG_ERROR(lib missing))
+    AC_CHECK_LIB([ssp],               [main],LIBS+=" -lssp", AC_MSG_ERROR(lib missing))
+    ;;
   esac
 fi
 
@@ -1086,7 +1087,7 @@ AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 AM_CONDITIONAL([WORDS_BIGENDIAN],[test x$ac_cv_c_bigendian = xyes])
 AM_CONDITIONAL([ALLOW_DOGECOIN_EXPERIMENTAL], [test x$allow_experimental = xyes])
 AM_CONDITIONAL([USE_SCRYPT_SSE2], [test x$use_scrypt_sse2 = xyes])
-AM_CONDITIONAL([USE_INTEL_AVX2], [test x$use_intel_avx2 = xyes])
+AM_CONDITIONAL([INTEL_AVX2], [test x$intel_avx2 = xyes])
 AM_CONDITIONAL([USE_ARMV8], [test x$armv8_crypto = xyes])
 AM_CONDITIONAL([USE_ARMV82], [test x$armv82_crypto = xyes])
 
@@ -1213,7 +1214,7 @@ echo
 echo "  experimental  = $allow_experimental"
 if test x$allow_experimental = xyes; then
 echo "  SSE2 Scrypt   = $use_scrypt_sse2"
-echo "  AVX2 crypto   = $use_intel_avx2"
+echo "  AVX2 crypto   = $intel_avx2"
 echo "  ARMv8 crypto  = $armv8_crypto"
 echo "  ARMv82 crypto = $armv82_crypto"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -183,17 +183,69 @@ AC_ARG_ENABLE([experimental],
   [allow_experimental=$enableval],
   [allow_experimental=no])
 
+# Configure experimental for compile-time asserts
+if test x$allow_experimental = xyes; then
+  AC_DEFINE(ALLOW_DOGECOIN_EXPERIMENTAL, 1, [Define this symbol if experimental features are allowed])
+fi
+
 AC_ARG_ENABLE([scrypt-sse2],
   [AS_HELP_STRING([--enable-scrypt-sse2],
   [Build with scrypt sse2 implementation (default is no)])],
   [use_scrypt_sse2=$enableval],
   [use_scrypt_sse2=no])
 
+# Configure Scrypt SSE2
+if test x$use_scrypt_sse2 = xyes; then
+  DOGECOIN_REQUIRE_EXPERIMENTAL
+  AC_MSG_CHECKING([whether to build with scrypt sse2 crypto])
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(USE_SCRYPT_SSE2, 1, [Define this symbol if SSE2 works])
+fi
+
 AC_ARG_WITH([intel-avx2],
-  [AS_HELP_STRING([--with-intel-avx2],
+  [AS_HELP_STRING([--enable-intel-avx2],
   [Build with intel avx2 (default is no)])],
-  [intel_avx2=$withval],
-  [intel_avx2=no])
+  [use_intel_avx2=$enableval],
+  [use_intel_avx2=no])
+
+if test x$use_intel_avx2 = xyes; then
+  DOGECOIN_REQUIRE_EXPERIMENTAL
+  case $host in
+  *x86_64-*-linux*)
+      AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_DEFINE(USE_INTEL_AVX2, 1, [Define this symbol if intel axv2 works])
+     ;;
+  *mingw*)
+      AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
+      AC_CHECK_LIB([Qt5PlatformSupport],[main],LIBS+=" -lQt5PlatformSupport", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([mingwthrd],         [main],LIBS+=" -lmingwthrd", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([kernel32],          [main],LIBS+=" -lkernel32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([user32],            [main],LIBS+=" -luser32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([gdi32],             [main],LIBS+=" -lgdi32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([comdlg32],          [main],LIBS+=" -lcomdlg32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([winspool],          [main],LIBS+=" -lwinspool", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([winmm],             [main],LIBS+=" -lwinmm", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([shell32],           [main],LIBS+=" -lshell32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([comctl32],          [main],LIBS+=" -lcomctl32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([ole32],             [main],LIBS+=" -lole32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([oleaut32],          [main],LIBS+=" -loleaut32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([uuid],              [main],LIBS+=" -luuid", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([rpcrt4],            [main],LIBS+=" -lrpcrt4", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([advapi32],          [main],LIBS+=" -ladvapi32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([ws2_32],            [main],LIBS+=" -lws2_32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([mswsock],           [main],LIBS+=" -lmswsock", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([shlwapi],           [main],LIBS+=" -lshlwapi", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([iphlpapi],          [main],LIBS+=" -liphlpapi", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([crypt32],           [main],LIBS+=" -lcrypt32", AC_MSG_ERROR(lib missing))
+      AC_CHECK_LIB([ssp],               [main],LIBS+=" -lssp", AC_MSG_ERROR(lib missing))
+      AC_DEFINE(USE_INTEL_AVX2, 1, [Define this symbol if intel axv2 works])
+     ;;
+  esac
+fi
 
 AC_ARG_WITH([armv8-crypto],
   [AS_HELP_STRING([--with-armv8-crypto],
@@ -201,11 +253,26 @@ AC_ARG_WITH([armv8-crypto],
   [armv8_crypto=$withval],
   [armv8_crypto=no])
 
+if test x$armv8_crypto = xyes; then
+  DOGECOIN_REQUIRE_EXPERIMENTAL
+  AC_MSG_CHECKING([whether to build with armv8 crypto])
+  AC_MSG_RESULT(yes)
+  AC_DEFINE(USE_ARMV8, 1, [Define this symbol if armv8 crypto works])
+  CXXFLAGS="$CXXFLAGS -march=armv8-a+crypto"
+fi
+
 AC_ARG_WITH([armv82-crypto],
   [AS_HELP_STRING([--with-armv82-crypto],
   [Build with armv8.2 crypto sha512 (default is no)])],
   [armv82_crypto=$withval],
   [armv82_crypto=no])
+
+if test x$armv82_crypto = xyes; then
+  DOGECOIN_REQUIRE_EXPERIMENTAL
+  AC_CHECK_DECLS([vsha512su0q_u64],
+     [AC_DEFINE(USE_ARMV82, 1, [Define this symbol if armv8.2 crypto works])
+     CXXFLAGS="$CXXFLAGS -march=armv8.2-a+crypto+sha3"], AC_MSG_ERROR(sha512 missing), [#include <arm_neon.h>])
+fi
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
@@ -737,32 +804,6 @@ BOOST_LIBS="$BOOST_LDFLAGS $BOOST_SYSTEM_LIB $BOOST_FILESYSTEM_LIB $BOOST_PROGRA
 
 fi
 
-# Configure experimental for compile-time asserts
-if test x$allow_experimental = xyes; then
-  AC_DEFINE(ALLOW_DOGECOIN_EXPERIMENTAL, 1, [Define this symbol if experimental features are allowed])
-fi
-
-# Configure Scrypt SSE2
-if test x$use_scrypt_sse2 = xyes; then
-  DOGECOIN_REQUIRE_EXPERIMENTAL
-  AC_DEFINE(USE_SSE2, 1, [Define this symbol if SSE2 works])
-fi
-
-if test x$armv8_crypto = xyes; then
-  DOGECOIN_REQUIRE_EXPERIMENTAL
-  AC_MSG_CHECKING([whether to build with armv8 crypto])
-  AC_MSG_RESULT(yes)
-  AC_DEFINE(USE_ARMV8, 1, [Define this symbol if armv8 crypto works])
-  CXXFLAGS="$CXXFLAGS -march=armv8-a+crypto"
-fi
-
-if test x$armv82_crypto = xyes; then
-  DOGECOIN_REQUIRE_EXPERIMENTAL
-  AC_CHECK_DECLS([vsha512su0q_u64],
-     [AC_DEFINE(USE_ARMV82, 1, [Define this symbol if armv8.2 crypto works])
-     CXXFLAGS="$CXXFLAGS -march=armv8.2-a+crypto+sha3"], AC_MSG_ERROR(sha512 missing), [#include <arm_neon.h>])
-fi
-
 if test x$use_pkgconfig = xyes; then
   : dnl
   m4_ifdef(
@@ -835,44 +876,6 @@ else
     BITCOIN_QT_CHECK([AC_CHECK_LIB([qrencode], [main],[QR_LIBS=-lqrencode], [have_qrencode=no])])
     BITCOIN_QT_CHECK([AC_CHECK_HEADER([qrencode.h],, have_qrencode=no)])
   fi
-fi
-
-if test x$intel_avx2 = xyes; then
-  DOGECOIN_REQUIRE_EXPERIMENTAL
-  case $host in
-     x86_64-*-linux*)
-    AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_DEFINE(USE_AVX2, 1, [Define this symbol if intel axv2 works])
-;;
-    *mingw*)
-    AC_CHECK_LIB([IPSec_MB],[sha1_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_CHECK_LIB([IPSec_MB],[sha256_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_CHECK_LIB([IPSec_MB],[sha512_one_block_avx2],LIBS=-lIPSec_MB, AC_MSG_ERROR(IPSec_MB missing))
-    AC_CHECK_LIB([Qt5PlatformSupport],[main],LIBS+=" -lQt5PlatformSupport", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([mingwthrd],         [main],LIBS+=" -lmingwthrd", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([kernel32],          [main],LIBS+=" -lkernel32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([user32],            [main],LIBS+=" -luser32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([gdi32],             [main],LIBS+=" -lgdi32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([comdlg32],          [main],LIBS+=" -lcomdlg32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([winspool],          [main],LIBS+=" -lwinspool", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([winmm],             [main],LIBS+=" -lwinmm", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([shell32],           [main],LIBS+=" -lshell32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([comctl32],          [main],LIBS+=" -lcomctl32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([ole32],             [main],LIBS+=" -lole32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([oleaut32],          [main],LIBS+=" -loleaut32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([uuid],              [main],LIBS+=" -luuid", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([rpcrt4],            [main],LIBS+=" -lrpcrt4", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([advapi32],          [main],LIBS+=" -ladvapi32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([ws2_32],            [main],LIBS+=" -lws2_32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([mswsock],           [main],LIBS+=" -lmswsock", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([shlwapi],           [main],LIBS+=" -lshlwapi", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([iphlpapi],          [main],LIBS+=" -liphlpapi", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([crypt32],           [main],LIBS+=" -lcrypt32", AC_MSG_ERROR(lib missing))
-    AC_CHECK_LIB([ssp],               [main],LIBS+=" -lssp", AC_MSG_ERROR(lib missing))
-    AC_DEFINE(USE_AVX2, 1, [Define this symbol if intel axv2 works])
-esac
 fi
 
 save_CXXFLAGS="${CXXFLAGS}"
@@ -1081,7 +1084,11 @@ AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])
 AM_CONDITIONAL([HARDEN],[test x$use_hardening = xyes])
 AM_CONDITIONAL([WORDS_BIGENDIAN],[test x$ac_cv_c_bigendian = xyes])
+AM_CONDITIONAL([ALLOW_DOGECOIN_EXPERIMENTAL], [test x$allow_experimental = xyes])
 AM_CONDITIONAL([USE_SCRYPT_SSE2], [test x$use_scrypt_sse2 = xyes])
+AM_CONDITIONAL([USE_INTEL_AVX2], [test x$use_intel_avx2 = xyes])
+AM_CONDITIONAL([USE_ARMV8], [test x$armv8_crypto = xyes])
+AM_CONDITIONAL([USE_ARMV82], [test x$armv82_crypto = xyes])
 
 AC_DEFINE(CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MAJOR, [Major version])
 AC_DEFINE(CLIENT_VERSION_MINOR, _CLIENT_VERSION_MINOR, [Minor version])
@@ -1193,8 +1200,8 @@ echo "Options used to compile and link:"
 echo "  with wallet   = $enable_wallet"
 echo "  with gui / qt = $bitcoin_enable_qt"
 if test x$bitcoin_enable_qt != xno; then
-    echo "    qt version  = $bitcoin_qt_got_major_vers"
-    echo "    with qr     = $use_qr"
+echo "  qt version    = $bitcoin_qt_got_major_vers"
+echo "  with qr       = $use_qr"
 fi
 echo "  with zmq      = $use_zmq"
 echo "  with test     = $use_tests"
@@ -1205,10 +1212,10 @@ echo "  werror        = $enable_werror"
 echo
 echo "  experimental  = $allow_experimental"
 if test x$allow_experimental = xyes; then
-    echo "    SSE2 Scrypt   = $use_scrypt_sse2"
-    echo "    AVX2 crypto   = $intel_avx2"
-    echo "    ARMv8 crypto  = $armv8_crypto"
-    echo "    ARMv82 crypto = $armv82_crypto"
+echo "  SSE2 Scrypt   = $use_scrypt_sse2"
+echo "  AVX2 crypto   = $use_intel_avx2"
+echo "  ARMv8 crypto  = $armv8_crypto"
+echo "  ARMv82 crypto = $armv82_crypto"
 fi
 echo
 echo "  target os     = $TARGET_OS"

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -12,7 +12,7 @@
 
 #if (defined(__ia64__) || defined(__x86_64__)) && \
     !defined(__APPLE__) && \
-    (defined(USE_AVX2))
+    (defined(INTEL_AVX2))
 #include <intel-ipsec-mb.h>
 #endif
 
@@ -38,7 +38,7 @@ namespace
 namespace sha1
 {
 
-#ifndef USE_AVX2
+#ifndef INTEL_AVX2
 /** One round of SHA-1. */
 void inline Round(uint32_t a, uint32_t& b, uint32_t c, uint32_t d, uint32_t& e, uint32_t f, uint32_t k, uint32_t w)
 {
@@ -243,7 +243,7 @@ void Transform(uint32_t* s, const unsigned char* chunk)
     vst1q_u32(&s[0], ABCD);
     s[4] = E0;
 
-#elif USE_AVX2
+#elif INTEL_AVX2
     // Perform SHA1 one block (Intel AVX2)
     EXPERIMENTAL_FEATURE
     sha1_one_block_avx2(chunk, s);

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -12,7 +12,7 @@
 
 #if (defined(__ia64__) || defined(__x86_64__)) && \
     !defined(__APPLE__) && \
-    (defined(USE_AVX2))
+    (defined(INTEL_AVX2))
 #include <intel-ipsec-mb.h>
 #endif
 
@@ -57,7 +57,7 @@ namespace
 /// Internal SHA-256 implementation.
 namespace sha256
 {
-#ifndef USE_AVX2
+#ifndef INTEL_AVX2
 uint32_t inline Ch(uint32_t x, uint32_t y, uint32_t z) { return z ^ (x & (y ^ z)); }
 uint32_t inline Maj(uint32_t x, uint32_t y, uint32_t z) { return (x & y) | (z & (x | y)); }
 uint32_t inline Sigma0(uint32_t x) { return (x >> 2 | x << 30) ^ (x >> 13 | x << 19) ^ (x >> 22 | x << 10); }
@@ -249,7 +249,7 @@ void Transform(uint32_t* s, const unsigned char* chunk)
     vst1q_u32(&s[0], STATE0);
     vst1q_u32(&s[4], STATE1);
 
-#elif USE_AVX2
+#elif INTEL_AVX2
     // Perform SHA256 one block (Intel AVX2)
     EXPERIMENTAL_FEATURE
     sha256_one_block_avx2(chunk, s);

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -12,7 +12,7 @@
 
 #if (defined(__ia64__) || defined(__x86_64__)) && \
     !defined(__APPLE__) && \
-    (defined(USE_AVX2))
+    (defined(INTEL_AVX2))
 #include <intel-ipsec-mb.h>
 #endif
 
@@ -81,7 +81,7 @@ namespace
 /// Internal SHA-512 implementation.
 namespace sha512
 {
-#ifndef USE_AVX2
+#ifndef INTEL_AVX2
 uint64_t inline Ch(uint64_t x, uint64_t y, uint64_t z) { return z ^ (x & (y ^ z)); }
 uint64_t inline Maj(uint64_t x, uint64_t y, uint64_t z) { return (x & y) | (z & (x | y)); }
 uint64_t inline Sigma0(uint64_t x) { return (x >> 28 | x << 36) ^ (x >> 34 | x << 30) ^ (x >> 39 | x << 25); }
@@ -312,7 +312,7 @@ void inline Initialize(uint64_t* s)
 /** Perform one SHA-512 transformation, processing a 128-byte chunk. */
 void Transform(uint64_t* s, const unsigned char* chunk)
 {
-#ifdef USE_AVX2
+#ifdef INTEL_AVX2
     // Perform SHA512 one block (Intel AVX2)
     EXPERIMENTAL_FEATURE
     sha512_one_block_avx2(chunk, s);

--- a/src/support/experimental.h
+++ b/src/support/experimental.h
@@ -6,9 +6,7 @@
 #define DOGECOIN_SUPPORT_EXPERIMENTAL_H
 
 // include config for experimental flag
-#if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
-#endif //HAVE_CONFIG_H
 
 #if defined(ALLOW_DOGECOIN_EXPERIMENTAL)
 #define EXPERIMENTAL_FEATURES_ALLOWED 1


### PR DESCRIPTION
Have a few things to do re cleaning this up but it appears that the `HAVE_CONFIG_H` flag in support/experimentation.h was not being properly defined. This caused a cascade effect as the experimental compiler flags were then not configured/defined which I suspect were then not allowing the code to be compiled on the correct conditional path e.g. checking for `#ifndef USE_AVX2` wrapping `Round`, `Sigma`s, etc, (used) the `shaX_one_block_avx2` function (skipped) and the legacy SHA one block transformation (used) in all the sha routines.

This is in part based on the errors I encountered [here](https://github.com/xanimo/dogecoin/actions/runs/3398326504/jobs/5651272053) and it's corresponding experimental windows run.