### PR TITLE
depends: updated to libX11 1.8.7, libxcp 1.15, xcb-proto 1.15

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,6 +29,8 @@ these dependencies.
 
   The following are developer notes on how to build Dogecoin on your native
   platform, using the dependencies as provided by your system's package manager.
+  Before starting, ensure your system is updated and has the latest security patches.
+  Outdated libraries can render the entire system, including Dogecoin Core, vulnerable.
   They are not complete guides, but include notes on the necessary libraries,
   compile flags, etc.
 

--- a/depends/packages/libX11.mk
+++ b/depends/packages/libX11.mk
@@ -1,8 +1,8 @@
 package=libX11
-$(package)_version=1.6.2
+$(package)_version=1.8.7
 $(package)_download_path=http://xorg.freedesktop.org/releases/individual/lib/
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=2aa027e837231d2eeea90f3a4afe19948a6eb4c8b2bec0241eba7dbc8106bd16
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=05f267468e3c851ae2b5c830bcf74251a90f63f04dd7c709ca94dc155b7e99ee
 $(package)_dependencies=libxcb xtrans xextproto xproto
 
 define $(package)_set_vars

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -1,8 +1,8 @@
 package=libxcb
-$(package)_version=1.10
+$(package)_version=1.15
 $(package)_download_path=http://xcb.freedesktop.org/dist
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c3f2d5b5
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d
 $(package)_dependencies=xcb_proto libXau xproto
 
 define $(package)_set_vars

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,8 +1,8 @@
 package=xcb_proto
-$(package)_version=1.10
+$(package)_version=1.15
 $(package)_download_path=http://xcb.freedesktop.org/dist
-$(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
-$(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
+$(package)_file_name=xcb-proto-$($(package)_version).tar.gz
+$(package)_sha256_hash=0e434af76af722ef9b2dc21066da1cd11e5dd85fc1996d66228d090f9ae9b217
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -62,6 +62,12 @@ using only fully tested dependencies, see the documentation in the
 
 ### Ubuntu & Debian example
 
+Before installing the dependencies, ensure your system is updated and has the latest security patches:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+
 **Required dependencies** :
 ```bash
 sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -48,7 +48,7 @@ These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
-First, install the general dependencies:
+Install the general dependencies. First, ensure your system is updated and has the latest security patches.
 
     sudo apt update
     sudo apt upgrade


### PR DESCRIPTION
### Updates
- **`libX11`** upgraded to `1.8.7`.
- Dependency **`libxcb`** upgraded to `1.15`.
- Dependency **`xcb-proto`** upgraded to `1.15`.

### Security 
Addresses multiple CVEs in `libX11` versions prior to `1.8.7`. 
[See X.Org Security Advisory](https://www.x.org/wiki/Development/Security/).
