### PR TITLE
1.14.8: backport test fixes

### DIFF
--- a/contrib/devtools/check-translations.py
+++ b/contrib/devtools/check-translations.py
@@ -130,9 +130,23 @@ def check_all_translations():
                 # pick all numerusforms
                 if numerus:
                     translations = [i.text for i in translation_node.findall('numerusform')]
+                    if len(translations) == 0:
+                        print(f'Numerus message without numerusform translations, needs fix.', sanitize_string(source))
+                        have_errors = True
+                    if translation_node.text is not None and not translation_node.text.isspace():
+                        print(f'Numerus message contains extra text {translation_node.text}, needs fix.')
+                        have_errors = True
+                    for child in list(translation_node.iter())[1:]: # exclude root
+                        if child.tag != 'numerusform':
+                            print('Numerus message contains extra child node, needs fix.', sanitize_string(source))
+                            have_errors = True
+                            break
                 else:
                     translations = [translation_node.text]
-
+                    if len(list(translation_node.iter())) != 1:
+                        print('Non-numerus message contains child node in translation, needs fix.', sanitize_string(source))
+                        have_errors = True
+                    
                 for translation in translations:
                     if translation is None:
                         continue

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -179,6 +179,7 @@ testScripts = [
     'getblockstats.py',
     'addnode.py',
     'getmocktime.py',
+    'p2p-getdata.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/p2p-getdata.py
+++ b/qa/rpc-tests/p2p-getdata.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Copyright (c) 2024 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test GETDATA processing behavior
+"""
+
+from collections import defaultdict
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import *
+
+class GetDataTestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.blocks = defaultdict(int) # track how many times we get a block
+        self.lastpong = 0 # nonce of last pong
+        self.nonce = 4919 # initial higher nonce
+
+    def on_block(self, conn, message):
+        message.block.calc_sha256()
+        self.blocks[message.block.sha256] += 1
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def on_pong(self, conn, message):
+        self.lastpong = message.nonce
+
+    def wait_for_disconnect(self):
+        if self.connection == None:
+            return True
+        def is_closed():
+            return self.connection.state == "closed"
+        return wait_until(is_closed, timeout=30)
+
+    def wait_for_pong(self, nonce):
+        def pong_received():
+            return self.lastpong == nonce
+        return wait_until(pong_received, timeout=10)
+
+    def wait_for_block(self, blkhash):
+        def block_received():
+            return self.blocks[blkhash] == 1
+        return wait_until(block_received, timeout=30)
+
+    def disconnect(self):
+        self.connection.disconnect_node()
+        return self.wait_for_disconnect()
+
+    def ping(self):
+        self.nonce += 1
+        self.connection.send_message(msg_ping(self.nonce))
+        return self.wait_for_pong(self.nonce)
+
+
+class GetDataTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, []))
+
+    def run_test(self):
+        # Mine a block
+        self.nodes[0].generate(1)
+        best_block = int(self.nodes[0].getbestblockhash(), 16)
+
+        # Connect test node after mining (so that we don't get any announces)
+        self.testnode = GetDataTestNode()
+        conn = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.testnode)
+        self.testnode.add_connection(conn)
+        NetworkThread().start()
+        self.testnode.wait_for_verack()
+
+        # Send invalid message
+        invalid_getdata = msg_getdata()
+        invalid_getdata.inv.append(CInv(t=0, h=0))  # INV type 0 is invalid.
+        self.testnode.connection.send_message(invalid_getdata)
+
+        # Verify that node responds to later ping
+        assert(self.testnode.ping())
+
+        # Should not have received a block message for the best block yet
+        assert(self.testnode.blocks[best_block] != 1)
+
+        # Try to get the block
+        good_getdata = msg_getdata()
+        good_getdata.inv.append(CInv(t=2, h=best_block))
+        self.testnode.connection.send_message(good_getdata)
+
+        # Should still respond to ping
+        assert(self.testnode.ping())
+
+        # Should have received the block
+        assert(self.testnode.wait_for_block(best_block))
+
+
+if __name__ == '__main__':
+    GetDataTest().main()


### PR DESCRIPTION
Cherry-picks all test fixes done on 1.15.0 that do not involve code changes:

- #3446
- #3572
- #3574

Conflicts resolved:

- 74b03aa9: in `qa/pull-tester/rpc-tests.py`, 1.15.0 also has the uptime RPC test, but that is out of scope for 1.14.8