### PR TITLE
build: bdb detection and configuration fixes for macOs/brew

### DIFF
--- a/build-aux/m4/dogecoin_find_bdb53.m4
+++ b/build-aux/m4/dogecoin_find_bdb53.m4
@@ -7,61 +7,74 @@ AC_DEFUN([BITCOIN_FIND_BDB53],[
   AC_ARG_VAR([BDB_CFLAGS], [C compiler flags for BerkeleyDB, bypasses autodetection])
   AC_ARG_VAR([BDB_LIBS], [Linker flags for BerkeleyDB, bypasses autodetection])
 
-  if test "$BDB_CFLAGS" = ""; then
-    AC_MSG_CHECKING([for Berkeley DB C++ headers])
+  AC_MSG_CHECKING([for Berkeley DB C++ headers])
+
+  dnl if BDB_CFLAGS is specified, add it to CPPFLAGS and override the searchpath
+  dnl store the current CPPFLAGS to restore later
+  if test "x$BDB_CFLAGS" != "x"; then
+    TCFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${CPPFLAGS} ${BDB_CFLAGS}"
+  else
     BDB_CPPFLAGS=
     BDB_LIBS=
-    bdbpath=X
-    bdb53path=X
     bdbdirlist=
     for _vn in 5.3 53 5 ''; do
       for _pfx in b lib ''; do
         bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
       done
     done
-    for searchpath in $bdbdirlist ''; do
-      test -n "${searchpath}" && searchpath="${searchpath}/"
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <${searchpath}db_cxx.h>
-      ]],[[
-        #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
-          #error "failed to find bdb 5.3+"
-        #endif
-      ]])],[
-        if test "x$bdbpath" = "xX"; then
-          bdbpath="${searchpath}"
-        fi
-      ],[
-        continue
-      ])
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <${searchpath}db_cxx.h>
-      ]],[[
-        #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
-          #error "failed to find bdb 5.3"
-        #endif
-      ]])],[
-        bdb53path="${searchpath}"
-        break
-      ],[])
-    done
-    if test "x$bdbpath" = "xX"; then
-      AC_MSG_RESULT([no])
-      AC_MSG_ERROR([libdb_cxx headers missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
-    elif test "x$bdb53path" = "xX"; then
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
-        AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
-      ],[
-        AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
-      ])
-    else
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
-      bdbpath="${bdb53path}"
-    fi
+  fi
+
+  bdbpath=X
+  bdb53path=X
+
+  for searchpath in $bdbdirlist ''; do
+    test -n "${searchpath}" && searchpath="${searchpath}/"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <${searchpath}db_cxx.h>
+    ]],[[
+      #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
+        #error "failed to find bdb 5.3+"
+      #endif
+    ]])],[
+      if test "x$bdbpath" = "xX"; then
+        bdbpath="${searchpath}"
+      fi
+    ],[
+      continue
+    ])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <${searchpath}db_cxx.h>
+    ]],[[
+      #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
+        #error "failed to find bdb 5.3"
+      #endif
+    ]])],[
+      bdb53path="${searchpath}"
+      break
+    ],[])
+  done
+  if test "x$bdbpath" = "xX"; then
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([libdb_cxx headers missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+  elif test "x$bdb53path" = "xX"; then
+    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
+    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
+      AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
+    ],[
+      AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
+    ])
   else
+    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
+    bdbpath="${bdb53path}"
+  fi
+
+  dnl restore orgininal CPPFLAGS and fixate the now checked flags.
+  if test "x$BDB_CFLAGS" != "x"; then
+    CPPFLAGS="${TCFLAGS}"
     BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
+
   AC_SUBST(BDB_CPPFLAGS)
 
   if test "$BDB_LIBS" = ""; then
@@ -75,6 +88,13 @@ AC_DEFUN([BITCOIN_FIND_BDB53],[
     if test "x$BDB_LIBS" = "x"; then
         AC_MSG_ERROR([libdb_cxx missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
     fi
+  else
+    TLIBS="${LIBS}"
+    LIBS="${LIBS} ${BDB_LIBS}"
+    AC_SEARCH_LIBS([main],[],[],[
+        AC_MSG_ERROR([libdb_cxx missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    ])
+    LIBS="${TLIBS}"
   fi
   AC_SUBST(BDB_LIBS)
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -373,16 +373,25 @@ case $host in
          dnl the user (--without-wallet or --without-gui for example).
 
          openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
-         bdb_prefix=`$BREW --prefix berkeley-db 2>/dev/null`
          qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
          if test x$openssl_prefix != x; then
            PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH
          fi
-         if test x$bdb_prefix != x; then
-           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
-           LIBS="$LIBS -L$bdb_prefix/lib"
+
+         dnl test brew installed bdb if no BDB_CFLAGS or BDB_LIBS was given.
+         dnl currently tests, in order, for 5.x, 4.x and the default version
+         if test x$BDB_CFLAGS = x && test x$BDB_LIBS = x; then
+           for brew_bdb_version in '@5' '@4' ''; do
+             bdb_prefix=`$BREW --prefix berkeley-db${brew_bdb_version} 2>/dev/null`
+             if test x$bdb_prefix != x && test -d $bdb_prefix; then
+               BDB_CFLAGS="-I$bdb_prefix/include"
+               BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx"
+               break
+             fi
+           done
          fi
+
          if test x$qt5_prefix != x; then
            PKG_CONFIG_PATH="$qt5_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
            export PKG_CONFIG_PATH


### PR DESCRIPTION
Currently, brew logic in `configure.ac` always adds the default `berkeley-db` path when compiling on macOs. This causes link-time and/or run-time issues when the default version (18.x) is installed on the compiling system, and prevents proper linking when using the `contrib/install_bdb.sh` script. This has been blocking #2686.

This PR fixes that issue by:

1. Updating `dogecoin_find_bdb53.m4` to also check manually specified `BDB_CFLAGS` and `BDB_LIBS`. This prevents link-time and run-time errors by catching the error during configuration.
2. Using the `BITCOIN_FIND_BDB53` m4 macro when using brew for bdb detection instead of appending values to the generic `CPPFLAGS` and `LIBS`, because these are used generically for every binary and can cause issues with libtool archive scope.
3. Only using brew to detect the installed version if no `BDB_CFLAGS` or `BDB_LIBS` is manually given. This is to allow maximum flexibility for custom compiles, while retaining automatic configuration.
4. Detect each version of the `berkeley-db` package, in the order `@5`, `@4` and only then the default version. The reason for this detection order is that 4.x is still fully readable by 5.3.27NC that is distributed by default, and therefore preferred over newer-than 5.x versions.

I've tested this to work on x86_64-linux, arm64-darwin and x86_64-darwin

After applying this patch on top of #3301, configuration on macOs only requires manual specification of boost, i.e.:

```bash
./autogen.sh
./configure --with-boost=`brew --prefix boost`
```

~~Note: this PR is best tested on top of #3301, so it's probably best to rebase this after that, or an alternative fix, gets merged.~~