### PR TITLE
net: explicitly include std::array

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -31,6 +31,7 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 
+#include <array>
 #include <boost/thread.hpp>
 
 #if defined(NDEBUG)


### PR DESCRIPTION
On boost 1.81, `std::array` is no longer included by default and causes a compile error on `net_processing.cpp`. This is the only place where `std::array` is used without explicitly including it.

This PR fixes it, and also fixes my finding on `debian:experimental` from #3207, allowing compile to pass completely.

On macOS x86 with apple clang 14.0:

```
  CXX      libdogecoin_server_a-net_processing.o
net_processing.cpp:1112:47: error: implicit instantiation of undefined template 'std::array<std::pair<unsigned long long, CNode *>, 2>'
    std::array<std::pair<uint64_t, CNode*>,2> best{{{0, nullptr}, {0, nullptr}}};
```

`debian:experimental` with gcc 12.1:

```
net_processing.cpp: In function 'void RelayAddress(const CAddress&, bool, CConnman&)': net_processing.cpp:1112:47: error: variable 'std::array<std::pair<long unsigned int, CNode*>, 2> best' has initializer but incomplete type
 1112 |     std::array<std::pair<uint64_t, CNode*>,2> best{{{0, nullptr}, {0, nullptr}}};
      |
```
