### PR TITLE
Add extra configuration file to persist RPC-set features

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -267,6 +267,7 @@ void Shutdown()
     delete pwalletMain;
     pwalletMain = NULL;
 #endif
+    WriteExtraConfigFile();
     globalVerifyHandle.reset();
     ECC_Stop();
     LogPrintf("%s: done\n", __func__);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -622,6 +622,19 @@ void ReadConfigFile(const std::string& confPath)
     ClearDatadirCache();
 }
 
+void WriteExtraConfigFile()
+{
+    boost::filesystem::path pathDebug = GetDataDir() / "dogecoin-extra.conf";
+    FILE* extraConfFileout = fopen(pathDebug.string().c_str(), "w");
+    if (extraConfFileout) {
+        fprintf(extraConfFileout,
+            "# Dogecoin Extra Configuration\n"
+            "# Add contents to your dogecoin.conf or --enable-dogecoin-extraconf to use\n"
+        );
+        fclose(file);
+    }
+}
+
 #ifndef WIN32
 boost::filesystem::path GetPidFile()
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -631,6 +631,13 @@ void WriteExtraConfigFile()
             "# Dogecoin Extra Configuration\n"
             "# Add contents to your dogecoin.conf or --enable-dogecoin-extraconf to use\n"
         );
+
+        vector<COutPoint> vOutpts;
+        pwalletMain->ListLockedCoins(vOutpts);
+
+        BOOST_FOREACH(const COutPoint& outpt, vOutpts) {
+            fprintf(extraConfFileout, "lockunspent=%s\n", outpt.hash.GetHex());
+        }
         fclose(file);
     }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -109,6 +109,7 @@ boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
 void ReadConfigFile(const std::string& confPath);
+void WriteExtraConfigFile();
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif


### PR DESCRIPTION
This begins to address a feature request in #3206. I'm creating it as a draft for now, because we should have make some design decisions before going further.

Current flaws:

- (missing implementation) there's no lockunspent configuration option anywhere
- (code style) the implementation is a mix of C and Boost, so it could be polished further
- (design) this may be the wrong approach
- (potential design question) there's no user notification that we're writing this file apart from its existence
- (potential design question, depends on approach) nothing uses this file

However, in the spirit of debating working code (and in the interest of not replicating uninspectable binary .dat files for important options like these), it's worth at least a draft.