### PR TITLE
utiltime: refactor nMockTime and add getmocktime

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -176,6 +176,7 @@ testScripts = [
     'liststucktransactions.py',
     'getblock.py',
     'addnode.py',
+    'getmocktime.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/getmocktime.py
+++ b/qa/rpc-tests/getmocktime.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from test_framework.mininode import * #NodeConnCB, NODE_NETWORK, NodeConn, wait_until
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+'''
+GetMockTime -- test getmocktime
+'''
+
+def wait_until_mocktime(node, time, timeout):
+    def mocktime_is_set():
+        return node.getmocktime() == time
+    return wait_until(mocktime_is_set, timeout=timeout)
+
+def wait_until_mocktime_change(node, time, timeout):
+    def mocktime_has_changed():
+        return node.getmocktime() != time
+    return wait_until(mocktime_has_changed, timeout=timeout)
+
+class GetMockTime(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.is_network_split = False
+
+    def run_test(self):
+        self.test_getmocktime()
+
+    def setup_network(self):
+        # set up full nodes
+        self.nodes = []
+        # Node 0 is going to be our testsubject
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug=net", "-debug=mempool", "-peertimeout=999999999"]))
+
+    def test_getmocktime(self):
+        assert wait_until_mocktime(self.nodes[0], 0, timeout=60)
+
+        self.nodes[0].setmocktime(-0) # negative zero
+        assert wait_until_mocktime(self.nodes[0], -0, timeout=60)
+
+        self.nodes[0].setmocktime(123)
+        assert wait_until_mocktime(self.nodes[0], 123, timeout=60)
+
+        self.nodes[0].setmocktime(9223372036854775807) # int64_t max
+        assert wait_until_mocktime(self.nodes[0], 9223372036854775807, timeout=60)
+
+        try: # overflow int64_t max
+            self.nodes[0].setmocktime(9223372036854775808) # int64_t max + 1
+        except JSONRPCException as e:
+            assert("JSON integer out of range" in e.error["message"])
+
+        self.nodes[0].setmocktime(-9223372036854775808) # int64_t min
+        assert wait_until_mocktime(self.nodes[0], -9223372036854775808, timeout=60)
+
+        try: # overflow int64_t min
+            self.nodes[0].setmocktime(-9223372036854775809) # int64_t min + 1
+        except JSONRPCException as e:
+            assert("JSON integer out of range" in e.error["message"])
+
+        self.nodes[0].setmocktime(0x7fffffffffffffff) # hex
+        assert wait_until_mocktime(self.nodes[0], 0x7fffffffffffffff, timeout=60)
+
+        self.nodes[0].setmocktime(1658308113) # 4314284 timestamp
+        assert wait_until_mocktime(self.nodes[0], 1658308113, timeout=60)
+        assert not wait_until_mocktime_change(self.nodes[0], 1658308113, timeout=5) # this must time out
+
+        self.nodes[0].setmocktime(1658308119) # 4314285 timestamp
+        assert wait_until_mocktime(self.nodes[0], 1658308119, timeout=60)
+        assert not wait_until_mocktime_change(self.nodes[0], 1658308119, timeout=5) # this must time out
+
+        self.nodes[0].setmocktime(0) # zero
+        assert wait_until_mocktime(self.nodes[0], 0, timeout=60)
+
+if __name__ == '__main__':
+    GetMockTime().main()

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -455,6 +455,25 @@ UniValue setmocktime(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue getmocktime(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "getmocktime\n"
+            "\nGet the current mocktime (-regtest only)\n"
+            "Note: this is an asynchronous read, and does not take into account any\n"
+            "setmocktime calls that are pending."
+            "\nResult:\n"
+            "\"timestamp\"          (int64) The current mocktime (0 = no mocktime is set)\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getmocktime", "")
+            + HelpExampleRpc("getmocktime", "")
+        );
+
+    UniValue result(GetMockTime());
+    return result;
+}
+
 static UniValue RPCLockedMemoryInfo()
 {
     LockedPool::Stats stats = LockedPoolManager::Instance().stats();
@@ -522,6 +541,7 @@ static const CRPCCommand commands[] =
 
     /* Not shown in help */
     { "hidden",             "setmocktime",            &setmocktime,            true,  {"timestamp"}},
+    { "hidden",             "getmocktime",            &getmocktime,            true,  {}},
     { "hidden",             "echo",                   &echo,                   true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                  true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
 };

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -10,16 +10,18 @@
 
 #include "utiltime.h"
 
+#include <atomic>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
 
 using namespace std;
 
-static int64_t nMockTime = 0; //!< For unit testing
+static std::atomic<int64_t> nMockTime(0); //!< For testing
 
 int64_t GetTime()
 {
-    if (nMockTime) return nMockTime;
+    int64_t mocktime = GetMockTime();
+    if (mocktime) return mocktime;
 
     time_t now = time(NULL);
     assert(now > 0);
@@ -28,13 +30,19 @@ int64_t GetTime()
 
 int64_t GetMockableTimeMicros()
 {
-    if (nMockTime) return nMockTime * 1000000;
+    int64_t mocktime = GetMockTime();
+    if (mocktime) return mocktime * 1000000;
     return GetTimeMicros();
 }
 
 void SetMockTime(int64_t nMockTimeIn)
 {
-    nMockTime = nMockTimeIn;
+    nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
+}
+
+int64_t GetMockTime()
+{
+    return nMockTime.load(std::memory_order_relaxed);
 }
 
 int64_t GetTimeMillis()

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -26,6 +26,7 @@ int64_t GetTimeMicros();
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 int64_t GetLogTimeMicros();
 int64_t GetMockableTimeMicros();
+int64_t GetMockTime();
 void SetMockTime(int64_t nMockTimeIn);
 void MilliSleep(int64_t n);
 


### PR DESCRIPTION
-adds a new function `getmocktime`, taken from bitcoin 9743, which allow us to ability to get the current mocktime that is set via `setmocktime`. 
-refactors `nMockTime` to use `std::atomic<int64_t>` over an `int64_t` which is loaded via `std::memory_order_relaxed`.
-adds rpc function `getmocktime` and simple qa test to assert it works correctly.