### PR TITLE
compat: fix compatibility with boost 1.85

### DIFF
--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -73,7 +73,7 @@ static const std::string COOKIEAUTH_FILE = ".cookie";
 fs::path GetAuthCookieFile()
 {
     fs::path path(GetArg("-rpccookiefile", COOKIEAUTH_FILE));
-    if (!path.is_complete()) path = GetDataDir() / path;
+    if (!path.is_absolute()) path = GetDataDir() / path;
     return path;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -588,7 +588,7 @@ const fs::path &GetBackupDir()
 fs::path GetConfigFile(const std::string& confPath)
 {
     fs::path pathConfigFile(confPath);
-    if (!pathConfigFile.is_complete())
+    if (!pathConfigFile.is_absolute())
         pathConfigFile = GetDataDir(false) / pathConfigFile;
 
     return pathConfigFile;
@@ -624,7 +624,7 @@ void ReadConfigFile(const std::string& confPath)
 fs::path GetPidFile()
 {
     fs::path pathPidFile(GetArg("-pid", BITCOIN_PID_FILENAME));
-    if (!pathPidFile.is_complete()) pathPidFile = GetDataDir() / pathPidFile;
+    if (!pathPidFile.is_absolute()) pathPidFile = GetDataDir() / pathPidFile;
     return pathPidFile;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <list>
 #include <map>
 #include <set>
 #include <stdint.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -459,8 +459,10 @@ bool CWallet::Verify()
     uiInterface.InitMessage(_("Verifying wallet..."));
 
     // Wallet file must be a plain filename without a directory
-    if (walletFile != fs::basename(walletFile) + fs::extension(walletFile))
+    fs::path walletPath(walletFile);
+    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
         return InitError(strprintf(_("Wallet %s resides outside data directory %s"), walletFile, GetDataDir().string()));
+    }
 
     if (!bitdb.Open(GetDataDir()))
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4021,7 +4021,11 @@ bool CWallet::BackupWallet(const std::string& strDest)
                         return false;
                     }
 
-#if BOOST_VERSION >= 104000
+#if BOOST_VERSION >= 107400
+                    // Boost 1.74.0 and up implements std++17 like "copy_options", and this
+                    // is the only remaining enum after 1.85.0
+                    fs::copy_file(pathSrc, pathDest, fs::copy_options::overwrite_existing);
+#elif BOOST_VERSION >= 104000
                     fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
 #else
                     fs::copy_file(pathSrc, pathDest);


### PR DESCRIPTION
Enables compiling Dogecoin Core with boost 1.85, addresses #3548

I've split this up into several commits because there are different constraints/reasons to each change:

1. Replace `path::is_complete()` with `path::is_absolute()`. The former was deprecated since the introduction of filesystem v3 in boost 1.44, so this can be safely changed: since deprecation the former was a wrapper for the latter.
2. Stop using the `boost::filesystem` convenience functions `basename()` and `extension()`. These have been re-introduced as `path::stem()` and `path::extension()` respectively in boost 1.44 and have been removed in 1.85
3. Since boost 1.74, the `copy_option` enum has been modified to `copy_options` to be similar to the c++17 `fs` namespace. The single value `copy_option::overwrite_if_exists` has been renamed to `copy_options::overwrite_existing`. Because our minimum supported boost version is 1.60, I've implemented this conditionally on the boost version used.
4. add missing `<list>` include in `validation.h` - this omission was until boost 1.85 masked by including `boost/unordered_map.hpp`

I've tested this to work on:
1. Boost 1.85 on arm64 macOS Sonoma
2. Boost 1.60 on x86_64 Ubuntu Focal
3. Boost 1.74 on x86_64 Ubuntu Focal
4. Our pinned boost 1.63 is tested by the CI for cross-compilation.