### PR TITLE
Minor update bitcoin_ko_KR.ts

### DIFF
--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -1771,13 +1771,17 @@ p, li { white-space: pre-wrap; }
         <source>BIP70 payment requests are deprecated and disabled by default. Restart with -enable-bip70 if you absolutely have to use this functionality.
 
 Use this functionality with extreme caution.</source>
-        <translation type="unfinished"></translation>
+        <translation>BIP70 지불 요청은 지원 종료 되었으며 기본적으로 비활성화 되어 있습니다. 꼭 해당 기능 이용해야 한다면 -enable-bip70 옵션을 추가해 재시작하기 바랍니다.
+
+해당 기능 사용시 매우 주의하기 바랍니다</translation>
     </message>
     <message>
         <source>Payment request file handling is disabled by default. Restart with -enable-bip70 if you absolutely have to use this functionality.
 
 Use this functionality with extreme caution.</source>
-        <translation type="unfinished"></translation>
+        <translation>지불 요청 파일 처리는 기본적으로 비활성화 되어 있습니다. 꼭 해당 기능 이용해야 한다면 -enable-bip70 옵션을 추가해 재시작하기 바랍니다.
+
+해당 기능 사용시 매우 주의하기 바랍니다</translation>
     </message>
 </context>
 <context>
@@ -2735,7 +2739,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 satoshis in fee, while &quot;total at least&quot; pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation>사용자 정의 수수료가 1000 사토시로 설정되고 트랜잭션이 250바이트에 불과한 경우 &quot;킬로바이트당&quot; &quot;최소한 합계&quot;는 수수료로 250사토시만 지불합니다. 1000사토시를 지불합니다. 1킬로바이트보다 큰 트랜잭션의 경우 둘 다 킬로바이트 단위로 지불합니다.</translation>
+        <translation>사용자 정의 수수료가 1000 사토시로 설정되고 트랜잭션이 250바이트에 불과한 경우 &quot;킬로바이트당&quot; 수수료로 250사토시만 지불하며, &quot;최소한 합계&quot; 는 1000사토시를 지불합니다. 1킬로바이트보다 큰 트랜잭션의 경우 둘 다 킬로바이트 단위로 지불합니다.</translation>
     </message>
     <message>
         <source>Priority:</source>
@@ -2759,7 +2763,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>If the custom fee is set to 1000 koinu and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 koinu in fee, while &quot;total at least&quot; pays 1000 koinu. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 정의 수수료가 1000 코이누로 설정되고 트랜잭션이 250바이트에 불과한 경우 &quot;킬로바이트당&quot; 수수료로 250코이누만 지불하며 &quot;최소한 합계&quot; 는 1000코이누를 지불합니다. 1킬로바이트보다 큰 트랜잭션의 경우 둘 다 킬로바이트 단위로 지불합니다.</translation>
     </message>
 </context>
 <context>
@@ -4571,11 +4575,11 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID, %i with block height, with a value of 0 if tx is no longer in chaintip)</source>
-        <translation type="unfinished"></translation>
+        <translation>지갑 트랜잭션 변화시 명령 실행 (명령 안의 %s는 TxID, %i 는 블록높이로 변경되며 트랜잭션이 더 이상 chaintip 안이 아닌 경우에는 0으로 대체됩니다)</translation>
     </message>
     <message>
         <source>Enable BIP-70 PaymentServer (default: 0)</source>
-        <translation type="unfinished"></translation>
+        <translation>BIP-70 PaymentServer 활성화 (기본값: 0)</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
not a programmer, unable to test run the results of my translation
translated new? untranslated lines 1773, 1779, 2761, 4573, 4577, i dont believe there are any more untranslated lines
in the case of line 2761 reused identical line 2737 translation with minor update to replace satoshi with koinu for 2761 translation and both to make more sense.
assumed for line 4573 that %s and %i would print as %s and %i instead of being replaced by a string or integer