### PR TITLE
qt: Display abort node error to UI

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -220,7 +220,7 @@ static bool InitRPCAuthentication()
         LogPrintf("No rpcpassword set - using random cookie authentication\n");
         if (!GenerateAuthCookie(&strRPCUserColonPass)) {
             uiInterface.ThreadSafeMessageBox(
-                _("Error: A fatal internal error occurred, see debug.log for details"), // Same message as AbortNode
+                _("A fatal internal error occurred, see debug.log for details: ") + "Unable to open cookie authentication file for writing", // Same message as AbortNode
                 "", CClientUIInterface::MSG_ERROR);
             return false;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1575,20 +1575,18 @@ bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint
 }
 
 /** Abort with a message */
-bool AbortNode(const std::string& strMessage, const std::string& userMessage="")
+bool AbortNode(const std::string& strMessage)
 {
     SetMiscWarning(strMessage);
-    LogPrintf("*** %s\n", strMessage);
-    uiInterface.ThreadSafeMessageBox(
-        userMessage.empty() ? _("Error: A fatal internal error occurred, see debug.log for details") : userMessage,
-        "", CClientUIInterface::MSG_ERROR);
+    LogPrintf("Node aborted: %s\n", strMessage);
+    InitError(_("A fatal internal error occurred, see debug.log for details: ") + strMessage);
     StartShutdown();
     return false;
 }
 
-bool AbortNode(CValidationState& state, const std::string& strMessage, const std::string& userMessage="")
+bool AbortNode(CValidationState& state, const std::string& strMessage)
 {
-    AbortNode(strMessage, userMessage);
+    AbortNode(strMessage);
     return state.Error(strMessage);
 }
 
@@ -3584,7 +3582,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
 
     // Check for nMinDiskSpace bytes (currently 50MB)
     if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
-        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+        return AbortNode(_("Error: Disk space is low!"));
 
     return true;
 }


### PR DESCRIPTION
Addresses #3489 Point 1

This PR displays the `AbortNode()` message to the user through a Qt dialog box instead of only printing to the log. 

In addition, the `AbortNode()` logs with `Node aborted: <message>` instead of `*** <message>` to make it clear that the node had to be aborted due to a reason.

Since `AbortNode()` only takes in a single error message now, only the disk space error would be translated. Not sure how this effects translations for other errors. I am also not sure how changing the error string affects the current translations since it remove "Error: " and adds a colon (:) to the end with a space.

![dogecoin-error](https://github.com/dogecoin/dogecoin/assets/36016500/8afaefb8-ee13-489f-8914-45455f427ca5)
