### PR TITLE
crypto: uniform runtime capability detection

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,6 +93,7 @@ BITCOIN_CORE_H = \
   coins.h \
   compat.h \
   compat/byteswap.h \
+  compat/cpuid.h \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,6 +262,8 @@ crypto_libdogecoin_crypto_a_SOURCES = \
   crypto/hmac_sha256.h \
   crypto/hmac_sha512.cpp \
   crypto/hmac_sha512.h \
+  crypto/hwcap.h \
+  crypto/hwcap.cpp \
   crypto/ripemd160.cpp \
   crypto/ripemd160.h \
   crypto/scrypt.cpp \

--- a/src/bench/scrypt.cpp
+++ b/src/bench/scrypt.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include "bench.h"
+#include "crypto/hwcap.h"
 #include "crypto/scrypt.h"
 #include "uint256.h"
 #include "utiltime.h"
@@ -15,9 +16,8 @@ static void Scrypt(benchmark::State& state)
     uint256 output;
     std::vector<char> in(BUFFER_SIZE, 0);
 
-#ifdef USE_SSE2
-    scrypt_detect_sse2();
-#endif // USE_SSE2
+    HardwareCapabilities capabilities = DetectHWCapabilities();
+    scrypt_select_implementation(capabilities);
 
     while (state.KeepRunning())
     {

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2017-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_CPUID_H
+#define BITCOIN_COMPAT_CPUID_H
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#define HAVE_GETCPUID
+
+#include <cpuid.h>
+
+#include <cstdint>
+
+// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+#ifdef __GNUC__
+    __cpuid_count(leaf, subleaf, a, b, c, d);
+#else
+  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
+#endif
+}
+
+#endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#endif // BITCOIN_COMPAT_CPUID_H

--- a/src/crypto/hwcap.cpp
+++ b/src/crypto/hwcap.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "crypto/hwcap.h"
+#include "support/experimental.h"
+
+#if defined(HAVE_CONFIG_H)
+#include "bitcoin-config.h" // for USE_SSE2
+#endif
+
+HardwareCapabilities DetectHWCapabilities()
+{
+ HardwareCapabilities capabilities;
+ capabilities.has_sse2 = false;
+
+// generic x86_64 and i686 detection
+#if defined(HAVE_GETCPUID)
+    uint32_t eax, ebx, ecx, edx;
+    GetCPUID(1, 0, eax, ebx, ecx, edx);
+
+// detect SSE2
+#if defined(USE_SSE2)
+    EXPERIMENTAL_FEATURE
+    capabilities.has_sse2 = (edx & 1<<26);
+#endif // USE_SSE2
+#endif // HAVE_GETCPUID
+    return capabilities;
+
+}

--- a/src/crypto/hwcap.h
+++ b/src/crypto/hwcap.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_HWCAP_H
+#define BITCOIN_CRYPTO_HWCAP_H
+
+#include "compat/cpuid.h"
+
+struct HardwareCapabilities {
+  bool has_sse2;
+};
+
+HardwareCapabilities DetectHWCapabilities();
+
+#endif // BITCOIN_CRYPTO_HWCAP_H

--- a/src/crypto/scrypt-sse2.cpp
+++ b/src/crypto/scrypt-sse2.cpp
@@ -38,7 +38,11 @@
 // this entire functionality is experimental
 EXPERIMENTAL_FEATURE
 
-static inline void xor_salsa8_sse2(__m128i B[4], const __m128i Bx[4])
+namespace scrypt_sse2 {
+
+namespace {
+
+inline void xor_salsa8_sse2(__m128i B[4], const __m128i Bx[4])
 {
 	__m128i X0, X1, X2, X3;
 	__m128i T;
@@ -95,7 +99,9 @@ static inline void xor_salsa8_sse2(__m128i B[4], const __m128i Bx[4])
 	B[3] = _mm_add_epi32(B[3], X3);
 }
 
-void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad)
+} // anon namespace
+
+void scrypt_1024_1_1_256_sp(const char *input, char *output, char *scratchpad)
 {
 	uint8_t B[128];
 	union {
@@ -137,3 +143,5 @@ void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchp
 
 	PBKDF2_SHA256((const uint8_t *)input, 80, B, 128, 1, (uint8_t *)output, 32);
 }
+
+} // namespace scrypt_sse2

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -5,6 +5,7 @@
 
 #ifndef BITCOIN_CRYPTO_SCRYPT_H
 #define BITCOIN_CRYPTO_SCRYPT_H
