### PR TITLE
build: use Ubuntu Focal for depends, ci and gitian releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         include:
           - name: i686-linux
             host: i686-pc-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: g++-multilib bc python3-zmq
             run-bench: true
             test-script: |
@@ -59,7 +59,7 @@ jobs:
             goal: install
           - name: armhf-linux
             host: arm-linux-gnueabihf
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: g++-arm-linux-gnueabihf qemu-user-static qemu-user
             run-bench: false
             test-script: |
@@ -71,7 +71,7 @@ jobs:
             goal: install
           - name: aarch64-linux-experimental
             host: aarch64-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
             run-bench: false
             test-script: |
@@ -95,7 +95,7 @@ jobs:
             goal: install
           - name: aarch64-linux
             host: aarch64-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
             run-bench: false
             test-script: |
@@ -107,7 +107,7 @@ jobs:
             goal: install
           - name: x86_64-linux-nowallet
             host: x86_64-unknown-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: python3
             run-bench: true
             test-script: |
@@ -119,7 +119,7 @@ jobs:
             goal: install
           - name: x86_64-linux-dbg
             host: x86_64-unknown-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: bc python3-zmq
             run-bench: true
             test-script: |
@@ -134,7 +134,7 @@ jobs:
           - name: i686-win
             host: i686-w64-mingw32
             arch: "i386"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: python3 nsis g++-mingw-w64-i686 wine-stable bc wine-binfmt
             postinstall: |
               sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
@@ -152,7 +152,7 @@ jobs:
           - name: x86_64-win
             host: x86_64-w64-mingw32
             arch: "i386"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
               sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
@@ -170,7 +170,7 @@ jobs:
           - name: x86_64-win-experimental
             host: x86_64-w64-mingw32
             arch: "i386"
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
               sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
@@ -187,7 +187,7 @@ jobs:
             goal: install
           - name: x86_64-macos
             host: x86_64-apple-darwin11
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libtiff-tools libtinfo5 xorriso
             run-bench: false
             check-security: true
@@ -199,7 +199,7 @@ jobs:
             sdk-shasum: "bec9d089ebf2e2dd59b1a811a38ec78ebd5da18cbbcd6ab39d1e59f64ac5033f"
           - name: x86_64-linux-experimental
             host: x86_64-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: bc python3-zmq
             run-bench: true
             test-script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,11 +133,19 @@ jobs:
             goal: install
           - name: i686-win
             host: i686-w64-mingw32
-            arch: "i386"
             os: ubuntu-20.04
