### PR TITLE
ci: pin setuptools version to 70.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
                pkg-config bsdmainutils curl ca-certificates ccache rsync git \
                procps bison python3 python3-pip python3-setuptools python3-wheel
           sudo apt-get install ${{ matrix.packages }}
-          python3 -m pip install setuptools --upgrade
+          python3 -m pip install setuptools==70.3.0 --upgrade
 
       - name: Install custom lief wheel
         if: matrix.os == 'ubuntu-18.04'


### PR DESCRIPTION
We need to upgrade setuptools, but for now not past 70.x; pin the latest version available.

This is caused by an issue in the CI Ubuntu 20.04 image that I unfortunately cannot seem to reproduce with the 20.04 docker image from Docker Library, so this needs more time to investigate. To not have a broken CI in the meantime, I think that we should simply pin the last working 70.x version (70.3.0) until the root cause has been found.