### PR TITLE
ci: update codeql to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         popd
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -68,4 +68,4 @@ jobs:
        make -j4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Per https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/ we need to do this before December. Removes annoying warnings.