-            packages: python3 nsis g++-mingw-w64-i686 wine-stable bc wine-binfmt
+            packages: python3 nsis g++-mingw-w64-i686 wine-stable winehq-stable bc wine-binfmt binfmt-support
+            preinstall: |
+              sudo dpkg --add-architecture i386
+              OS_FLAVOR=$(cat /etc/*ease | grep UBUNTU_CODENAME | cut -d "=" -f 2)
+              if [ ! -d "/etc/apt/keyrings" ]; then sudo mkdir -pm755 /etc/apt/keyrings; fi
+              sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+              sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$OS_FLAVOR/winehq-$OS_FLAVOR.sources
+              sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+              sudo apt-get update
+              sudo apt-get install -y --allow-downgrades libgd3/$OS_FLAVOR libpcre2-8-0/$OS_FLAVOR libpcre2-16-0/$OS_FLAVOR libpcre2-32-0/$OS_FLAVOR libpcre2-posix2/$OS_FLAVOR
+              sudo apt-get purge -yq libmono* moby* mono* php* libgdiplus libpcre2-posix3 libzip4
             postinstall: |
-              sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
               sudo update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
               sudo update-alternatives --set i686-w64-mingw32-g++  /usr/bin/i686-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
@@ -151,7 +159,6 @@ jobs:
             goal: install
           - name: x86_64-win
             host: x86_64-w64-mingw32
-            arch: "i386"
             os: ubuntu-20.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
@@ -169,7 +176,6 @@ jobs:
             goal: install
           - name: x86_64-win-experimental
             host: x86_64-w64-mingw32
-            arch: "i386"
             os: ubuntu-20.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 bc wine-binfmt
             postinstall: |
@@ -213,10 +219,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Add architecture
-        if: ${{ matrix.arch }}
-        run: |
-          sudo dpkg --add-architecture "${{ matrix.arch }}"
+      - name: Pre install
+        if: ${{ matrix.preinstall }}
+        run: ${{ matrix.preinstall }}
 
       - name: Install packages
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/configure.ac
+++ b/configure.ac
@@ -503,6 +503,7 @@ if test x$use_glibc_compat != xno; then
     [ fdelt_type="long int"])
   AC_MSG_RESULT($fdelt_type)
   AC_DEFINE_UNQUOTED(FDELT_TYPE, $fdelt_type,[parameter and return value type for __fdelt_chk])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=clock_gettime]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=clock_gettime"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=exp]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=exp"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=log]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log"])  

--- a/configure.ac
+++ b/configure.ac
@@ -504,7 +504,10 @@ if test x$use_glibc_compat != xno; then
   AC_MSG_RESULT($fdelt_type)
   AC_DEFINE_UNQUOTED(FDELT_TYPE, $fdelt_type,[parameter and return value type for __fdelt_chk])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=exp]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=exp"])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=log]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log"])  
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=log2f]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log2f"])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=pow]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=pow"])
 else
   AC_SEARCH_LIBS([clock_gettime],[rt])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -506,9 +506,17 @@ if test x$use_glibc_compat != xno; then
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=clock_gettime]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=clock_gettime"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=exp]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=exp"])
-  AX_CHECK_LINK_FLAG([[-Wl,--wrap=log]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log"])  
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=log]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=log2f]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log2f"])
   AX_CHECK_LINK_FLAG([[-Wl,--wrap=pow]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=pow"])
+
+  dnl only wrap fcntl and fctnl64 for 32-bit linux
+  case $host in
+    i?86*linux* | arm*linux*)
+      AX_CHECK_LINK_FLAG([[-Wl,--wrap=fcntl]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=fcntl"])
+      AX_CHECK_LINK_FLAG([[-Wl,--wrap=fcntl64]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=fcntl64"])
+      ;;
+    esac
 else
   AC_SEARCH_LIBS([clock_gettime],[rt])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -487,8 +487,10 @@ AX_GCC_FUNC_ATTRIBUTE([dllimport])
 if test x$use_glibc_compat != xno; then
 
   #glibc absorbed clock_gettime in 2.17. librt (its previous location) is safe to link
-  #in anyway for back-compat.
-  AC_CHECK_LIB([rt],[clock_gettime],, AC_MSG_ERROR(lib missing))
+  #in anyway for back-compat. Since gcc-9, we need to explicitly add lrt outside the
+  #scope of "as-needed" packages, so we disable it, add librt, and re-enable.
+  AX_CHECK_LINK_FLAG([[-Wl,-no-as-needed -Wl,-lrt -Wl,-as-needed]],
+         [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,-no-as-needed -Wl,-lrt -Wl,-as-needed"])
 
   #__fdelt_chk's params and return type have changed from long unsigned int to long int.
   # See which one is present here.

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -23,9 +23,8 @@ ossTarHash="f9a8cdb38b9c309326764ebc937cba1523a3a751a7ab05df3ecc99d18ae466c9"
 macosSdkUrl="https://depends.dogecoincore.org/MacOSX10.11.sdk.tar.gz"
 macosSdkHash="bec9d089ebf2e2dd59b1a811a38ec78ebd5da18cbbcd6ab39d1e59f64ac5033f"
 
-# lief custom wheel is only needed for bionic-based gitian
-lief="https://depends.dogecoincore.org/lief-0.12.3-cp36-cp36m-linux_x86_64.whl"
-liefHash="c84cbdb32c8a830fbb82c907b733050c7fc5c9bf4f51a46541f1b8c2e48def9f"
+liefUrl="https://depends.dogecoincore.org/lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+liefHash="c848aadac0816268aeb9dde7cefdb54bf24f78e664a19e97e74c92d3be1bb147"
 
 # What to do
 verify=false
@@ -271,7 +270,7 @@ if [[ $setup == true ]]; then
     download_file $ossPatchUrl $ossPatchHash
     download_file $ossTarUrl $ossTarHash
     download_file $macosSdkUrl $macosSdkHash
-    download_file $lief $liefHash
+    download_file $liefUrl $liefHash
 
     popd
 
@@ -279,11 +278,11 @@ if [[ $setup == true ]]; then
     if [ "$USE_LXC" -eq 1 ]
     then
         sudo apt-get install -y lxc
-        bin/make-base-vm --suite bionic --arch amd64 --lxc
+        bin/make-base-vm --suite focal --arch amd64 --lxc
     elif [ "$USE_DOCKER" -eq 1 ]; then
-        bin/make-base-vm --suite bionic --arch amd64 --docker
+        bin/make-base-vm --suite focal --arch amd64 --docker
     else
-        bin/make-base-vm --suite bionic --arch amd64
+        bin/make-base-vm --suite focal --arch amd64
     fi
     popd
 fi

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -2,27 +2,28 @@
 name: "dogecoin-linux-1.14"
 enable_cache: true
 suites:
-- "bionic"
+- "focal"
 architectures:
 - "amd64"
 packages:
 - "curl"
 - "g++-aarch64-linux-gnu"
-- "g++-7-aarch64-linux-gnu"
-- "gcc-7-aarch64-linux-gnu"
+- "g++-9-aarch64-linux-gnu"
+- "gcc-9-aarch64-linux-gnu"
 - "binutils-aarch64-linux-gnu"
 - "g++-arm-linux-gnueabihf"
-- "g++-7-arm-linux-gnueabihf"
-- "gcc-7-arm-linux-gnueabihf"
+- "g++-9-arm-linux-gnueabihf"
+- "gcc-9-arm-linux-gnueabihf"
 - "binutils-arm-linux-gnueabihf"
-- "g++-7-multilib"
-- "gcc-7-multilib"
-- "binutils-gold"
-- "git-core"
+- "g++-9-multilib"
+- "gcc-9-multilib"
+- "binutils"
+- "git"
 - "pkg-config"
 - "autoconf"
 - "libtool"
 - "automake"
+- "make"
 - "faketime"
 - "bison"
 - "bsdmainutils"
@@ -34,7 +35,7 @@ remotes:
 - "url": "https://github.com/dogecoin/dogecoin.git"
   "dir": "dogecoin"
 files:
-- "lief-0.12.3-cp36-cp36m-linux_x86_64.whl"
+- "lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 script: |
 
   WRAP_DIR=$HOME/wrapped
@@ -118,7 +119,7 @@ script: |
   done
 
   # install python-lief
-  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp36-cp36m-linux_x86_64.whl
+  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 
   cd dogecoin
   BASEPREFIX=`pwd`/depends

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -2,7 +2,7 @@
 name: "dogecoin-osx-1.14"
 enable_cache: true
 suites:
-- "bionic"
+- "focal"
 architectures:
 - "amd64"
 packages:
@@ -28,12 +28,14 @@ packages:
 - "python3-setuptools"
 - "python3-pip"
 - "fonts-tuffy"
+- "libtinfo5"
+- "xorriso"
 remotes:
 - "url": "https://github.com/dogecoin/dogecoin.git"
   "dir": "dogecoin"
 files:
 - "MacOSX10.11.sdk.tar.gz"
-- "lief-0.12.3-cp36-cp36m-linux_x86_64.whl"
+- "lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin11"
@@ -92,7 +94,7 @@ script: |
   tar -C ${BASEPREFIX}/SDKs -xf ${BUILD_DIR}/MacOSX10.11.sdk.tar.gz
 
   # install python-lief
-  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp36-cp36m-linux_x86_64.whl
+  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 
   # Build dependencies for each host
   for i in $HOSTS; do

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -2,7 +2,7 @@
 name: "dogecoin-win-1.14"
 enable_cache: true
 suites:
-- "bionic"
+- "focal"
 architectures:
 - "amd64"
 packages:
@@ -13,6 +13,7 @@ packages:
 - "autoconf"
 - "libtool"
 - "automake"
+- "make"
 - "faketime"
 - "bsdmainutils"
 - "mingw-w64"
@@ -21,14 +22,13 @@ packages:
 - "zip"
 - "ca-certificates"
 - "python3"
-- "python3-setuptools"
 - "python3-pip"
 - "rename"
 remotes:
 - "url": "https://github.com/dogecoin/dogecoin.git"
   "dir": "dogecoin"
 files:
-- "lief-0.12.3-cp36-cp36m-linux_x86_64.whl"
+- "lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
@@ -98,7 +98,7 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   # install python-lief
-  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp36-cp36m-linux_x86_64.whl
+  python3 -m pip install ${BUILD_DIR}/lief-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 
   cd dogecoin
   BASEPREFIX=`pwd`/depends

--- a/depends/README.md
+++ b/depends/README.md
@@ -1,6 +1,6 @@
 ### Prerequisites
 
-The depends system is maintained and tested using Ubuntu Bionic. Both generic
+The depends system is maintained and tested using Ubuntu Focal. Both generic
 apt packages, and packages specific to the target architecture are required to
 successfully compile all dependencies. Listed packages are tested and known to
 work.
@@ -8,28 +8,28 @@ work.
 #### Generic packages
 
 ```
-sudo apt-get install autoconf automake binutils-gold ca-certificates curl \
+sudo apt-get install autoconf automake make binutils ca-certificates curl \
                      faketime git-core libtool pkg-config python bison
 ```
 
 #### Generic linux: i686-pc-linux-gnu and x86_64-linux-gnu
 
 ```
-sudo apt-get install g++-7-multilib gcc-7-multilib
+sudo apt-get install g++-9-multilib gcc-9-multilib
 ```
 
 #### ARM7 32bit: arm-linux-gnueabihf
 
 ```
-sudo apt-get install g++-arm-linux-gnueabihf g++-7-arm-linux-gnueabihf \
-                     gcc-7-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+sudo apt-get install g++-arm-linux-gnueabihf g++-9-arm-linux-gnueabihf \
+                     gcc-9-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 ```
 
 #### ARM 64bit: aarch64-linux-gnu
 
 ```
-sudo apt-get install g++-aarch64-linux-gnu g++-7-aarch64-linux-gnu \
-                     gcc-7-aarch64-linux-gnu binutils-aarch64-linux-gnu
+sudo apt-get install g++-aarch64-linux-gnu g++-9-aarch64-linux-gnu \
+                     gcc-9-aarch64-linux-gnu binutils-aarch64-linux-gnu
 ```
 
 #### Windows: i686-w64-mingw32 and x86_64-w64-mingw32
@@ -43,7 +43,7 @@ sudo apt-get install g++ g++-mingw-w64 mingw-w64 nsis zip
 ```
 sudo apt-get install g++ cmake imagemagick fonts-tuffy libz-dev libbz2-dev \
                      libcap-dev librsvg2-bin libtiff-tools python python-dev \
-                     python-setuptools
+                     python-setuptools libtinfo5 xorriso
 ```
 
 ### Usage

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -1,42 +1,55 @@
 package=native_cctools
-$(package)_version=807d6fd1be5d2224872e381870c0a75387fe05e6
-$(package)_download_path=https://github.com/theuni/cctools-port/archive
+$(package)_version=3764b223c011574971ee3ae09ce968ba5dc2f00f
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
+$(package)_sha256_hash=3e35907bf376269a844df08e03cbb43e345c88125374f2228e03724b5f9a2a04
 $(package)_build_subdir=cctools
 $(package)_clang_version=6.0.1
 $(package)_clang_download_path=https://releases.llvm.org/$($(package)_clang_version)
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_sha256_hash=fa5416553ca94a8c071a27134c094a5fb736fe1bd0ecc5ef2d9bc02754e1bef0
+
+$(package)_libtapi_version=3efb201881e7a76a21e0554906cf306432539cef
+$(package)_libtapi_download_path=https://github.com/tpoechtrager/apple-libtapi/archive
+$(package)_libtapi_download_file=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_file_name=$($(package)_libtapi_version).tar.gz
+$(package)_libtapi_sha256_hash=380c1ca37cfa04a8699d0887a8d3ee1ad27f3d08baba78887c73b09485c0fbd3
+
 $(package)_extra_sources=$($(package)_clang_file_name)
+$(package)_extra_sources += $($(package)_libtapi_file_name)
 
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash))
+$(call fetch_file,$(package),$($(package)_clang_download_path),$($(package)_clang_download_file),$($(package)_clang_file_name),$($(package)_clang_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_libtapi_download_path),$($(package)_libtapi_download_file),$($(package)_libtapi_file_name),$($(package)_libtapi_sha256_hash))
 endef
 
 define $(package)_extract_cmds
   mkdir -p $($(package)_extract_dir) && \
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_clang_sha256_hash)  $($(package)_source_dir)/$($(package)_clang_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_libtapi_sha256_hash)  $($(package)_source_dir)/$($(package)_libtapi_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   mkdir -p toolchain/bin toolchain/lib/clang/$($(package)_clang_version)/include && \
+  mkdir -p libtapi && \
+  tar --no-same-owner --strip-components=1 -C libtapi -xf $($(package)_source_dir)/$($(package)_libtapi_file_name) && \
   tar --no-same-owner --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
   rm -f toolchain/lib/libc++abi.so* && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source)
 endef
 
 define $(package)_set_vars
-$(package)_config_opts=--target=$(host) --disable-lto-support
-$(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
-$(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
-$(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
+  $(package)_config_opts=--target=$(host) --disable-lto-support --with-libtapi=$($(package)_extract_dir)
+  $(package)_ldflags+=-Wl,-rpath=\\$$$$$$$$\$$$$$$$$ORIGIN/../lib
+  $(package)_cc=$($(package)_extract_dir)/toolchain/bin/clang
+  $(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
 endef
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh && \
-  sed -i.old "/define HAVE_PTHREADS/d" ld64/src/ld/InputFiles.h
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/build.sh && \
+  CC=$($(package)_cc) CXX=$($(package)_cxx) INSTALLPREFIX=$($(package)_extract_dir) ./libtapi/install.sh && \
+  sed -i.old "/define HAVE_PTHREADS/d" $($(package)_build_subdir)/ld64/src/ld/InputFiles.h
 endef
 
 define $(package)_config_cmds
@@ -49,6 +62,9 @@ endef
 
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install && \
+  mkdir -p $($(package)_staging_prefix_dir)/lib/ && \
+  cd $($(package)_extract_dir) && \
+  cp lib/libtapi.so.6 $($(package)_staging_prefix_dir)/lib/ && \
   cd $($(package)_extract_dir)/toolchain && \
   mkdir -p $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include && \
   mkdir -p $($(package)_staging_prefix_dir)/bin $($(package)_staging_prefix_dir)/include && \

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -4,11 +4,11 @@ $(package)_download_path=https://github.com/theuni/cctools-port/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=a09c9ba4684670a0375e42d9d67e7f12c1f62581a27f28f7c825d6d7032ccc6a
 $(package)_build_subdir=cctools
-$(package)_clang_version=3.7.1
-$(package)_clang_download_path=http://llvm.org/releases/$($(package)_clang_version)
+$(package)_clang_version=6.0.1
+$(package)_clang_download_path=https://releases.llvm.org/$($(package)_clang_version)
 $(package)_clang_download_file=clang+llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
 $(package)_clang_file_name=clang-llvm-$($(package)_clang_version)-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-$(package)_clang_sha256_hash=99b28a6b48e793705228a390471991386daa33a9717cd9ca007fcdde69608fd9
+$(package)_clang_sha256_hash=fa5416553ca94a8c071a27134c094a5fb736fe1bd0ecc5ef2d9bc02754e1bef0
 $(package)_extra_sources=$($(package)_clang_file_name)
 
 define $(package)_fetch_cmds
@@ -21,12 +21,9 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_clang_sha256_hash)  $($(package)_source_dir)/$($(package)_clang_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
-  mkdir -p toolchain/bin toolchain/lib/clang/3.5/include && \
+  mkdir -p toolchain/bin toolchain/lib/clang/$($(package)_clang_version)/include && \
   tar --no-same-owner --strip-components=1 -C toolchain -xf $($(package)_source_dir)/$($(package)_clang_file_name) && \
   rm -f toolchain/lib/libc++abi.so* && \
-  echo "#!/bin/sh" > toolchain/bin/$(host)-dsymutil && \
-  echo "exit 0" >> toolchain/bin/$(host)-dsymutil && \
-  chmod +x toolchain/bin/$(host)-dsymutil && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source)
 endef
 

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -73,3 +73,45 @@ extern "C" float __wrap_log2f(float x)
 {
     return log2f_old(x);
 }
+
+extern "C" double exp_old(double x);
+#ifdef __i386__
+__asm(".symver exp_old,exp@GLIBC_2.0");
+#elif defined(__amd64__)
+__asm(".symver exp_old,exp@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver exp_old,exp@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver exp_old,exp@GLIBC_2.17");
+#endif
+extern "C" double __wrap_exp(double x) {
+    return exp_old(x);
+}
+
+extern "C" double log_old(double x);
+#ifdef __i386__
+__asm(".symver log_old,log@GLIBC_2.0");
+#elif defined(__amd64__)
+__asm(".symver log_old,log@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver log_old,log@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver log_old,log@GLIBC_2.17");
+#endif
+extern "C" double __wrap_log(double x) {
+    return log_old(x);
+}
+
+extern "C" double pow_old(double x, double y);
+#ifdef __i386__
+__asm(".symver pow_old,pow@GLIBC_2.0");
+#elif defined(__amd64__)
+__asm(".symver pow_old,pow@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver pow_old,pow@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver pow_old,pow@GLIBC_2.17");
+#endif
+extern "C" double __wrap_pow(double x, double y) {
+    return pow_old(x,y);
+}

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -9,6 +9,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <stdarg.h>
 #include <time.h>
 
 #if defined(HAVE_SYS_SELECT_H)
@@ -130,3 +132,30 @@ __asm(".symver clock_gettime_old,clock_gettime@GLIBC_2.17");
 extern "C" int __wrap_clock_gettime(clockid_t a, struct timespec *b) {
     return clock_gettime_old(a, b);
 }
+
+// Wrap fcntl and fcntl64 for 32-bit linux only (both ARM and intel)
+#if defined(__i386__) || defined(__arm__)
+extern "C" int fcntl_old(int fd, int cmd, ...);
+
+# if defined(__i386__)
+__asm(".symver fcntl_old,fcntl@GLIBC_2.0");
+# elif defined(__arm__)
+__asm(".symver fcntl_old,fcntl@GLIBC_2.4");
+# endif
+
+extern "C" int __wrap_fcntl(int fd, int cmd, ...) {
+     va_list ap;
+     va_start(ap, cmd);
+     void* arg = va_arg(ap, void*);
+     va_end(ap);
+     return fcntl_old(fd, cmd, arg);
+}
+
+extern "C" int __wrap_fcntl64(int fd, int cmd, ...) {
+     va_list ap;
+     va_start(ap, cmd);
+     void* arg = va_arg(ap, void*);
+     va_end(ap);
+     return fcntl_old(fd, cmd, arg);
+}
+#endif //defined(__i386__) || defined(__arm__)

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <time.h>
 
 #if defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>
@@ -114,4 +115,18 @@ __asm(".symver pow_old,pow@GLIBC_2.17");
 #endif
 extern "C" double __wrap_pow(double x, double y) {
     return pow_old(x,y);
+}
+
+extern "C" int clock_gettime_old(clockid_t a, struct timespec *b);
+#ifdef __i386__
+__asm(".symver clock_gettime_old,clock_gettime@GLIBC_2.2");
+#elif defined(__amd64__)
+__asm(".symver clock_gettime_old,clock_gettime@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver clock_gettime_old,clock_gettime@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver clock_gettime_old,clock_gettime@GLIBC_2.17");
+#endif
+extern "C" int __wrap_clock_gettime(clockid_t a, struct timespec *b) {
+    return clock_gettime_old(a, b);
 }


### PR DESCRIPTION
Ubuntu Bionic will go [end-of-life in April 2023](https://wiki.ubuntu.com/Releases), so everything that relies on it needs to be updated. This encompasses the:

- continuous integration processes
- gitian release system
- supported OS for the depends system

This PR combines and enhances prior work done by @xanimo in #3133 and #3185 into an end-to-end upgrade to Ubuntu Focal for all these items, at once, because these turn out to all be interdependent on each other after extensive testing. Most of the prerequisites that came from the earlier PRs have already been merged separately, with the only remaining open requirement being #3204: that PR blocks this one as we need a portable set of check tooling to be able to compare binaries across host OS's. The commits from that PR are included in this one - this will need a rebase once that is merged. Commits that belong to this PR are 58553dba1525b71e9fa363af9afe20ca514e2de4 and onward.

### what this does

- wrap functions with an explicit glibc version selector for linux builds to ensure that the binary remains usable on systems with old glibc (this is enabled with the `--enable-glibc-back-compat` configure flag):
    - `clock_gettime`, `exp`, `log` and `pow` for all target Linux architectures
    - `fcntl` and `fcntl64` for 32-bit Linux architectures (`i686-pc-linux-gnu` and `arm-linux-gnuabihf` targets)
- update the `clang` and `cctools` packages in `depends` to respectively versions 6.0.1 and 921 while retaining minimum SDK compatibility. This is needed to be able to compile with our current macOS SDK on focal.
- Upgrade the CI to use Ubuntu Focal and gcc 9 for all targets
- Upgrade gitian scripts to use Ubuntu Focal and gcc 9 for all descriptors
- Update the documentation of requirements for the depends system

### what needs to be done now

- [x] Wait until #3204 is merged or cross-platform binary checking is attained in any other way

---- once that is done ----

- [x] Review, and apologies for the big change (will get a lot smaller after the previous item is checked)
- [x] A gitian comparison to ensure that the release build is still deterministic
- [x] Tests that binaries from the gitian builds are capable of sync on as old platforms as possible. Think: 32-bit armhf RPi, 32-bit intel with WinXP, Ubuntu Trusty, Centos 7, MacOS Mavericks/Yosemite... and so on.

### acknowledgements

This work is the final outcome of months of work and reworking the approach between @xanimo and myself. I couldn't have done this alone. Thank you, @xanimo ❤️