### PR TITLE
policy: tune feerate estimator parameters

### DIFF
--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -169,26 +169,70 @@ public:
 /** Track confirm delays up to 25 blocks, can't estimate beyond that */
 static const unsigned int MAX_BLOCK_CONFIRMS = 25;
 
-/** Decay of .998 is a half-life of 346 blocks or about 2.4 days */
-static const double DEFAULT_DECAY = .998;
+/** Inverse rate of decay of statistical history
+ * Reduces all historical block stats by this multiplier, for each new block
+ *
+ * A value of 0.98845 corresponds to a half-life of 60 blocks or about 1 hour
+ *
+ * The calculation involves the rate constant for first order reactions, "ln 2",
+ * which is approximately 0.693: 1 - ( ln(2) / <t0.5> )
+ *
+ * Rationale: The mempool from hours ago should have only a light effect
+ * on estimates, to better deal with volatility.
+ */
+static const double DEFAULT_DECAY = 1.0 - (0.693 / 60.0); // 0.98845
 
-/** Require greater than 95% of X feerate transactions to be confirmed within Y blocks for X to be big enough */
-static const double MIN_SUCCESS_PCT = .95;
+/** Historical confidence level
+ * Determines validity of results based on the historical inclusion rate of
+ * transactions of this feerate
+ *
+ * Require greater than 80% of X feerate transactions to be confirmed within
+ * Y blocks for X to be big enough
+ *
+ * Rationale: More conservative than Bitcoin Core's 60% for "half" confidence,
+ * but less conservative than the 85% for "normal" confidence, because the
+ * Dogecoin miners have a hightened incentive to not orphan blocks while the
+ * impact of not being included in a block is only ~1/10th of Bitcoin's when
+ * expressed in time expired.
+ */
+static const double MIN_SUCCESS_PCT = .8;
 
-/** Require an avg of 1 tx in the combined feerate bucket per block to have stat significance */
-static const double SUFFICIENT_FEETXS = 1;
+/** Bucket significance in transactions per bucket
+ * Filters which ranges of feerates are significant enough to consider
+ *
+ * Require an avg of 1 tx in the combined feerate bucket per 10 blocks to have
+ * stat significance
+ *
+ * Rationale: Reduced this from 1 tx per feerate per block as lower values make
+ * more buckets relevant during periods of low transaction volume, uniform fee
+ * transaction surges (i.e. spam) or miners rapidly finding successive blocks
+ * while there are no transactions matching their feefilter
+ *
+ * Copied from Bitcoin Core 0.15-25.0
+ */
+static const double SUFFICIENT_FEETXS = 0.1;
 
-// Minimum and Maximum values for tracking feerates
-static constexpr double MIN_FEERATE = 10;
-static const double MAX_FEERATE = 1e7;
+// Minimum and Maximum values for tracking feerates, in koinu per kB
+static constexpr double MIN_FEERATE = COIN / 1000.0;  //!< 100,000 - equals 100 koinu per byte
+static const double MAX_FEERATE = COIN * 10.0;    //!< 1000,000,000 koinu - equals 10 DOGE/kb
+
+// Feerate and priority for the upper border of the highest bucket, in koinu per kB
 static const double INF_FEERATE = MAX_MONEY;
 static const double INF_PRIORITY = 1e9 * MAX_MONEY;
 
