### PR TITLE
set character display limit label in Send coin dialog

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -33,6 +33,7 @@
 #include <QTimer>
 
 #define SEND_CONFIRM_DELAY   3
+#define CHARACTERS_DISPLAY_LIMIT_IN_LABEL 45
 
 SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent),
@@ -276,7 +277,12 @@ void SendCoinsDialog::on_sendButton_clicked()
         {
             if(rcp.label.length() > 0) // label with address
             {
-                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.label));
+                QString displayedLabel = rcp.label;
+                if (rcp.label.length() > CHARACTERS_DISPLAY_LIMIT_IN_LABEL)  
+                {
+                    displayedLabel = displayedLabel.left(CHARACTERS_DISPLAY_LIMIT_IN_LABEL).append("..."); // limit the amount of characters displayed in label
+                }
+                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(displayedLabel));
                 recipientElement.append(QString(" (%1)").arg(address));
             }
             else // just address


### PR DESCRIPTION
An attempt to fix #3182  bug tx confirmation window is getting out of the screen and can't click on "send" by setting a maximum of 45 characters to not wrap lines in the label and be able to add ... if the size exceeds that.