### PR TITLE
Fix two QT payment server warnings

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -460,7 +460,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
               return;
             }
             QByteArray temp;
-            temp.append(uri.queryItemValue("r"));
+            temp.append(uri.queryItemValue("r").toUtf8());
             QString decoded = QUrl::fromPercentEncoding(temp);
             QUrl fetchUrl(decoded, QUrl::StrictMode);
 
@@ -716,7 +716,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
         }
     }
 
-    int length = payment.ByteSize();
+    quint64 length = payment.ByteSizeLong();
     netRequest.setHeader(QNetworkRequest::ContentLengthHeader, length);
     QByteArray serData(length, '\0');
     if (payment.SerializeToArray(serData.data(), length)) {


### PR DESCRIPTION
This code cleans up two warnings about deprecated functions and removes another case of using a signed integer for a network request length.

I don't think this needs to block 1.14.7; I noticed it while running builds and thought it was worth filing anyhow.