### PR TITLE
bugfix: avoid the use of abs in time data

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -15,8 +15,6 @@
 #include "utilstrencodings.h"
 #include "warnings.h"
 
-#include <boost/foreach.hpp>
-
 static CCriticalSection cs_nTimeOffset;
 static int64_t nTimeOffset = 0;
 
@@ -104,8 +102,10 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             }
         }
 
-        BOOST_FOREACH(int64_t n, vSorted)
+        for (int64_t n : vSorted) {
             LogPrint("net", "%+d  ", n);
+        }
+
         LogPrint("net", "|  ");
 
         LogPrint("net", "nTimeOffset = %+d  (%+d minutes)\n", nTimeOffset, nTimeOffset/60);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -38,11 +38,6 @@ int64_t GetAdjustedTime()
     return GetTime() + GetTimeOffset();
 }
 
-static int64_t abs64(int64_t n)
-{
-    return (n >= 0 ? n : -n);
-}
-
 #define BITCOIN_TIMEDATA_MAX_SAMPLES 200
 
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
@@ -82,8 +77,8 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
         int64_t nMedian = vTimeOffsets.median();
         std::vector<int64_t> vSorted = vTimeOffsets.sorted();
         // Only let other nodes change our time by so much
-        if (abs64(nMedian) <= std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT)))
-        {
+        int64_t max_adjustment = std::max<int64_t>(0, GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT));
+        if (nMedian >= -max_adjustment && nMedian <= max_adjustment) {
             nTimeOffset = nMedian;
         }
         else
@@ -95,9 +90,9 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             {
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
-                BOOST_FOREACH(int64_t nOffset, vSorted)
-                    if (nOffset != 0 && abs64(nOffset) < 5 * 60)
-                        fMatch = true;
+                for (const int64_t nOffset : vSorted) {
+                    if (nOffset != 0 && nOffset > -5 * 60 && nOffset < 5 * 60) fMatch = true;
+                }
 
                 if (!fMatch)
                 {
@@ -108,11 +103,11 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 }
             }
         }
-        
+
         BOOST_FOREACH(int64_t n, vSorted)
             LogPrint("net", "%+d  ", n);
         LogPrint("net", "|  ");
-        
+
         LogPrint("net", "nTimeOffset = %+d  (%+d minutes)\n", nTimeOffset, nTimeOffset/60);
     }
 }


### PR DESCRIPTION
Cleans up `timedata.cpp` to not use `abs64()` when evaluating our timestamps vs that of our peers - this is a bugfix from upstream that fixes a potential timewarp issue.

Also removes the last instance of `BOOST_FOREACH` in `timedata.cpp` while we're changing it, so that it's now free of dependency on boost.