### PR TITLE
build: allow c++17 standard to be used for compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,8 +63,19 @@ AC_ARG_ENABLE([c++14],
   [use_cxx14=$enableval],
   [use_cxx14=no])
 
-dnl Require C++11 or C++14 compiler (no GNU extensions)
-if test "x$use_cxx14" = xyes; then
+AC_ARG_ENABLE([c++17],
+  [AS_HELP_STRING([--enable-c++17],
+  [enable compilation in c++17 mode (disabled by default)])],
+  [use_cxx17=$enableval],
+  [use_cxx17=no])
+
+dnl Require either of C++ 17, 14 or 11 (default) compiler (no GNU extensions)
+if test "x$use_cxx17" = xyes; then
+  if test "x$use_cxx14" = xyes; then
+    AC_MSG_ERROR("Both c++17 and c++14 are configured. Please configure only one standard")
+  fi
+  AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
+elif test "x$use_cxx14" = xyes; then
   AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
 else
   AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])


### PR DESCRIPTION
This will allow compiling with the c++17 standard, which on some distributions (macOS, FreeBSD) is required when using system dependencies.

Enables resolution of #3547 and simplifies macOS custom builds.