### PR TITLE
doc: simplify macOS build guide

### DIFF
--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -1,4 +1,4 @@
-# Building dogecoin-qt 1.14 on MacOS #
+# Building Dogecoin Core on MacOS #
 
 Tested on MacOs Ventura and Sonoma on Intel (x86_64) and Apple Silicon (arm64) macs.
 
@@ -35,9 +35,8 @@ chmod -R go-w "$(brew --prefix)/share/zsh"
 Install dependencies via Brew.
 
 ```sh
-brew install autoconf automake libtool miniupnpc openssl pkg-config protobuf@21 \
+brew install autoconf automake libtool miniupnpc openssl pkg-config protobuf \
              qt5 zeromq qrencode librsvg boost berkeley-db@5 libevent
-brew link protobuf@21
 ```
 
 ### Go back to your Dogecoin repo ###
@@ -46,7 +45,7 @@ brew link protobuf@21
 cd ~/dogecoin
 
 ./autogen.sh
-./configure --with-gui=qt5 --with-boost=`brew --prefix boost`
+./configure --enable-c++17 --with-gui --with-boost=`brew --prefix boost`
 make
 ```
 


### PR DESCRIPTION
Now that we have c++17 compatibility from #3561 (and the boost fix from #3558) macOS building no longer needs to pin a specific protobuf version pre-abseil if c++17 is configured.