### PR TITLE
ci: disable macOs native task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,17 +134,18 @@ task:
   env:
     FILE_ENV: "./ci/test/00_setup_env_mac.sh"
 
-task:
-  name: 'macOS 10.14 native [GOAL: install] [GUI] [no depends]'
-  brew_install_script:
-    - brew update
-    - brew install boost libevent qt@5 miniupnpc ccache zeromq qrencode sqlite libtool automake pkg-config gnu-getopt
-  << : *GLOBAL_TASK_TEMPLATE
-  osx_instance:
-    # Use latest image, but hardcode version to avoid silent upgrades (and breaks)
-    image: catalina-xcode-12.1  # https://cirrus-ci.org/guide/macOS
-  env:
-    DANGER_RUN_CI_ON_HOST: "true"
-    CI_USE_APT_INSTALL: "no"
-    PACKAGE_MANAGER_INSTALL: "echo"  # Nothing to do
-    FILE_ENV: "./ci/test/00_setup_env_mac_host.sh"
+# Disabled until macOS arm64 compiles without errors
+#task:
+#  name: 'macOS 10.14 native [GOAL: install] [GUI] [no depends]'
+#  brew_install_script:
+#    - brew update
+#    - brew install boost libevent qt@5 miniupnpc ccache zeromq qrencode sqlite libtool automake pkg-config gnu-getopt
+#  << : *GLOBAL_TASK_TEMPLATE
+#  osx_instance:
+#    # Use latest image, but hardcode version to avoid silent upgrades (and breaks)
+#    image: catalina-xcode-12.1  # https://cirrus-ci.org/guide/macOS
+#  env:
+#    DANGER_RUN_CI_ON_HOST: "true"
+#    CI_USE_APT_INSTALL: "no"
+#    PACKAGE_MANAGER_INSTALL: "echo"  # Nothing to do
+#    FILE_ENV: "./ci/test/00_setup_env_mac_host.sh"


### PR DESCRIPTION
Step 1 from #3349. 

Disables the macOs native build in the CI to allow several blocking issues to be resolved atomically rather than creating a huge pull request that is hard to review.

Once arm64 macOs compiles again, this commit can be reverted.