### PR TITLE
depends: Suppress array-bounds errors in libxkbcommon

### DIFF
--- a/depends/packages/libxkbcommon.mk
+++ b/depends/packages/libxkbcommon.mk
@@ -5,9 +5,14 @@ $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=60ddcff932b7fd352752d51a5c4f04f3d0403230a584df9a2e0d5ed87c486c8b
 $(package)_dependencies=libxcb
 
+# This package explicitly enables -Werror=array-bounds, which causes build failures
+# with GCC 12.1+. Work around that by turning errors back into warnings.
+# This workaround would be dropped if the package was updated, as that would require
+# a different build system (Meson)
 define $(package)_set_vars
 $(package)_config_opts = --enable-option-checking --disable-dependency-tracking
 $(package)_config_opts += --disable-static --disable-docs
+$(package)_cflags += -Wno-error=array-bounds
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
When building `depends` on GCC 12.1+ (GCC 12.2 in my case) it will fail when building `libxkbcommon`. This PR introduces a workaround around that error to fix compilation. 

```bash
src/xkbcomp/ast-build.c:82:27: error: array subscript 'ExprDef[0]' is partly outside array bounds of 'unsigned char[32]' [-Werror=array-bounds]
   82 |     expr->expr.value_type = type;
      |     ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
src/xkbcomp/ast-build.c:75:21: note: object of size 32 allocated by 'malloc'
   75 |     ExprDef *expr = malloc(size);
      |                     ^~~~~~~~~~~~
```