### PR TITLE
1.14.8: update pinned dependencies

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.5.0
+$(package)_version=2.6.2
 $(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=6f0e6e01f7b30025fa05c85fdad1e5d0ec7fd35d9f61b22f34998de11969ff67
+$(package)_sha256_hash=9C7C1B5DCBC3C237C500A8FB1493E14D9582146DD9B42AA8D3FFB856A3B927E0
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,12 +1,12 @@
 package=freetype
-$(package)_version=2.7.1
+$(package)_version=2.11.0
 $(package)_download_path=http://download.savannah.gnu.org/releases/$(package)
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
-  $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_linux=--with-pic --without-brotli
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Backports dependency updates from `1.15.0-dev`:

- #3362
- #3481

Both could be cleanly picked.