### PR TITLE
Use nullptr instead of null

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -49,9 +49,9 @@ double GetDifficulty(const CBlockIndex* blockindex)
 {
     // Floating point number that is a multiple of the minimum difficulty,
     // minimum difficulty = 1.0.
-    if (blockindex == NULL)
+    if (blockindex == nullptr)
     {
-        if (chainActive.Tip() == NULL)
+        if (chainActive.Tip() == nullptr)
             return 1.0;
         else
             blockindex = chainActive.Tip();


### PR DESCRIPTION
Reasons for the change:

1) Type Safety:
nullptr is a keyword introduced in modern C++. It's designed to be type-safe, meaning it can only represent a null pointer value.

NULL, on the other hand, is typically defined as 0. It's a macro and is not type-safe. This means you can unintentionally assign NULL to an integer variable without any compiler warnings.

2) Explicit Null Pointer Value:
nullptr is explicitly defined to represent a null pointer value. It's clear and unambiguous.

NULL is usually defined as 0, which can lead to ambiguity. For instance, when comparing a pointer to an integer, it's unclear whether you're checking for a null pointer or a zero integer value.

3) Consistency with C++:
nullptr is consistent with the principles of modern C++. C++ is a strongly typed language, and nullptr is designed to be a type-safe representation of a null pointer.

NULL is a legacy from C and is essentially a macro for 0. It doesn't align as well with the type-safe nature of C++.