### PR TITLE
doc: update debian/copyright

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -1,14 +1,12 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Bitcoin
-Upstream-Contact: Satoshi Nakamoto <satoshin@gmx.com>
- irc://#bitcoin@freenode.net
-Source: https://github.com/bitcoin/bitcoin
+Upstream-Name: Dogecoin Core
+Source: https://github.com/dogecoin/dogecoin
 
 Files: *
-Copyright: 2009-2017, Bitcoin Core Developers
+Copyright: 2009-2024, Bitcoin Core and Dogecoin Core Developers
 License: Expat
-Comment: The Bitcoin Core Developers encompasses the current developers listed on bitcoin.org,
-         as well as the numerous contributors to the project.
+Comment: The Bitcoin Core and Dogecoin Core Developers encompasses all
+         contributors to the project, listed in the release notes or the git log
 
 Files: debian/*
 Copyright: 2010-2011, Jonas Smedegaard <dr@jones.dk>
@@ -85,6 +83,11 @@ Copyright: Bitboy, Jonas Schnelli
 License: public-domain
 Comment: Site: https://bitcointalk.org/?topic=1756.0
 
+Files: src/crypto/scrypt*
+Copyright: 2009 Colin Percival
+           2011 ArtForz
+           2012-2013 pooler
+License: tarsnap
 
 License: Expat
  Permission is hereby granted, free of charge, to any person obtaining a
@@ -136,3 +139,30 @@ Comment:
 
 License: public-domain
  This work is in the public domain.
+
+License: tarsnap
+ All rights reserved.
+ .
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ SUCH DAMAGE.
+ .
+ This file was originally written by Colin Percival as part of the Tarsnap
+ online backup system.


### PR DESCRIPTION
Updates the debian/copyright file. I intended to update with OFL text, but after re-reading, it turns out that this actually isn't required per OFL guidelines for packaging non-mobile apps.

However, I saw that we didn't add the scrypt license text here yet, so I've added that. 

We've also never updated the definition of "Bitcoin Core and Dogecoin Core developers" as defined in `configure.ac`, so I fixed that while I was touching it. I've made the definition similar to the current text at Bitcoin Core, so that there is no conflict with work we backport. See: https://github.com/bitcoin/bitcoin/blob/master/contrib/debian/copyright