### PR TITLE
policy: only load fee_estimates.dat from 1.14.7 and later

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -909,6 +909,16 @@ CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
         filein >> nVersionRequired >> nVersionThatWrote;
         if (nVersionRequired > CLIENT_VERSION)
             return error("CTxMemPool::ReadFeeEstimates(): up-version (%d) fee estimate file", nVersionRequired);
+
+        /* From 1.14.7, only accept fee estimate files created by a version equal to or higher than the
+         * minimum writer version.
+         *
+         * If in the future any of the MIN_FEERATE, MAX_FEERATE or FEE_SPACING in policy/fees.h change,
+         * or these values become configurable, this logic will need to be adapted. */
+        if (nVersionThatWrote < FEEFILE_MIN_COMPAT_VERSION_WRITER) {
+            return error("CTxMemPool::ReadFeeEstimates(): cannot re-use fee estimate files from version %d, ignoring file (non-fatal)", nVersionThatWrote);
+        }
+
         LOCK(cs);
         minerPolicyEstimator->Read(filein, nVersionThatWrote);
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -890,7 +890,7 @@ CTxMemPool::WriteFeeEstimates(CAutoFile& fileout) const
 {
     try {
         LOCK(cs);
-        fileout << 139900; // version required to read: 0.13.99 or later
+        fileout << FEEFILE_MIN_BACKCOMPAT_VERSION;
         fileout << CLIENT_VERSION; // version that wrote the file
         minerPolicyEstimator->Write(fileout);
     }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -34,7 +34,15 @@ class CBlockIndex;
 /** Minimum client version required to read fee_estimates.dat
  * Clients with a lower version than this should ignore the file
  */
-static const int FEEFILE_MIN_BACKCOMPAT_VERSION = 139900; // 0.13.99.0
+static const int FEEFILE_MIN_BACKCOMPAT_VERSION = 1140700; // 1.14.7.0
+
+/** Minimum client version required to read fee_estimates.dat
+ * Files created with a lower version than this are ignored
+ *
+ * Due to bucket spacing and min/max changes in 1.14.7, set this
+ * to 1.14.7.0 exactly.
+ */
+static const int FEEFILE_MIN_COMPAT_VERSION_WRITER = 1140700; // 1.14.7.0
 
 inline double AllowFreeThreshold()
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -31,6 +31,11 @@
 class CAutoFile;
 class CBlockIndex;
 
+/** Minimum client version required to read fee_estimates.dat
+ * Clients with a lower version than this should ignore the file
+ */
+static const int FEEFILE_MIN_BACKCOMPAT_VERSION = 139900; // 0.13.99.0
+
 inline double AllowFreeThreshold()
 {
     return COIN * 144 / 250;


### PR DESCRIPTION
This PR addresses the caveat of having to manually remove `fee_estimates.dat` from the datadir to fully benefit from the improved estimator parametrization (#3389) for most deployments. 

The only deployments that will still need to manually remove the file are:

- Deployments of 1.14.7-dev ~~that didn't re-use the file created with an earlier version~~
- Customized forks that changed the version number to be higher than `1140700`

Note: using the client version number for file format versioning is suboptimal - this causes the above exceptions to automated detection. [Upstream knows this too but chose to not change it when they did something similar to what we're doing now](https://github.com/bitcoin/bitcoin/pull/10199#discussion_r115555345). I had addressed this in my planned follow-up to #3389 that makes parametrization user-configurable, but I feel that doing it now is too risky due to time constraints, so let's do a proper fix for this when we need it, i.e. when we fix configurability of these parameters in a next version, because that would require many more checks to decide whether to re-use historical estimates anyway.

----

To test: 

1. Run a 1.14.6 client on a separate datadir (regtest) and feed it some transactions and blocks
2. Shut it down, check that it saved `fee_estimates.dat`
3. Compile and run this PR on the same datadir
4. During initialization, a non-fatal error message must appear in `debug.log`:

```
ERROR: CTxMemPool::ReadFeeEstimates(): cannot re-use fee estimate files from version 1140600, ignoring file (non-fatal)
```

5. Feed it some transactions and blocks and shut it down, check that it saved a new `fee_estimates.dat`
6. Run 1.14.6 again on the same datadir
7. During initialization, a non-fatal error message must appear in `debug.log`:

```
CTxMemPool::ReadFeeEstimates(): up-version (1140700) fee estimate file
```