### PR TITLE
Make Qt auto-detect the preferred page size for printer

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -58,6 +58,7 @@
 #include <QtPrintSupport/QPrinter>
 #include <QtPrintSupport/QPrintDialog>
 #include <QtPrintSupport/QPrintPreviewDialog>
+#include <QtPrintSupport/QPrinterInfo>
 #endif
 #include <QPainter>
 #include "walletmodel.h"
@@ -347,17 +348,25 @@ void PaperWalletDialog::on_printButton_clicked()
     QPrinter printer(QPrinter::HighResolution);
     QPrintDialog* qpd = new QPrintDialog(&printer, this);
 
-    qpd->setPrintRange(QAbstractPrintDialog::AllPages);
+    #if QT_VERSION > 0x050000
+    QPrinterInfo printerinfo(printer);
+    QPageSize papersize = printerinfo.defaultPageSize();
+    #endif
 
+    qpd->setPrintRange(QAbstractPrintDialog::AllPages);
     QList<QString> recipientPubKeyHashes;
 
     if (qpd->exec() != QDialog::Accepted) {
         return;
     }
 
-    // Hardcode these values
+
     printer.setOrientation(QPrinter::Portrait);
+    #if QT_VERSION > 0x050000
+    printer.QPagedPaintDevice::setPageSize(papersize);
+    #else
     printer.setPaperSize(QPrinter::A4);
+    #endif
     printer.setFullPage(true);
 
     QPainter painter;


### PR DESCRIPTION
-> Removes the need for hard-coded paper size in printer configuration if QT 5.3 or above is used related to issue #3152