### PR TITLE
random: use std::shuffle instead of std::random_shuffle

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1641,7 +1641,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         // Randomize entries before processing, to prevent an attacker to
         // determine which entries will make it through the rate limit
-        random_shuffle(vAddr.begin(), vAddr.end(), GetRandInt);
+        FastRandomContext insecure_rand;
+        shuffle(vAddr.begin(), vAddr.end(), insecure_rand);
 
         BOOST_FOREACH(CAddress& addr, vAddr)
         {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2157,6 +2157,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 {
     setCoinsRet.clear();
     nValueRet = 0;
+    FastRandomContext insecure_rand;
 
     // List of values less than target
     pair<CAmount, pair<const CWalletTx*,unsigned int> > coinLowestLarger;
@@ -2165,7 +2166,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    shuffle(vCoins.begin(), vCoins.end(), insecure_rand);
 
     BOOST_FOREACH(const COutput &output, vCoins)
     {


### PR DESCRIPTION
`random_shuffle` is deprecated since c++11 and removed in c++17. Use the `shuffle` function instead, now that we have a standardized interface available on `FastRandomContext`.

This enables c++17 compilation (to be added to `configure.ac` in a follow-up PR.)