### PR TITLE
depends: updated to freetype 2.11.0

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,12 +1,12 @@
 package=freetype
-$(package)_version=2.7.1
+$(package)_version=2.11.0
 $(package)_download_path=http://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
-  $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux=--with-pic --without-brotli
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Addresses potential issues related to out-of-bounds writes in earlier versions of freetype and fontconfig. Updated depends to freetype 2.11.0 and fontconfig 2.12.6 per advisories ([GHSA-g839-937g-3fhv](https://github.com/advisories/GHSA-g839-937g-3fhv), [GHSA-3f3f-jhpf-w85x](https://github.com/advisories/GHSA-3f3f-jhpf-w85x), [GHSA-hvhj-84gh-p5vr](https://github.com/advisories/GHSA-hvhj-84gh-p5vr)). The exact conditions that trigger these issues may not be common in core, updating ensures robustness.

#### Original commits:

- **build: Bump Fonconfig version up to 2.12.6**
  - **Commit:** [6575d354c8176c67c847b0e0a6cdd42800731a00](https://github.com/bitcoin/bitcoin/commit/6575d354c8176c67c847b0e0a6cdd42800731a00)
  - **Committed on:** Dec 3, 2021 by hebasto

- **build: freetype 2.11.0**
  - **Commit:** [01544dd78ccc0b0474571da854e27adef97137fb](https://github.com/bitcoin/bitcoin/commit/01544dd78ccc0b0474571da854e27adef97137fb)
  - **Committed on:** Dec 3, 2021 by fanquake and mammix2