### PR TITLE
build: fix bdb detection with macOs/brew

### DIFF
--- a/build-aux/m4/dogecoin_find_bdb53.m4
+++ b/build-aux/m4/dogecoin_find_bdb53.m4
@@ -7,60 +7,73 @@ AC_DEFUN([BITCOIN_FIND_BDB53],[
   AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
   AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
 
-  if test "x$BDB_CFLAGS" = "x"; then
-    AC_MSG_CHECKING([for Berkeley DB C++ headers])
+  AC_MSG_CHECKING([for Berkeley DB C++ headers])
+
+  dnl if BDB_CFLAGS is specified, add it to CPPFLAGS and override the searchpath
+  dnl store the current CPPFLAGS to restore later
+  if test "x$BDB_CFLAGS" != "x"; then
+    TCFLAGS="${CPPFLAGS}"
+    CPPFLAGS="${CPPFLAGS} ${BDB_CFLAGS}"
+  else
     BDB_CPPFLAGS=
-    bdbpath=X
-    bdb53path=X
     bdbdirlist=
     for _vn in 5.3 53 5 4.8 48 4 ''; do
       for _pfx in b lib ''; do
         bdbdirlist="$bdbdirlist ${_pfx}db${_vn}"
       done
     done
-    for searchpath in $bdbdirlist ''; do
-      test -n "${searchpath}" && searchpath="${searchpath}/"
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <${searchpath}db_cxx.h>
-      ]],[[
-        #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
-          #error "failed to find bdb 5.3+"
-        #endif
-      ]])],[
-        if test "x$bdbpath" = "xX"; then
-          bdbpath="${searchpath}"
-        fi
-      ],[
-        continue
-      ])
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <${searchpath}db_cxx.h>
-      ]],[[
-        #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
-          #error "failed to find bdb 5.3"
-        #endif
-      ]])],[
-        bdb53path="${searchpath}"
-        break
-      ],[])
-    done
-    if test "x$bdbpath" = "xX"; then
-      AC_MSG_RESULT([no])
-      AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
-    elif test "x$bdb53path" = "xX"; then
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
-        AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
-      ],[
-        AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
-      ])
-    else
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
-      bdbpath="${bdb53path}"
-    fi
+  fi
+
+  bdbpath=X
+  bdb53path=X
+
+  for searchpath in $bdbdirlist ''; do
+    test -n "${searchpath}" && searchpath="${searchpath}/"
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <${searchpath}db_cxx.h>
+    ]],[[
+      #if !((DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 3) || DB_VERSION_MAJOR > 5)
+        #error "failed to find bdb 5.3+"
+      #endif
+    ]])],[
+      if test "x$bdbpath" = "xX"; then
+        bdbpath="${searchpath}"
+      fi
+    ],[
+      continue
+    ])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <${searchpath}db_cxx.h>
+    ]],[[
+      #if !(DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR == 3)
+        #error "failed to find bdb 5.3"
+      #endif
+    ]])],[
+      bdb53path="${searchpath}"
+      break
+    ],[])
+  done
+  if test "x$bdbpath" = "xX"; then
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([libdb_cxx headers missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+  elif test "x$bdb53path" = "xX"; then
+    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
+    AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 5.3])],[
+      AC_MSG_WARN([Found Berkeley DB other than 5.3; wallets opened by this build will not be portable!])
+    ],[
+      AC_MSG_ERROR([Found Berkeley DB other than 5.3, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
+    ])
   else
+    BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb53path}],db_cxx)
+    bdbpath="${bdb53path}"
+  fi
+
+  dnl restore orgininal CPPFLAGS and fixate the now checked flags.
+  if test "x$BDB_CFLAGS" != "x"; then
+    CPPFLAGS="${TCFLAGS}"
     BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
+
   AC_SUBST(BDB_CPPFLAGS)
 
   if test "x$BDB_LIBS" = "x"; then
@@ -74,6 +87,13 @@ AC_DEFUN([BITCOIN_FIND_BDB53],[
     if test "x$BDB_LIBS" = "x"; then
         AC_MSG_ERROR([libdb_cxx missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
     fi
+  else
+    TLIBS="${LIBS}"
+    LIBS="${LIBS} ${BDB_LIBS}"
+    AC_SEARCH_LIBS([main],[],[],[
+        AC_MSG_ERROR([libdb_cxx missing, Dogecoin Core requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
+    ])
+    LIBS="${TLIBS}"
   fi
   AC_SUBST(BDB_LIBS)
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -652,8 +652,8 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         if test "x$use_bdb" != xno && $BREW list --versions berkeley-db5 >/dev/null && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
-           bdb_prefix=$($BREW --prefix berkeley-db5 2>/dev/null)
+         if test "x$use_bdb" != xno && $BREW list --versions berkeley-db@5 >/dev/null && test "x$BDB_CFLAGS" = "x" && test "x$BDB_LIBS" = "x"; then
+           bdb_prefix=$($BREW --prefix berkeley-db@5 2>/dev/null)
            dnl This must precede the call to BITCOIN_FIND_BDB53 below.
            BDB_CFLAGS="-I$bdb_prefix/include"
            BDB_LIBS="-L$bdb_prefix/lib -ldb_cxx-5.3"


### PR DESCRIPTION
Backport of #3308 into 1.21, fixes the detection of bdb 5.3 on systems that use brew

This is step 2b of #3349