### PR TITLE
Correct DEFAULT_BLOCK_MAX_SIZE to increase network Capacity

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -23,7 +23,7 @@ class CCoinsViewCache;
 static const CAmount RECOMMENDED_MIN_TX_FEE = COIN / 100;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 1000000;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/


### PR DESCRIPTION
The maximum allowed size for a block in /src/consensus.h (protocol rule), excluding witness data, is 1 MB. The default setting for DEFAULT_BLOCK_MAX_SIZE should be 1 MB if we are trying to fully maximize the network.

Some pools might patch this on their own anyway. But setting this at 750K might lead to reduced network throughput.