### PR TITLE
p2p: reduce amount of getheaders sent per inv

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -883,6 +883,7 @@ void Misbehaving(NodeId pnode, int howmuch)
 //             already requesting headers from, unless forced.
 void RequestHeadersFrom(CNode* pto, CConnman& connman, const CBlockIndex* pindex, uint256 untilHash, bool fforceQuery)
 {
+  AssertLockHeld(cs_main);
   if (pto->nPendingHeaderRequests > 0) {
     if (fforceQuery) {
       LogPrint("net", "forcing getheaders request (%d) to peer=%d (%d open)\n",

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1741,6 +1741,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         uint32_t nFetchFlags = GetFetchFlags(pfrom, chainActive.Tip(), chainparams.GetConsensus(chainActive.Height()));
         int64_t current_time = GetMockableTimeMicros();
+        uint256* best_block{nullptr};
 
         std::vector<CInv> vToFetch;
 
@@ -1761,14 +1762,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (inv.type == MSG_BLOCK) {
                 UpdateBlockAvailability(pfrom->GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
-                    // We used to request the full block here, but since headers-announcements are now the
-                    // primary method of announcement on the network, and since, in the case that a node
-                    // fell back to inv we probably have a reorg which we should get the headers for first,
-                    // we now only provide a getheaders response here. When we receive the headers, we will
-                    // then ask for the blocks we need.
-                    // Dogecoin: We force this check, in case we're only connected to nodes that send invs
-                    RequestHeadersFrom(pfrom, connman, pindexBestHeader, inv.hash, true);
-                    LogPrint("net", "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->id);
+                  // Headers-first is the primary method of announcement on
+                  // the network. If a node fell back to sending blocks by inv,
+                  // it's probably for a re-org. The final block hash
+                  // provided should be the highest, so send a getheaders and
+                  // then fetch the blocks we need to catch up.
+                  best_block = &inv.hash;
                 }
             }
             else
@@ -1780,6 +1779,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     RequestTx(State(pfrom->GetId()), inv.hash, current_time);
             }
 
+        }
+
+        if (best_block != nullptr) {
+            // Dogecoin: allow header requests from inv to be non-serial by
+            // forcing the request, to be able to get split chaintips quickly.
+            RequestHeadersFrom(pfrom, connman, pindexBestHeader, *best_block, true /* force */);
+            LogPrint("net", "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, best_block->ToString(), pfrom->id);
         }
 
         if (!vToFetch.empty())


### PR DESCRIPTION
Avoids doing unnecessary `getheaders` requests per `inv` message - improvement from upstream.

When receiving an `inv` that contains block hashes, now only request the last hash from the message, as the response to `getheaders` contains all the headers between the given blocklocator and that hash (up to 1000). This reduces the amount of data requested over the network.

Additionally, to make sure that no data races are introduced in the Dogecoin-specific `RequestHeadersFrom()` request serializer, enforce that all calling code holds a lock on `cs_main` (this was already the case, but is now explicitly enforced.)