### PR TITLE
Fix array.array object has no attribute tostring()

### DIFF
--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -105,7 +105,7 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]


### PR DESCRIPTION
array.tostring() was renamed to array.tobytes() for clarity in python 3.2 and further removed in python 3.9

Further this bugfix fixes problem in  rpcbind_test.py as mentioned in https://github.com/dogecoin/dogecoin/issues/3201