### PR TITLE
Update build-windows.md, remove linux lib deps installation line.

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -54,10 +54,6 @@ First, install the general dependencies:
     sudo apt upgrade
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
     
-If you want to build with the wallet and Qt GUI you also want to install the following (this example is under Ubuntu):
-
-    sudo apt-get install libssl-dev libboost-all-dev qt5-default libprotobuf-dev libqrencode4 libdb++-dev libdb-dev miniupnpc
-
 A host toolchain (`build-essential`) is necessary because some dependency
 packages (such as `protobuf`) need to build host utilities that are used in the
 build process.


### PR DESCRIPTION
Removes misinformation, as this is already on the dogecoin/docs/build-unix.md page. Installing these linux libraries from aptitude can, and will interfere with the libraries that are cross-compiled from /dogecoin/depends/packages m4's using gcc/mingw.