### PR TITLE
backport: Add perf counter data to GetStrongRandBytes state in scheduler 

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -129,6 +129,26 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+static std::mutex cs_rng_state;
+static unsigned char rng_state[32] = {0};
+static uint64_t rng_counter = 0;
+
+static void AddDataToRng(void* data, size_t len) {
+    CSHA512 hasher;
+    hasher.Write((const unsigned char*)&len, sizeof(len));
+    hasher.Write((const unsigned char*)data, len);
+    unsigned char buf[64];
+    {
+        std::unique_lock<std::mutex> lock(cs_rng_state);
+        hasher.Write(rng_state, sizeof(rng_state));
+        hasher.Write((const unsigned char*)&rng_counter, sizeof(rng_counter));
+        ++rng_counter;
+        hasher.Finalize(buf);
+        memcpy(rng_state, buf + 32, 32);
+    }
+    memory_cleanse(buf, 64);
+}
+
 void GetStrongRandBytes(unsigned char* out, int num)
 {
     assert(num <= 32);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -14,8 +14,11 @@
 #include "util.h"             // for LogPrint()
 #include "utilstrencodings.h" // for GetTime()
 
+#include <mutex>
 #include <stdlib.h>
 #include <limits>
+#include <chrono>
+#include <thread>
 
 #ifndef WIN32
 #include <sys/time.h>
@@ -128,6 +131,23 @@ void GetRandBytes(unsigned char* buf, int num)
         RandFailure();
     }
 }
+
+static void AddDataToRng(void* data, size_t len);
+
+void RandAddSeedSleep()
+{
+    int64_t nPerfCounter1 = GetPerformanceCounter();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    int64_t nPerfCounter2 = GetPerformanceCounter();
+
+    // Combine with and update state
+    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1));
+    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2));
+
+    memory_cleanse(&nPerfCounter1, sizeof(nPerfCounter1));
+    memory_cleanse(&nPerfCounter2, sizeof(nPerfCounter2));
+}
+
 
 static std::mutex cs_rng_state;
 static unsigned char rng_state[32] = {0};

--- a/src/random.h
+++ b/src/random.h
@@ -22,6 +22,13 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
+ * Add a little bit of randomness to the output of GetStrongRangBytes.
+ * This sleeps for a millisecond, so should only be called when there is
+ * no other work to be done.
+ */
+void RandAddSeedSleep();
+
+/**
  * Function to gather random data from multiple sources, failing whenever any
  * of those source fail to provide a result.
  */

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -5,6 +5,7 @@
 
 #include "scheduler.h"
 
+#include "random.h"
 #include "reverselock.h"
 
 #include <assert.h>
@@ -38,6 +39,11 @@ void CScheduler::serviceQueue()
     // is called.
     while (!shouldStop()) {
         try {
+            if (!shouldStop() && taskQueue.empty()) {
+                reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+                // Use this chance to get a tiny bit more entropy
+                RandAddSeedSleep();
+            }
             while (!shouldStop() && taskQueue.empty()) {
                 // Wait until there is something to do.
                 newTaskScheduled.wait(lock);


### PR DESCRIPTION
This is an intermediate step in regards to updating the code base prior to integration of #3229. Note it should most likely be added prior to #3487.

EDIT: These commits add an internal method to add new random data to our internal random number generator state (`AddDataToRng`) and adds performance counter data to that state (`RandAddSeedSleep`) within the `CScheduler::serviceQueue`. As discussed below, these commits are eventually removed.