### PR TITLE
docs: update French README

### DIFF
--- a/doc/intl/fr/README.md
+++ b/doc/intl/fr/README.md
@@ -11,6 +11,8 @@ Dogecoin Core [DOGE, Ð]
 
 </div>
 
+IMPORTANT : À partir d'août 2024, la branche master est devenue la branche principale d'intégration et est devenue instable. Veuillez consulter une version _taguée_ avant de compiler des binaires de production
+
 Dogecoin est une crypto-monnaie communautaire qui s'inspire d'un mème de Shiba Inu. Le logiciel Dogecoin Core permet à quiconque d'exploiter un nœud dans les réseaux de la blockchain Dogecoin et utilise la méthode de hachage Scrypt pour la preuve de travail. Il est adapté de Bitcoin Core et d'autres crypto-monnaies.
 
 Pour plus d'informations sur les frais par défaut utilisés sur le réseau Dogecoin, veuillez consulter la [recommandation sur les frais](doc/fee-recommendation.md).
@@ -43,20 +45,25 @@ Principales ressources de développement :
 
 * [GitHub Discussion](https://github.com/dogecoin/dogecoin/discussions) est utilisé pour
   discuter des caractéristiques, planifiées et non planifiées, liées à la fois au développement du logiciel Dogecoin Core, les protocoles sous-jacents et l'actif DOGE.
-  
+
 * [Dogecoindev subreddit](https://www.reddit.com/r/dogecoindev/)
 
 ### Stratégie de version
+
 Les numéros de version suivent la sémantique ```major.minor.patch```.
 
 ### Branches
-Il y a 3 types de branches dans ce référentiel :
 
-- **master:** Stable, contient la dernière version de la dernière *major.minor* version.
-- **maintenance:** Stable, contient la dernière version des versions précédentes, qui sont toujours en maintenance active. Format : ```<version>-maint```
-- **development:** Instable, contient du nouveau code pour les versions prévues. Format : ```<version>-dev```
+Il y a 4 types de branches dans ce répertoire :
 
-*Les branches master et de maintenance sont exclusivement mutables par version. Les versions planifiées auront toujours une branche de développement et les demandes de pull doivent être soumises dans cette branche. Les branches de maintenance ne sont là **seulement pour corriger les bugs**, veuillez soumettre les nouvelles fonctionnalités dans la branche de développement avec la version la plus récente.*
+- **master :** Instable, contient le code le plus récent en développement.
+- **maintenance :** Stable, contient la dernière version des versions précédentes, qui sont toujours en maintenance active. Format : ```<version>-maint```
+- **development :** Instable, contient du nouveau code pour les versions prévues. Format : ```<version>-dev``` 
+- **archive :** Stable, branches immuables d'anciennes versions qui ne sont plus maintenues.
+
+***Veuillez soumettre vos demandes de tirage contre la branche `master`.***
+
+*Les branches `master` et `maintenance` sont exclusivement mutables par version. Lorsqu'une version est planifiée, une branche de développement est créée et les commits de `master` sont sélectionnés et intégrés par les mainteneurs.*
 
 ## Contribution🤝
 


### PR DESCRIPTION
Updates the French README to reflect the new branching strategy introduced in version 1.14.8. This update follows the changes made at commit `9222634` and merge `70e7bf6`.