### PR TITLE
build: allow c++14 standard to be used for compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,21 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+
+AC_ARG_ENABLE([c++14],
+  [AS_HELP_STRING([--enable-c++14],
+  [enable compilation in c++14 mode (disabled by default)])],
+  [use_cxx14=$enableval],
+  [use_cxx14=no])
+
+dnl Require C++11 or C++14 compiler (no GNU extensions)
+if test "x$use_cxx14" = xyes; then
+  AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
+else
+  AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+fi
+
+
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 


### PR DESCRIPTION
This will allow testing the codebase against newer standards and increase compatibility with newer dependencies. Test it with `--enable-c++14`.

I think that `c++14` should only be a step towards `c++17`, but that's a bigger change, so I figured doing the small step first. This compiles for me with gcc-11 - but has to be tested on all the gcc-9 cross compilers too. Doesn't need a gitian check, because we're not changing the default, which stays safely at `c++11`.