+#include "crypto/hwcap.h"
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -14,27 +15,20 @@
 
 static const int SCRYPT_SCRATCHPAD_SIZE = 131072 + 63;
 
-void scrypt_1024_1_1_256(const char *input, char *output);
-void scrypt_1024_1_1_256_sp_generic(const char *input, char *output, char *scratchpad);
-
-#if defined(USE_SSE2)
-#if defined(_M_X64) || defined(__x86_64__) || defined(_M_AMD64) || (defined(MAC_OSX) && defined(__i386__))
-#define USE_SSE2_ALWAYS 1
-#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_sse2((input), (output), (scratchpad))
-#else
-#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_detected((input), (output), (scratchpad))
-#endif
-
-bool scrypt_detect_sse2();
-void scrypt_1024_1_1_256_sp_sse2(const char *input, char *output, char *scratchpad);
-extern void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, char *scratchpad);
-#else
-#define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_generic((input), (output), (scratchpad))
-#endif
-
 void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
+
+namespace scrypt_generic {
+    void scrypt_1024_1_1_256_sp(const char *input, char *output, char *scratchpad);
+}
+
+namespace scrypt_sse2 {
+    void scrypt_1024_1_1_256_sp(const char *input, char *output, char *scratchpad);
+}
+
+void scrypt_1024_1_1_256(const char *input, char *output);
+bool scrypt_select_implementation(const HardwareCapabilities capabilities);
 
 #ifndef __FreeBSD__
 static inline uint32_t le32dec(const void *pp)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,7 +17,8 @@
 #include "checkpoints.h"
 #include "compat/sanity.h"
 #include "consensus/validation.h"
-#include "crypto/scrypt.h" // for scrypt_detect_sse2
+#include "crypto/hwcap.h" // for DetectHWCapabilities
+#include "crypto/scrypt.h" // for scrypt_select_implementation
 #include "fs.h"
 #include "httpserver.h"
 #include "httprpc.h"
@@ -1251,13 +1252,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     int64_t nStart;
 
