### PR TITLE
Fix boost compatibility until 1.82

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -560,6 +560,7 @@ libbitcoin_util_a_SOURCES = \
   $(BITCOIN_CORE_H)
 
 if USE_LIBEVENT
+libbitcoin_util_a_CPPFLAGS += $(EVENT_CFLAGS)
 libbitcoin_util_a_SOURCES += util/url.cpp
 endif
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -138,7 +138,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # should raise rpc error if wallet path can't be created
         err_code = -4 if self.options.descriptors else -1
-        assert_raises_rpc_error(err_code, "boost::filesystem::create_directory:", self.nodes[0].createwallet, "w8/bad")
+        assert_raises_rpc_error(err_code, "boost::filesystem::create_director", self.nodes[0].createwallet, "w8/bad")
 
         # check that all requested wallets were created
         self.stop_node(0)


### PR DESCRIPTION
Fixes compatibility with boost until version 1.82:

- Explicitly add `EVENT_CFLAGS` to libbitcoin_util, because not all versions of boost will add this
- Fix a test assumption where the function that throws a directory not found error changed between boost 1.70 and 1.82 (changed in both 1.75 and 1.76)

This is item 2c from #3349 