### PR TITLE
ci: execute only one aarch64 experimental ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         name:
           - aarch64-linux
           - aarch64-linux-experimental
-          - aarch64-linux-sha512-experimental
           - armhf-linux
           - i686-linux
           - i686-win
@@ -79,19 +78,7 @@ jobs:
             check-security: true
             check-symbols: false
             dep-opts: "NO_QT=1"
-            config-opts: "--enable-experimental --with-armv8-crypto --enable-zmq --enable-glibc-back-compat LDFLAGS=-static-libstdc++"
-            goal: install
-          - name: aarch64-linux-sha512-experimental
-            host: aarch64-linux-gnu
-            os: ubuntu-20.04
-            packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
-            run-bench: false
-            test-script: |
-              qemu-aarch64 -E LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib/ /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 src/test/test_dogecoin
-            check-security: true
-            check-symbols: false
-            dep-opts: "NO_QT=1"
-            config-opts: "--enable-experimental --with-armv82-crypto --enable-zmq --enable-glibc-back-compat LDFLAGS=-static-libstdc++"
+            config-opts: "--enable-experimental --with-armv8-crypto --with-armv82-crypto --enable-zmq --enable-glibc-back-compat LDFLAGS=-static-libstdc++"
             goal: install
           - name: aarch64-linux
             host: aarch64-linux-gnu


### PR DESCRIPTION
For #2687, a separate CI job was created because bionic's gcc-7 didn't have sha512 intrinsics support. Now that we've moved to a focal build system, the experimental CI job for aarch64 can be ran as a single job again, just like the other experimental jobs.

See the discussion starting at https://github.com/dogecoin/dogecoin/pull/2687#issuecomment-983328362 for rationale.