### PR TITLE
rpc: add uptime (backport) 

### DIFF
--- a/doc/rpc-maturity.md
+++ b/doc/rpc-maturity.md
@@ -119,6 +119,7 @@ Core RPC. Maturity is expressed over 3 stages:
 | stop                   | STABLE     |                                            |
 | submitauxblock         | STABLE     |                                            |
 | submitblock            | STABLE     |                                            |
+| uptime                 | STABLE     | Introduced in 1.15.0                       |
 | validateaddress        | STABLE     |                                            |
 | verifychain            | STABLE     |                                            |
 | verifymessage          | STABLE     |                                            |

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -179,6 +179,7 @@ testScripts = [
     'getblockstats.py',
     'addnode.py',
     'getmocktime.py',
+    'uptime.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/uptime.py
+++ b/qa/rpc-tests/uptime.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC call related to the uptime command.
+
+Test corresponds to code in rpc/server.cpp.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class UptimeTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def setup_network(self):
+        self.nodes = self.setup_nodes()
+
+    def run_test(self):
+        self._test_uptime()
+
+    def _test_uptime(self):
+        wait_time = 10
+        self.nodes[0].setmocktime(int(time.time() + wait_time))
+        assert(self.nodes[0].uptime() >= wait_time)
+
+
+if __name__ == '__main__':
+    UptimeTest().main()

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -28,7 +28,6 @@
 
 class CBlockIndex;
 
-static const int64_t nClientStartupTime = GetTime();
 static int64_t nLastHeaderTipUpdateNotification = 0;
 static int64_t nLastBlockTipUpdateNotification = 0;
 
@@ -240,7 +239,7 @@ bool ClientModel::isReleaseVersion() const
 
 QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime).toString();
+    return QDateTime::fromTime_t(GetStartupTime()).toString();
 }
 
 QString ClientModel::dataDir() const

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -277,6 +277,22 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     return "Dogecoin server stopping";
 }
 
+UniValue uptime(const JSONRPCRequest& jsonRequest)
+{
+    if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
+        throw std::runtime_error(
+                "uptime\n"
+                        "\nReturns the total uptime of the server.\n"
+                        "\nResult:\n"
+                        "ttt        (numeric) The number of seconds that the server has been running\n"
+                        "\nExamples:\n"
+                + HelpExampleCli("uptime", "")
+                + HelpExampleRpc("uptime", "")
+        );
+
+    return GetTime() - GetStartupTime();
+}
+
 /**
  * Call Table
  */
@@ -286,6 +302,7 @@ static const CRPCCommand vRPCCommands[] =
     /* Overall control/query calls */
     { "control",            "help",                   &help,                   true,  {"command"}  },
     { "control",            "stop",                   &stop,                   true,  {}  },
+    { "control",            "uptime",                 &uptime,                 true,  {}  },
 };
 
 CRPCTable::CRPCTable()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -104,6 +104,9 @@ namespace boost {
 
 using namespace std;
 
+// Application startup time (used for uptime calculation)
+const int64_t nStartupTime = GetTime();
+
 const char * const BITCOIN_CONF_FILENAME = "dogecoin.conf";
 const char * const BITCOIN_PID_FILENAME = "dogecoind.pid";
 
@@ -892,4 +895,10 @@ std::string CopyrightHolders(const std::string& strPrefix)
         strCopyrightHolders += "\n" + strPrefix + "The Bitcoin Core developers";
     }
     return strCopyrightHolders;
+}
+
+// Obtain the application startup time (used for uptime calculation)
+int64_t GetStartupTime()
+{
+    return nStartupTime;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -6,7 +6,7 @@
 
 /**
  * Server/client environment: argument handling, config file parsing,
- * logging, thread wrappers
+ * logging, thread wrappers, startup time
  */
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
@@ -29,6 +29,9 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
+
+// Application startup time (used for uptime calculation)
+int64_t GetStartupTime();
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;


### PR DESCRIPTION
Backported rpc "uptime" from upstream (https://github.com/bitcoin/bitcoin/pull/10400). This is used by various node dashboards.

