### PR TITLE
ci: add linter for translations

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,17 @@
+name: linter
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  translations:
+    name: Check Translations
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Lint translation files
+      run: python3 contrib/devtools/check-translations.py


### PR DESCRIPTION
Adds a lint job to the CI where we can do sanity analysis on included files to help spot errors on non-cpp source files that may cause problems during runtime.

This first job implements `contrib/devtools/check-translations.py` that alerts the repository of errors in the translation files in `src/qt/locale`. Errors in a translation file are otherwise only becoming visible during runtime.

Example result when things go wrong: https://github.com/patricklodder/dogecoin/actions/runs/6580286523/job/17877955772