### PR TITLE
include stdexcept in the lockedpool.cpp file

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -5,6 +5,7 @@
 
 #include "support/lockedpool.h"
 #include "support/cleanse.h"
+#include <stdexcept> // for std::runtime_error
 
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"


### PR DESCRIPTION
It is needed for handling std::runtime_error correctly.