### PR TITLE
maint: don't ignore legit patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ src/qt/test/moc*.cpp
 *.pyc
 *.o
 *.o-*
-*.patch
 *.a
 *.pb.cc
 *.pb.h
@@ -71,6 +70,10 @@ src/qt/test/moc*.cpp
 #libtool object files
 *.lo
 *.la
+
+# ignore only unwanted patches
+*.patch
+!depends/patches/**/*.patch
 
 # Compilation and Qt preprocessor part
 *.qm


### PR DESCRIPTION
Make git track patches under `depends/patches/**/*.patch` as an exception to the "no `*.patch`" rule.

Mostly because it's annoying to one's workflow when working on depends and easy to miss out something important.