### PR TITLE
Extract set_mocktime() in QA tests

### DIFF
--- a/qa/rpc-tests/liststucktransactions.py
+++ b/qa/rpc-tests/liststucktransactions.py
@@ -38,7 +38,7 @@ class ListStuckTransactionsTest(BitcoinTestFramework):
         self.nodes = self.setup_nodes()
 
         # set the time explicitly
-        self.setmocktime(int(time.time()))
+        self.set_mocktime(int(time.time()))
 
         # connect wallet node to relay nodes
         connect_nodes_bi(self.nodes, 0, 1)
@@ -46,13 +46,9 @@ class ListStuckTransactionsTest(BitcoinTestFramework):
         self.is_network_split = False
         self.sync_all()
 
-    def setmocktime(self, time):
-        self.mocktime = time
-        for n in self.nodes:
-            n.setmocktime(self.mocktime)
-
     def incrementmocktime(self, seconds):
-        self.setmocktime(self.mocktime + seconds)
+        self.mocktime += seconds
+        self.set_mocktime(self.mocktime)
 
     def mine_one_minute_blocks(self, miner_node, num):
         for i in range(num):

--- a/qa/rpc-tests/p2p-tx-download.py
+++ b/qa/rpc-tests/p2p-tx-download.py
@@ -171,14 +171,7 @@ class TxDownloadTest(BitcoinTestFramework):
 
     def forward_mocktime(self, delta_time):
         self.mocktime += delta_time
-        for node in self.nodes:
-            node.setmocktime(self.mocktime)
-            if not self.wait_for_mocktime(node):
-                return False
-        # sync the control peer with ping so that we're 100% sure we have
-        # entered a new message handling loop
-        self.control_peer.sync_with_ping()
-        return True
+        return self.set_mocktime(self.mocktime, self.control_peer)
 
     def forward_mocktime_step2(self, iterations):
         # forward mocktime in steps of 2 seconds to allow the nodes

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -29,7 +29,7 @@ import asyncore
 import time
 import sys
 import random
-from .util import hex_str_to_bytes, bytes_to_hex_str
+from .util import hex_str_to_bytes, bytes_to_hex_str, wait_until, test_lock
 from io import BytesIO
 from codecs import encode
 import hashlib
@@ -67,7 +67,7 @@ mininode_socket_map = dict()
 # and whenever adding anything to the send buffer (in send_message()).  This
 # lock should be acquired in the thread running the test logic to synchronize
 # access to any data shared with the NodeConnCB or NodeConn.
-mininode_lock = RLock()
+mininode_lock = test_lock
 
 # Serialization/deserialization tools
 def sha256(s):
@@ -1378,21 +1378,6 @@ class msg_reject(object):
     def __repr__(self):
         return "msg_reject: %s %d %s [%064x]" \
             % (self.message, self.code, self.reason, self.data)
-
-# Helper function
-def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf')):
-    attempt = 0
-    elapsed = 0
-
-    while attempt < attempts and elapsed < timeout:
-        with mininode_lock:
-            if predicate():
-                return True
-        attempt += 1
-        elapsed += 0.05
-        time.sleep(0.05)
-
-    return False
 
 class msg_feefilter(object):
     command = b"feefilter"

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -26,6 +26,7 @@ from .util import (
     check_json_precision,
     initialize_chain_clean,
     PortSeed,
+    wait_until
 )
 from .authproxy import JSONRPCException
 
@@ -189,6 +190,19 @@ class BitcoinTestFramework(object):
         else:
             print("Failed")
             sys.exit(1)
+
+    def set_mocktime(self, time, syncnode=None):
+        for n in self.nodes:
+            n.setmocktime(time)
+            def mocktime_set():
+                return n.getmocktime() == time
+            if not wait_until(mocktime_set, timeout=10):
+                return False
+
+        if syncnode is not None:
+            return syncnode.sync_with_ping()
+
+        return True
 
 
 # Test framework for doing p2p comparison testing, which sets up some dogecoind


### PR DESCRIPTION
While we probably want to use this helper method on our test classes more broadly, this refactoring is a little invasive because it also requires moving mininode's `wait_until()` helper function and resource lock into the `util` package.

This may be a code smell which suggests further code reorganization before the right design is obvious.