### PR TITLE
Disable BIP-70 payment server by default

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -373,6 +373,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-discover", _("Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)"));
     strUsage += HelpMessageOpt("-dns", _("Allow DNS lookups for -addnode, -seednode and -connect") + " " + strprintf(_("(default: %u)"), DEFAULT_NAME_LOOKUP));
     strUsage += HelpMessageOpt("-dnsseed", _("Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect/-noconnect)"));
+    strUsage += HelpMessageOpt("-enable-bip70", _("Enable BIP-70 PaymentServer (default: 0)"));
     strUsage += HelpMessageOpt("-externalip=<ip>", _("Specify your own public address"));
     strUsage += HelpMessageOpt("-forcednsseed", strprintf(_("Always query for peer addresses via DNS lookup (default: %u)"), DEFAULT_FORCEDNSSEED));
     strUsage += HelpMessageOpt("-listen", _("Accept connections from outside (default: 1 if no -proxy or -connect/-noconnect)"));

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -73,7 +73,9 @@ public:
 
     // parent should be QApplication object
     PaymentServer(QObject* parent, bool startLocalServer = true);
+    PaymentServer(QObject* parent, bool startLocalServer = true, bool enableBip70Flag = false);
     PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer = true);
+    PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer = true, bool enableBip70Flag = false);
     ~PaymentServer();
 
     // Load root certificate authorities. Pass NULL (default)
@@ -140,7 +142,8 @@ private:
 
     bool saveURIs;                      // true during startup
 
-    void initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer);
+    void initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer, bool enableBip70Flag);
+    bool enableBip70;                   // false by default
     QLocalServer* uriServer;
 
     QNetworkAccessManager* netManager;  // Used to fetch payment requests

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -67,7 +67,7 @@ void PaymentServerTests::paymentServerTests()
 {
     SelectParams(CBaseChainParams::MAIN);
     OptionsModel optionsModel;
-    PaymentServer* server = new PaymentServer(NULL, QString("testIPCServer"), false);
+    PaymentServer* server = new PaymentServer(NULL, QString("testIPCServer"), false, true);
     X509_STORE* caStore = X509_STORE_new();
     X509_STORE_add_cert(caStore, parse_b64der_cert(caCert1_BASE64));
     PaymentServer::LoadRootCAs(caStore);


### PR DESCRIPTION
This commit adds a configuration option, `enable-bip70`, to enable this feature. Only enable this if you know what you're doing.

Please note that BIP-21 payment links continue to work.