### PR TITLE
doc: change the branching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Dogecoin Core [DOGE, Ð]
 
 </div>
 
+**IMPORTANT: Starting August 2024, the `master` branch has become the primary
+integration branch and has become unstable. Please check out a tagged version
+before compiling production binaries.**
+
 For internationalized documentation, see the index at [doc/intl](doc/intl/README.md).
 
 Dogecoin is a community-driven cryptocurrency that was inspired by a Shiba Inu meme. The Dogecoin Core software allows anyone to operate a node in the Dogecoin blockchain networks and uses the Scrypt hashing method for Proof of Work. It is adapted from Bitcoin Core and other cryptocurrencies.
@@ -58,16 +62,20 @@ Main development resources:
 Version numbers are following ```major.minor.patch``` semantics.
 
 ### Branches
-There are 3 types of branches in this repository:
+There are 4 types of branches in this repository:
 
-- **master:** Stable, contains the latest version of the latest *major.minor* release.
-- **maintenance:** Stable, contains the latest version of previous releases, which are still under active maintenance. Format: ```<version>-maint```
-- **development:** Unstable, contains new code for planned releases. Format: ```<version>-dev```
+- **master:** Unstable, contains the latest code under development.
+- **maintenance:** Stable, contains the latest version of previous releases,
+  which are still under active maintenance. Format: ```<version>-maint```
+- **development:** Unstable, contains new code for upcoming releases. Format: ```<version>-dev```
+- **archive:** Stable, immutable branches for old versions that no longer change
+  because they are no longer maintained.
 
-*Master and maintenance branches are exclusively mutable by release. Planned*
-*releases will always have a development branch and pull requests should be*
-*submitted against those. Maintenance branches are there for **bug fixes only,***
-*please submit new features against the development branch with the highest version.*
+***Submit your pull requests against `master`***
+
+*Maintenance branches are exclusively mutable by release. When a release is*
+*planned, a development branch will be created and commits from master will*
+*be cherry-picked into these by maintainers.*
 
 ## Contributing 🤝
 


### PR DESCRIPTION
Major administrative policy change: change the branching strategy to be able to release software for multiple versions asynchronously, while having an integral up to date but unstable master branch.

Soon, a 1.14.8 minor release will have to be done, but the major version being worked on right now - 1.15.0 - is not ready to be released around the same time. This means that under the current branching strategy, there will either be a `master` branch that does not contain fixes from 1.14.8, or one that cannot be cleanly fast-forwarded into 1.15.0. Both outcomes are undesirable.

The fix is easy: since patches apply to both `1.15.0` and `1.14.8` (almost 1-on-1), by making `master` unstable and tracking the latest work there. A major release (other than a re-port from upstream) becomes simply a copy of master when creating a development branch at the time of releasing a candidate, and a minor release is - as is now - a copy of the maintenance branch, which can then get the desired commits picked into them. This is largely the upstream branching strategy. If another full re-port is required (unforeseen at this time), this can happen on a separate `-dev` branch (and will disrupt `master` the same way it did in the past.

Practically this means:

- All pull requests that are not release-specific will need to be done to `master` - every new feature or bug fix needs to go there first.
- When self-compiling, `master` is no longer a safe choice for production deployments - tags need to be checked out.
- Maintainers will have a little more work when preparing releases, as sometimes, bug fixes need to be backported to multiple branches.

Additional upsides:
- Documentation and tooling on `master` will always be the latest version

-----

Administrative note: please discuss, but do not merge this yet. We need to have a decision towards this on the day that 1.14.8 gets released, before that, it'd be premature to change the documented policy.