### PR TITLE
Update fee rate to 0.01 DOGE/kb in p2p-feefilter.py

### DIFF
--- a/qa/rpc-tests/p2p-feefilter.py
+++ b/qa/rpc-tests/p2p-feefilter.py
@@ -74,22 +74,22 @@ class FeeFilterTest(BitcoinTestFramework):
         NetworkThread().start()
         test_node.wait_for_verack()
 
-        # Test that invs are received for all txs at feerate of 20 sat/byte
-        node1.settxfee(Decimal("0.00020000"))
+        # Test that invs are received for all txs at feerate of 20000 sat/byte
+        node1.settxfee(Decimal("0.20000000"))
         txids = [node1.sendtoaddress(node1.getnewaddress(), 1) for x in range(3)]
         assert(allInvsMatch(txids, test_node))
         test_node.clear_invs()
 
-        # Set a filter of 15 sat/byte
-        test_node.send_filter(15000)
+        # Set a filter of 15000 sat/byte
+        test_node.send_filter(15000000)
 
-        # Test that txs are still being received (paying 20 sat/byte)
+        # Test that txs are still being received (paying 20000 sat/byte)
         txids = [node1.sendtoaddress(node1.getnewaddress(), 1) for x in range(3)]
         assert(allInvsMatch(txids, test_node))
         test_node.clear_invs()
 
-        # Change tx fee rate to 10 sat/byte and test they are no longer received
-        node1.settxfee(Decimal("0.00010000"))
+        # Change tx fee rate to 10000 sat/byte and test they are no longer received
+        node1.settxfee(Decimal("0.10000000"))
         [node1.sendtoaddress(node1.getnewaddress(), 1) for x in range(3)]
         sync_mempools(self.nodes) # must be sure node 0 has received all txs 
 
@@ -100,7 +100,7 @@ class FeeFilterTest(BitcoinTestFramework):
         # to 35 entries in an inv, which means that when this next transaction
         # is eligible for relay, the prior transactions from node1 are eligible
         # as well.
-        node0.settxfee(Decimal("0.00020000"))
+        node0.settxfee(Decimal("0.20000000"))
         txids = [node0.sendtoaddress(node0.getnewaddress(), 1)]
         assert(allInvsMatch(txids, test_node))
         test_node.clear_invs()


### PR DESCRIPTION
I have made an attempt to update fee rate in p2p-feefilter.py to recommended minimum transaction fee of 0.01 DOGE/kb to reflect fee rate changes made in 1.14.4 release , it is linked with issue #3201