### PR TITLE
depends: updated to fontconfig 2.12.6

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,26 +1,21 @@
 package=fontconfig
-$(package)_version=2.12.1
+$(package)_version=2.12.6
 $(package)_download_path=http://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
+$(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
 $(package)_dependencies=freetype expat
+$(package)_patches=gperf_header_regen.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static
 endef
 
-define $(package)_config_cmds
-  $($(package)_autoconf)
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/gperf_header_regen.patch
 endef
 
-# 2.12.1 uses CHAR_WIDTH which is reserved and clashes with some glibc versions, but newer versions of fontconfig
-# have broken makefiles which needlessly attempt to re-generate headers with gperf.
-# Instead, change all uses of CHAR_WIDTH, and disable the rule that forces header re-generation.
-# This can be removed once the upstream build is fixed.
-define $(package)_build_cmds
-  sed -i 's/CHAR_WIDTH/CHARWIDTH/g' fontconfig/fontconfig.h src/fcobjshash.gperf src/fcobjs.h src/fcobjshash.h && \
-  sed -i 's/fcobjshash.h: fcobjshash.gperf/fcobjshash.h:/' src/Makefile && \
-  $(MAKE)
+define $(package)_config_cmds
+  $($(package)_autoconf)
 endef
 
 define $(package)_stage_cmds

--- a/depends/patches/fontconfig/gperf_header_regen.patch
+++ b/depends/patches/fontconfig/gperf_header_regen.patch
@@ -1,0 +1,24 @@
+commit 7b6eb33ecd88768b28c67ce5d2d68a7eed5936b6
+Author: fanquake <fanquake@gmail.com>
+Date:   Tue Aug 25 14:34:53 2020 +0800
+
+    Remove rule that causes inadvertent header regeneration
+
+    Otherwise the makefile will needlessly attempt to re-generate the
+    headers with gperf. This can be dropped once the upstream build is fixed.
+
+    See #10851.
+
+diff --git a/src/Makefile.in b/src/Makefile.in
+index f4626ad..4ae1b00 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -912,7 +912,7 @@
+ 	' - > $@.tmp && \
+ 	mv -f $@.tmp fcobjshash.gperf && touch $@ || ( $(RM) $@.tmp && false )
+
+-fcobjshash.h: Makefile fcobjshash.gperf
++fcobjshash.h:
+ 	$(AM_V_GEN) $(GPERF) --pic -m 100 fcobjshash.gperf > $@.tmp && \
+ 	mv -f $@.tmp $@ || ( $(RM) $@.tmp && false )
+


### PR DESCRIPTION
Split fontconfig 2.12.6 from https://github.com/dogecoin/dogecoin/pull/3362 into a separate PR due to the extent of changes in freetype2 2.11.0.