### PR TITLE
Limit debugfile on SIGHUP

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -322,6 +322,9 @@ int LogPrintStr(const std::string &str)
             // reopen the log file, if requested
             if (fReopenDebugLog) {
                 fReopenDebugLog = false;
+                if (GetBoolArg("-shrinkdebugfile", !fDebug)) {
+                    ShrinkDebugFile();
+                }
                 boost::filesystem::path pathDebug = GetDataDir() / "debug.log";
                 if (freopen(pathDebug.string().c_str(),"a",fileout) != NULL)
                     setbuf(fileout, NULL); // unbuffered


### PR DESCRIPTION
When reading the code and intent around `-shrinkdebugfile`, this omission seemed odd.