### PR TITLE
Add NotoSans font to Qt makefile includes

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -380,7 +380,11 @@ RES_FONTS = \
   qt/res/fonts/ComicNeue-Light-Oblique.ttf \
   qt/res/fonts/ComicNeue-Light.ttf \
   qt/res/fonts/ComicNeue-Regular-Oblique.ttf \
-  qt/res/fonts/ComicNeue-Regular.ttf
+  qt/res/fonts/ComicNeue-Regular.ttf \
+  qt/res/fonts/NotoSans-Bold.ttf \
+  qt/res/fonts/NotoSans-Light.ttf \
+  qt/res/fonts/NotoSans-Medium.ttf \
+  qt/res/fonts/NotoSans-Regular.ttf
 
 BITCOIN_RC = qt/res/bitcoin-qt-res.rc
 


### PR DESCRIPTION
Follow-up from PR #2676, attempts to address error in #3415.