-#if defined(USE_SSE2)
-    if (scrypt_detect_sse2()) {
-        LogPrintf("scrypt: using SSE2 implementation\n");
+
+    HardwareCapabilities capabilities = DetectHWCapabilities();
+    if (scrypt_select_implementation(capabilities)) {
+      LogPrintf("scrypt: using SSE2 implementation\n");
     } else {
-        LogPrintf("scrypt: using generic implementation\n");
+      LogPrintf("scrypt: using generic implementation\n");
     }
-#endif
 
     // ********************************************************* Step 5: verify wallet database integrity
 #ifdef ENABLE_WALLET

--- a/src/test/scrypt_tests.cpp
+++ b/src/test/scrypt_tests.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
 
+#include "crypto/hwcap.h"
 #include "crypto/scrypt.h"
 #include "uint256.h"
 #include "util.h"
@@ -13,13 +14,14 @@ BOOST_AUTO_TEST_SUITE(scrypt_tests)
 
 BOOST_AUTO_TEST_CASE(scrypt_hashtest)
 {
+#if defined(USE_SSE2)
+    // get cpu capabilities
+    HardwareCapabilities capabilities = DetectHWCapabilities();
+#endif
     // Test Scrypt hash with known inputs against expected outputs
     #define HASHCOUNT 5
     const char* inputhex[HASHCOUNT] = { "020000004c1271c211717198227392b029a64a7971931d351b387bb80db027f270411e398a07046f7d4a08dd815412a8712f874a7ebf0507e3878bd24e20a3b73fd750a667d2f451eac7471b00de6659", "0200000011503ee6a855e900c00cfdd98f5f55fffeaee9b6bf55bea9b852d9de2ce35828e204eef76acfd36949ae56d1fbe81c1ac9c0209e6331ad56414f9072506a77f8c6faf551eac7471b00389d01", "02000000a72c8a177f523946f42f22c3e86b8023221b4105e8007e59e81f6beb013e29aaf635295cb9ac966213fb56e046dc71df5b3f7f67ceaeab24038e743f883aff1aaafaf551eac7471b0166249b", "010000007824bc3a8a1b4628485eee3024abd8626721f7f870f8ad4d2f33a27155167f6a4009d1285049603888fe85a84b6c803a53305a8d497965a5e896e1a00568359589faf551eac7471b0065434e", "0200000050bfd4e4a307a8cb6ef4aef69abc5c0f2d579648bd80d7733e1ccc3fbc90ed664a7f74006cb11bde87785f229ecd366c2d4e44432832580e0608c579e4cb76f383f7f551eac7471b00c36982" };
     const char* expected[HASHCOUNT] = { "00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806" , "00000000003a0d11bdd5eb634e08b7feddcfbbf228ed35d250daf19f1c88fc94", "00000000000b40f895f288e13244728a6c2d9d59d8aff29c65f8dd5114a8ca81", "00000000003007005891cd4923031e99d8e8d72f6e8e7edc6a86181897e105fe", "000000000018f0b426a4afc7130ccb47fa02af730d345b4fe7c7724d3800ec8c" };
-#if defined(USE_SSE2)
-    scrypt_detect_sse2();
-#endif
     uint256 scrypthash;
     std::vector<unsigned char> inputbytes;
     char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
@@ -27,11 +29,13 @@ BOOST_AUTO_TEST_CASE(scrypt_hashtest)
         inputbytes = ParseHex(inputhex[i]);
 #if defined(USE_SSE2)
         // Test SSE2 scrypt
-        scrypt_1024_1_1_256_sp_sse2((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
-        BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
+        if (capabilities.has_sse2) {
+            scrypt_sse2::scrypt_1024_1_1_256_sp((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
+            BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
+        }
 #endif
         // Test generic scrypt
-        scrypt_1024_1_1_256_sp_generic((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
+        scrypt_generic::scrypt_1024_1_1_256_sp((const char*)&inputbytes[0], BEGIN(scrypthash), scratchpad);
         BOOST_CHECK_EQUAL(scrypthash.ToString().c_str(), expected[i]);
     }
 }


### PR DESCRIPTION
Because we want to check for hardware capabilities at runtime among a set of current experimental features when they mature, it's good to have a uniform, central facility that checks capabilities. Detection code is riddled with macros making it hard to review/debug, because for each architecture/compiler there can be quirks.

This PR does 3 things:

1. It backports `compat/cpuid.h` from Bitcoin Core, to provide a generic, low level interface for reading out CPU properties. This helps us in the future outside of crypto algorithms too, because we'll need it for RNG enhancements; see for example [this finding on a proposed `RDSEED` implementation](https://github.com/dogecoin/dogecoin/pull/2482#pullrequestreview-988204372).
2. It implements a detection function in `crypto/hwcap.*`, where all capabilities can be tested (once), and decoupled from implementation selectors. It can be easily extended by enumerating new booleans into the `HardwareCapabilities` struct, which can then be detected in the `DetectHWCapabilities()` function. The values in this struct can also be overridden in `init.cpp` in the future, for example: there are plenty products where you would not want to run RDSEED or AVX2 on because either the implementation is terribly slow or has serious security flaws. This construct allows us to create a facility that turns those off using a startup argument that overrides the detection. This would allow users to simply run a released binary but runtime override what features to use, sparing them the need for compile expertise.
3. Implementation on the scrypt-sse2 experimental code, which is now a lot cleaner. I've slightly refactored it to have namespaces, like the Bitcoin sha256 and the sha512 proposal from #3188 has.

### Testing

I think this needs a couple of specific tests that we don't have a CI for:

- Compiling with clang
- Compiling with MSVC
- Compiling with newer mingw
- Sync at least testnet with the experimental scrypt code, and once without it, because scrypt is of course part of consensus code.