-// We have to lump transactions into buckets based on feerate, but we want to be able
-// to give accurate estimates over a large range of potential feerates
-// Therefore it makes sense to exponentially space the buckets
-/** Spacing of FeeRate buckets */
-static const double FEE_SPACING = 1.1;
+/** Spacing of FeeRate buckets
+ * Determines the (exponential) granularity of the fee buckets
+ *
+ * We have to lump transactions into buckets based on feerate, but we want to be
+ * able to give accurate estimates over a large range of potential feerates
+ * Therefore it makes sense to exponentially space the buckets
+ *
+ * Rationale: previously, spacing was 1.1; we reduce this to 1.05 to have finer
+ * grained buckets
+ *
+ * Copied from Bitcoin Core 0.15-25.0
+ */
+static const double FEE_SPACING = 1.05;
 
 /**
  *  We want to be able to estimate feerates that are needed on tx's to be included in

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -16,10 +16,10 @@ BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {
-    CTxMemPool mpool(CFeeRate(1000));
+    CTxMemPool mpool(CFeeRate(100000));
     TestMemPoolEntryHelper entry;
-    CAmount basefee(2000);
-    CAmount deltaFee(100);
+    CAmount basefee(200000);
+    CAmount deltaFee(100); // error margin for feerate tests
     std::vector<CAmount> feeV;
 
     // Populate vectors of increasing fees
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     int blocknum = 0;
 
     // Loop through 200 blocks
-    // At a decay .998 and 4 fee transactions per block
-    // This makes the tx count about 1.33 per bucket, above the 1 threshold
+    // At a decay .98845 and 4 fee transactions per block
+    // This makes the tx count about 0.39 per bucket, above the 0.1 threshold
     while (blocknum < 200) {
         for (int j = 0; j < 10; j++) { // For each fee
             for (int k = 0; k < 4; k++) { // add 4 fee txs
@@ -74,20 +74,12 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         }
         mpool.removeForBlock(block, ++blocknum);
         block.clear();
-        if (blocknum == 30) {
-            // At this point we should need to combine 5 buckets to get enough data points
-            // So estimateFee(1,2,3) should fail and estimateFee(4) should return somewhere around
-            // 8*baserate.  estimateFee(4) %'s are 100,100,100,100,90 = average 98%
-            BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(2) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(3) == CFeeRate(0));
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() < 8*baseRate.GetFeePerK() + deltaFee);
-            BOOST_CHECK(mpool.estimateFee(4).GetFeePerK() > 8*baseRate.GetFeePerK() - deltaFee);
-            int answerFound;
-            BOOST_CHECK(mpool.estimateSmartFee(1, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(3, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(4, &answerFound) == mpool.estimateFee(4) && answerFound == 4);
-            BOOST_CHECK(mpool.estimateSmartFee(8, &answerFound) == mpool.estimateFee(8) && answerFound == 8);
+        if (blocknum == 3) {
+            // At this point we should need to combine 2 buckets to get enough data points
+            // So estimateFee(2) should return somewhere around 9*baserate.
+            // estimateFee(2) %'s are 100,100,90 = average 97%
+            BOOST_CHECK(mpool.estimateFee(2).GetFeePerK() < 9*baseRate.GetFeePerK() + deltaFee);
+            BOOST_CHECK(mpool.estimateFee(2).GetFeePerK() > 9*baseRate.GetFeePerK() - deltaFee);
         }
     }
 
@@ -97,14 +89,14 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // third highest feerate is 8*base rate, and gets in 8/10 blocks = 80%,
     // so estimateFee(1) would return 10*baseRate but is hardcoded to return failure
     // Second highest feerate has 100% chance of being included by 2 blocks,
-    // so estimateFee(2) should return 9*baseRate etc...
-    for (int i = 1; i < 10;i++) {
+    // thus at 80% confidence, estimateFee(2) should return 8*baseRate etc...
+    for (int i = 1; i < 8;i++) {
         origFeeEst.push_back(mpool.estimateFee(i).GetFeePerK());
         if (i > 2) { // Fee estimates should be monotonically decreasing
             BOOST_CHECK(origFeeEst[i-1] <= origFeeEst[i-2]);
         }
-        int mult = 11-i;
-        if (i > 1) {
+        int mult = 9-i;
+        if (i > 1 && i < 8) {
             BOOST_CHECK(origFeeEst[i-1] < mult*baseRate.GetFeePerK() + deltaFee);
             BOOST_CHECK(origFeeEst[i-1] > mult*baseRate.GetFeePerK() - deltaFee);
         }
@@ -119,7 +111,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         mpool.removeForBlock(block, ++blocknum);
 
     BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-    for (int i = 2; i < 10;i++) {
+    for (int i = 2; i < 8;i++) {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
     }
@@ -140,7 +132,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     }
 
     int answerFound;
-    for (int i = 1; i < 10;i++) {
+    for (int i = 1; i < 8;i++) {
         BOOST_CHECK(mpool.estimateFee(i) == CFeeRate(0) || mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
         BOOST_CHECK(mpool.estimateSmartFee(i, &answerFound).GetFeePerK() > origFeeEst[answerFound-1] - deltaFee);
     }
@@ -158,7 +150,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     mpool.removeForBlock(block, 265);
     block.clear();
     BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-    for (int i = 2; i < 10;i++) {
+    for (int i = 2; i < 8;i++) {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
     }
 
@@ -180,7 +172,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         block.clear();
     }
     BOOST_CHECK(mpool.estimateFee(1) == CFeeRate(0));
-    for (int i = 2; i < 10; i++) {
+    for (int i = 2; i < 8; i++) {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
     }
 


### PR DESCRIPTION
Changes the static parameters used in `CBlockPolicyEstimator` to support the Dogecoin network, inspired by changes made in Bitcoin Core 0.15, and field-tested to survive and recover from peak inflow of transactions.

In addition to changing the parameters:

- documented each changed parameter and the rationale in-line
- changed the fee estimator tests to take into account the new configuration. Note that only 8 buckets can be tested on a set of 10, when confidence is set to 80%

#### 1. Changes the decay rate of statistical history from a half-life of 346 blocks to a half-life of 60 blocks. (`DEFAULT_DECAY`)

This means that the weight of previous block feerate stats on the current fee estimates becomes smaller, and more recent block results weigh heavier, so that the estimates react faster to temporary peaks.

Weight:

age | previous |   now
:-: | -----: | -----:
1h  |    0.887 | 0.498
2h  |    0.786 | 0.248
3h  |    0.697 | 0.124
4h  |    0.618 | 0.062
5h  |    0.548 | 0.031
7h  |    0.431 | 0.008
10h |    0.301 | 0.001
24h |    0.056 | 0.001

#### 2. Changes the historical confidence level (the percentage of transactions included at a certain level) from 95% to 80%. (`MIN_SUCCESS_PCT`)

This lowers the successful inclusion rate because miners in the Dogecoin ecosystem tune mempool policy for orphan prevention more than transaction inclusion (because subsidy > fees). This negatively impacts the precision of the estimate, but with 10% of empty blocks and at least 2 orders of magnitude difference between miner enforced minimum fee rates, higher precision will cause extremely high feerate estimate, yet still have low effectivity rates. The value was picked by taking Bitcoin Core's half-confidence of 60% used for 24-block half-time, and standard confidence of 85% and picking a workable value between those.

#### 3. Decreases the number of transactions per bucket required to consider a feerate valid from 1 to 0.1 (`SUFFICIENT_FEETXS`)

This makes more buckets relevant while filtering for fees to consider and offsets the more rapid half-life from point 1, as we still want to consider a feerate included with a single transaction 10 blocks ago, yet because of decay would not be sufficient for inclusion (because effective relevance would be 0.89 with the new parametrization). Value taken from Bitcoin Core because it's been the default there for v0.15 until v25.0

#### 4. Set the minimum and maximum feerates to be considered in line with default mempool policies: min `0.001 DOGE/kB` and max `10 DOGE/kB` (`MIN_FEERATE`, `MAX_FEERATE`)

This is copied 1-on-1 from an earlier attempt by Ross that needed further work (see #2564) - i.e. this work.

#### 5. Lowers the spacing inside feerate buckets from exponent 1.1 to 1.05 (`FEE_SPACING`)

This increases the granularity of the buckets and is copied directly from Bitcoin Core, where this has been the parameter from v0.15 until v25.0

-----

Testers:

- You'll need to backup and remove your `<datadir>/fee_estimates.dat` file for the new parametrization to fully take effect. I will address automation of this in a followup PR when I make these default values operator-configurable.
- Thanks to the more rapid half-life, after 12 hours (720 blocks) of uptime with these parameters, your estimation should have fully adapted to a situation where it would be negligibly different from a node that has been running for more than 12 hours.