### PR TITLE
[QA] Check command-line arguments for test runner

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -222,6 +222,10 @@ def runtests():
             if t in opts or re.sub(".py$", "", t) in opts:
                 test_list.append(t)
 
+    if len(test_list) == 0:
+        print(f"No tests selected; do you have a typo in {opts}?")
+        sys.exit(1)
+
     if print_help:
         # Only print help of the first script and exit
         subprocess.check_call((RPC_TESTS_DIR + test_list[0]).split() + ['-h'])


### PR DESCRIPTION
Before this change, if you made a typo such as `-parellel-8` when trying to run tests, you'd get a backtrace that's difficult to interpret. With this change, you'll get a better error message and a non-zero exit code.