### PR TITLE
qt: fix qt4 compile error

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -87,7 +87,12 @@ static QString ipcServerName()
     // Note that GetDataDir(true) returns a different path
     // for -testnet versus main net
     QString ddir(GUIUtil::boostPathToQString(GetDataDir(true)));
+#if QT_VERSION >= 0x050000
     name.append(QString::number(qHash(ddir, IPC_SOCKET_HASH)));
+#else
+    QString rseed = QString::number(IPC_SOCKET_HASH);
+    name.append(QString::number(qHash(rseed + ddir + rseed)));
+#endif //QT_VERSION >= 0x050000
 
     return name;
 }


### PR DESCRIPTION
Found an issue with qt4 while testing "exotic" builds.

#3037 introduced a compile error on qt4 because `qHash` only takes a second `int` argument from qt5 forward. This fixes that issue by converting the random seed into a string and both prepending and appending the seed to the `datadir` name whenever compiling on qt4.

Although it makes of course no sense to do a security fix for builds using qt4, this fix is small and it helps people that only have qt4 to still be able to get all the other security fixes. We can easily remove qt4 support in the next major version.

The qt4 build on `1.14.7-dev` (ad6a62b7) fails with:

```
qt/paymentserver.cpp: In function 'QString ipcServerName()':
qt/paymentserver.cpp:90:60: error: no matching function for call to 'qHash(QString&, const int&)'
     name.append(QString::number(qHash(ddir, IPC_SOCKET_HASH)));
                                                        ^
In file included from /usr/include/qt4/QtCore/qvariant.h:50,
                 from /usr/include/qt4/QtCore/qabstractitemmodel.h:45,
                 from /usr/include/qt4/QtCore/QAbstractListModel:1,
                 from qt/bitcoinunits.h:11,
                 from qt/paymentserver.cpp:8:
```

-----

Dockerfile to build a qt4 dogecoin-qt with (change `MAKEOPTS` to reflect your system), can be used to confirm the issue and confirm the fix.

```Dockerfile
FROM debian:10
WORKDIR /build
ARG MAKEOPTS=-j8

RUN apt-get update \
 && apt-get install -y build-essential libtool autotools-dev automake \
            pkg-config libssl-dev libevent-dev bsdmainutils libqt4-dev \
            qt4-default libboost-system-dev libboost-filesystem-dev \
            libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
            libboost-thread-dev libprotobuf-dev protobuf-compiler \
            libqrencode-dev libdb5.3++-dev libdb5.3++ libdb5.3-dev

COPY . .

RUN ./autogen.sh \
 && ./configure --with-gui=qt4 \
 && make ${MAKEOPTS}
```
