### PR TITLE
bench: iwyu cleanup on non-test sources

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -3,11 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bench.h"
-#include "perf.h"
 
-#include <iostream>
-#include <iomanip>
-#include <sys/time.h>
+#include <cstddef>     // for NULL
+#include <sys/time.h>  // for gettimeofday, timeval
+#include <iomanip>     // for operator<<, setprecision
+#include <iostream>    // for operator<<, basic_ostream
+#include <utility>     // for pair, make_pair
+
+#include "perf.h"      // for perf_cpucycles, perf_fini, perf_init
 
 benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
     static std::map<std::string, benchmark::BenchFunction> benchmarks_map;

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,12 +5,15 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
-#include <map>
-#include <string>
+#include <cstdint>                               // for uint64_t
 
-#include <boost/function.hpp>
-#include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/stringize.hpp>
+#include <boost/function.hpp>                    // for function
+#include <boost/preprocessor/cat.hpp>            // for BOOST_PP_CAT
+#include <boost/preprocessor/stringize.hpp>      // for BOOST_PP_STRINGIZE
+
+#include <limits>                                // for numeric_limits
+#include <map>                                   // for map
+#include <string>                                // for string
 
 // Simple micro-benchmarking framework; API mostly matches a subset of the Google Benchmark
 // framework (see https://github.com/google/benchmark)

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -2,11 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "bench.h"
-
-#include "key.h"
-#include "validation.h"
-#include "util.h"
+#include "bench.h"  // for BenchRunner
+#include "key.h"    // for ECC_Start, ECC_Stop
+#include "util.h"   // for SetupEnvironment, fPrintToDebugLog
 
 int
 main(int argc, char** argv)


### PR DESCRIPTION
Attempts to fix #3454 by somewhat listening to [iwyu](https://include-what-you-use.org) to report what includes were missed for the types used, in `src/bench`, and only for non-test sources (i.e. the generic framework)

Needs to be tested against a couple of boost versions:
- [x] 1.60, this is the version we list as minimum, but this doesn't have to be blocking if it doesn't work, as we're on a major version now
- [x] 1.74, this is the default on current Ubuntu LTS 
- [x] 1.82, this is the last known version of boost to work without patches
- [x] 1.84, this is the version that reported a bug against the code