### PR TITLE
qa: also log named arguments when using `--tracerpc`

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -142,7 +142,7 @@ class AuthServiceProxy(object):
         AuthServiceProxy.__id_count += 1
 
         log.debug("-%s-> %s %s"%(AuthServiceProxy.__id_count, self._service_name,
-                                 json.dumps(args, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
+                                 json.dumps(args or argsn, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
         if args and argsn:
             raise ValueError('Cannot handle both named and positional arguments')
         postdata = json.dumps({'version': '1.1',


### PR DESCRIPTION
When testing #3306, I learned that named arguments to `AuthServiceProxy.__call__` weren't logged when inspecting tests with `--tracerpc`.

This PR changes the log logic to either print positional arguments or named arguments if no positional arguments exist. The `__call__` function rejects any calls made using both positional and named arguments, therefore we can print either in this construction.