### PR TITLE
net: make IteratorComparator's operator const

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -43,7 +43,7 @@ std::atomic<int64_t> nTimeBestReceived(0); // Used only to inform the wallet of 
 struct IteratorComparator
 {
     template<typename I>
-    bool operator()(const I& a, const I& b)
+    bool operator()(const I& a, const I& b) const
     {
         return &(*a) < &(*b);
     }


### PR DESCRIPTION
Although this is okay to be sloppy with operator constness on c++11/14, it is not okay when using c++17. 

See: https://cplusplus.github.io/LWG/issue2542

The full error when compiling with c++17 is:

```console
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tree.h:771:4: error: static_assert failed due to requirement 'is_invocable_v<const IteratorComparator &, const std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>> &, const std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>> &>' "comparison object must be invocable as const"
          static_assert(
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tree.h:2119:41: note: in instantiation of member function 'std::_Rb_tree<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Identity<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>>, IteratorComparator>::_S_key' requested here
          __comp = _M_impl._M_key_compare(__k, _S_key(__x));
                                               ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tree.h:2172:4: note: in instantiation of member function 'std::_Rb_tree<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Identity<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>>, IteratorComparator>::_M_get_insert_unique_pos' requested here
        = _M_get_insert_unique_pos(_KeyOfValue()(__v));
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_set.h:512:9: note: in instantiation of function template specialization 'std::_Rb_tree<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, std::_Identity<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>>, IteratorComparator>::_M_insert_unique<const std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>> &>' requested here
          _M_t._M_insert_unique(__x);
               ^
net_processing.cpp:781:51: note: in instantiation of member function 'std::set<std::_Rb_tree_iterator<std::pair<const uint256, COrphanTx>>, IteratorComparator>::insert' requested here
        mapOrphanTransactionsByPrev[txin.prevout].insert(ret.first);
```