### PR TITLE
Fix: depends fail to build, bump expat version

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.5.0
+$(package)_version=2.6.2
 $(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67
+$(package)_sha256_hash=9C7C1B5DCBC3C237C500A8FB1493E14D9582146DD9B42AA8D3FFB856A3B927E0
 
 define $(package)_config_cmds
   $($(package)_autoconf)


### PR DESCRIPTION
2.5.0 version of expat has a vulnerability in it and it is recommended to use 2.6.2 as seen in the file names on the download page.

https://sourceforge.net/projects/expat/files/expat/2.5.0/