### PR TITLE
Optimize IPC Server Name Handling

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -19,26 +19,19 @@
 
 #include <cstdlib>
 
-#include <openssl/x509_vfy.h>
-
 #include <QApplication>
 #include <QByteArray>
 #include <QDataStream>
 #include <QDateTime>
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
 #include <QFileOpenEvent>
 #include <QHash>
 #include <QList>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QNetworkAccessManager>
-#include <QNetworkProxy>
-#include <QNetworkReply>
-#include <QNetworkRequest>
-#include <QSslCertificate>
-#include <QSslError>
-#include <QSslSocket>
 #include <QStringList>
 #include <QTextDocument>
 
@@ -46,28 +39,15 @@
 
 const int BITCOIN_IPC_CONNECT_TIMEOUT = 1000; // milliseconds
 const QString BITCOIN_IPC_PREFIX("dogecoin:");
-// BIP70 payment protocol messages
-const char* BIP70_MESSAGE_PAYMENTACK = "PaymentACK";
-const char* BIP70_MESSAGE_PAYMENTREQUEST = "PaymentRequest";
-// BIP71 payment protocol media types
-const char* BIP71_MIMETYPE_PAYMENT = "application/bitcoin-payment";
-const char* BIP71_MIMETYPE_PAYMENTACK = "application/bitcoin-paymentack";
-const char* BIP71_MIMETYPE_PAYMENTREQUEST = "application/bitcoin-paymentrequest";
 const int IPC_SOCKET_HASH = GetRandInt(INT_MAX);
 
-struct X509StoreDeleter {
-      void operator()(X509_STORE* b) {
-          X509_STORE_free(b);
-      }
-};
+// Create a file in datadir to store ipcServerName
 
-struct X509Deleter {
-      void operator()(X509* b) { X509_free(b); }
-};
-
-namespace // Anon namespace
+static QString dataDirServerFile()
 {
-    std::unique_ptr<X509_STORE, X509StoreDeleter> certStore;
+    QString dataDirPath = QString::fromStdString(GetDataDir(true).string());
+    QString filePath = dataDirPath + "/server_name.txt";
+    return filePath;
 }
 
 //
@@ -94,95 +74,6 @@ static QString ipcServerName()
 // to send payment.
 
 static QList<QString> savedPaymentRequests;
-
-static void ReportInvalidCertificate(const QSslCertificate& cert)
-{
-    qDebug() << QString("%1: Payment server found an invalid certificate: ").arg(__func__) << cert.serialNumber() << cert.subjectInfo(QSslCertificate::CommonName) << cert.subjectInfo(QSslCertificate::DistinguishedNameQualifier) << cert.subjectInfo(QSslCertificate::OrganizationalUnitName);
-}
-
-//
-// Load OpenSSL's list of root certificate authorities
-//
-void PaymentServer::LoadRootCAs(X509_STORE* _store)
-{
-    // Unit tests mostly use this, to pass in fake root CAs:
-    if (_store)
-    {
-        certStore.reset(_store);
-        return;
-    }
-
-    // Normal execution, use either -rootcertificates or system certs:
-    certStore.reset(X509_STORE_new());
-
-    // Note: use "-system-" default here so that users can pass -rootcertificates=""
-    // and get 'I don't like X.509 certificates, don't trust anybody' behavior:
-    QString certFile = QString::fromStdString(GetArg("-rootcertificates", "-system-"));
-
-    // Empty store
-    if (certFile.isEmpty()) {
-        qDebug() << QString("PaymentServer::%1: Payment request authentication via X.509 certificates disabled.").arg(__func__);
-        return;
-    }
-
-    QList<QSslCertificate> certList;
-
-    if (certFile != "-system-") {
-            qDebug() << QString("PaymentServer::%1: Using \"%2\" as trusted root certificate.").arg(__func__).arg(certFile);
-
-        certList = QSslCertificate::fromPath(certFile);
-        // Use those certificates when fetching payment requests, too:
-        QSslSocket::setDefaultCaCertificates(certList);
-    } else
-        certList = QSslSocket::systemCaCertificates();
-
-    int nRootCerts = 0;
-    const QDateTime currentTime = QDateTime::currentDateTime();
-
-    Q_FOREACH (const QSslCertificate& cert, certList) {
-        // Don't log NULL certificates
-        if (cert.isNull())
-            continue;
-
-        // Not yet active/valid, or expired certificate
-        if (currentTime < cert.effectiveDate() || currentTime > cert.expiryDate()) {
-            ReportInvalidCertificate(cert);
-            continue;
-        }
-
-        // Blacklisted certificate
-        if (cert.isBlacklisted()) {
-            ReportInvalidCertificate(cert);
-            continue;
-        }
-
-        QByteArray certData = cert.toDer();
-        const unsigned char *data = (const unsigned char *)certData.data();
-
-        std::unique_ptr<X509, X509Deleter> x509(d2i_X509(0, &data, certData.size()));
-        if (x509 && X509_STORE_add_cert(certStore.get(), x509.get()))
-        {
-            // Note: X509_STORE increases the reference count to the X509 object,
-            // we still have to release our reference to it.
-            ++nRootCerts;
-        }
-        else
-        {
-            ReportInvalidCertificate(cert);
-            continue;
-        }
-    }
-    qWarning() << "PaymentServer::LoadRootCAs: Loaded " << nRootCerts << " root certificates";
-
-    // Project for another day:
-    // Fetch certificate revocation lists, and add them to certStore.
-    // Issues to consider:
-    //   performance (start a thread to fetch in background?)
-    //   privacy (fetch through tor/proxy so IP address isn't revealed)
-    //   would it be easier to just use a compiled-in blacklist?
-    //    or use Qt's blacklist?
-    //   "certificate stapling" with server-side caching is more efficient
-}
 
 //
 // Sending to the server is done synchronously, at startup.
@@ -224,23 +115,6 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
                 }
             }
         }
-        else if (QFile::exists(arg)) // Filename
-        {
-            savedPaymentRequests.append(arg);
-
-            PaymentRequestPlus request;
-            if (readPaymentRequestFromFile(arg, request))
-            {
-                if (request.getDetails().genesis() == "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691")
-                {
-                    SelectParams(CBaseChainParams::MAIN);
-                }
-                else if (request.getDetails().genesis() == "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e")
-                {
-                    SelectParams(CBaseChainParams::TESTNET);
-                }
-            }
-        }
         else
         {
             // Printing to debug.log is about the best we can do here, the
@@ -258,11 +132,19 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 //
 bool PaymentServer::ipcSendCommandLine()
 {
+    // Attempt to retrieve server name from active instance from stored txt
+    QString existingServerName;
+    QFile serverNameFile(dataDirServerFile());
+    if (serverNameFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&serverNameFile);
+        existingServerName = in.readLine();
+        serverNameFile.close();
+    }
     bool fResult = false;
     Q_FOREACH (const QString& r, savedPaymentRequests)
     {
         QLocalSocket* socket = new QLocalSocket();
-        socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
+        socket->connectToServer(existingServerName, QIODevice::WriteOnly);
         if (!socket->waitForConnected(BITCOIN_IPC_CONNECT_TIMEOUT))
         {
             delete socket;
@@ -289,12 +171,7 @@ bool PaymentServer::ipcSendCommandLine()
     return fResult;
 }
 
-void PaymentServer::initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer, bool enableBip70) {
-    // Verify that the version of the library that we linked against is
-    // compatible with the version of the headers we compiled against.
-    GOOGLE_PROTOBUF_VERIFY_VERSION;
-    this->enableBip70 = enableBip70;
-
+void PaymentServer::initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer) {
     // Install global event filter to catch QFileOpenEvents
     // on Mac: sent when you click bitcoin: links
     // other OSes: helpful when dealing with payment request files
@@ -312,7 +189,14 @@ void PaymentServer::initializeServer(QObject* parent, QString ipcServerName, boo
         }
         else {
             connect(uriServer, SIGNAL(newConnection()), this, SLOT(handleURIConnection()));
-            connect(this, SIGNAL(receivedPaymentACK(QString)), this, SLOT(handlePaymentACK(QString)));
+            // Open server name from file to attempt socket connection from there 
+            // instead of new rand INT hashed socket each new instance
+            QFile serverNameFile(dataDirServerFile());
+            if (serverNameFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                QTextStream out(&serverNameFile);
+                out << ipcServerName;
+                serverNameFile.close();
+            }
         }
     }
 }
@@ -321,48 +205,18 @@ PaymentServer::PaymentServer(QObject* parent, bool startLocalServer) :
     QObject(parent),
     saveURIs(true),
     uriServer(0),
-    netManager(0),
     optionsModel(0)
 {
-    this->initializeServer(parent, ipcServerName(), startLocalServer, false);
+    this->initializeServer(parent, ipcServerName(), startLocalServer);
 }
-
-
-PaymentServer::PaymentServer(QObject* parent, bool startLocalServer, bool enableBip70) :
-    QObject(parent),
-    saveURIs(true),
-    uriServer(0),
-    netManager(0),
-    optionsModel(0)
-{
-    this->initializeServer(parent, ipcServerName(), startLocalServer, enableBip70);
-}
-
 
 PaymentServer::PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer) :
     QObject(parent),
     saveURIs(true),
     uriServer(0),
-    netManager(0),
     optionsModel(0)
 {
-    this->initializeServer(parent, ipcServerName, startLocalServer, false);
-}
-
-
-PaymentServer::PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer, bool enableBip70Flag) :
-    QObject(parent),
-    saveURIs(true),
-    uriServer(0),
-    netManager(0),
-    optionsModel(0)
-{
-    this->initializeServer(parent, ipcServerName, startLocalServer, enableBip70Flag);
-}
-
-PaymentServer::~PaymentServer()
-{
-    google::protobuf::ShutdownProtobufLibrary();
+    this->initializeServer(parent, ipcServerName, startLocalServer);
 }
 
 //
@@ -385,37 +239,8 @@ bool PaymentServer::eventFilter(QObject *object, QEvent *event)
     return QObject::eventFilter(object, event);
 }
 
-void PaymentServer::initNetManager()
-{
-    if (!optionsModel)
-        return;
-    if (netManager != NULL)
-        delete netManager;
-
-    // netManager is used to fetch paymentrequests given in bitcoin: URIs
-    netManager = new QNetworkAccessManager(this);
-
-    QNetworkProxy proxy;
-
-    // Query active SOCKS5 proxy
-    if (optionsModel->getProxySettings(proxy)) {
-        netManager->setProxy(proxy);
-
-        qDebug() << "PaymentServer::initNetManager: Using SOCKS5 proxy" << proxy.hostName() << ":" << proxy.port();
-    }
-    else
-        qDebug() << "PaymentServer::initNetManager: No active proxy server found.";
-
-    connect(netManager, SIGNAL(finished(QNetworkReply*)),
-            this, SLOT(netRequestFinished(QNetworkReply*)));
-    connect(netManager, SIGNAL(sslErrors(QNetworkReply*, const QList<QSslError> &)),
-            this, SLOT(reportSslErrors(QNetworkReply*, const QList<QSslError> &)));
-}
-
 void PaymentServer::uiReady()
 {
-    initNetManager();
-
     saveURIs = false;
     Q_FOREACH (const QString& s, savedPaymentRequests)
     {
@@ -436,81 +261,21 @@ void PaymentServer::handleURIOrFile(const QString& s)
     {
         QUrlQuery uri((QUrl(s)));
 
-        if (uri.hasQueryItem("r")) // payment request URI
-        {
-            if (!enableBip70) {
-              qDebug() << "PaymentServer::handleURIOrFile: 'r' item supplied but BIP70 disabled.";
-              Q_EMIT message(tr("URI handling"), tr(
-                      "BIP70 payment requests are deprecated and disabled by default. "
-                      "Restart with -enable-bip70 if you absolutely have to use this functionality.\n\n"
-                      "Use this functionality with extreme caution."),
-                  CClientUIInterface::MSG_ERROR);
-              return;
-            }
-            QByteArray temp;
-            temp.append(uri.queryItemValue("r").toUtf8());
-            QString decoded = QUrl::fromPercentEncoding(temp);
-            QUrl fetchUrl(decoded, QUrl::StrictMode);
-
-            if (fetchUrl.isValid())
-            {
-                qDebug() << "PaymentServer::handleURIOrFile: fetchRequest(" << fetchUrl << ")";
-                fetchRequest(fetchUrl);
-            }
-            else
-            {
-                qWarning() << "PaymentServer::handleURIOrFile: Invalid URL: " << fetchUrl;
-                Q_EMIT message(tr("URI handling"),
-                    tr("Payment request fetch URL is invalid: %1").arg(fetchUrl.toString()),
-                    CClientUIInterface::ICON_WARNING);
-            }
-
-            return;
-        }
-        else // normal URI
-        {
-            SendCoinsRecipient recipient;
-            if (GUIUtil::parseBitcoinURI(s, &recipient))
-            {
-                CBitcoinAddress address(recipient.address.toStdString());
-                if (!address.IsValid()) {
-                    Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
-                        CClientUIInterface::MSG_ERROR);
-                }
-                else
-                    Q_EMIT receivedPaymentRequest(recipient);
-            }
-            else
-                Q_EMIT message(tr("URI handling"),
-                    tr("URI cannot be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters."),
-                    CClientUIInterface::ICON_WARNING);
-
-            return;
-        }
-    }
-
-    // payment request file
-    if (!enableBip70) {
-        Q_EMIT message(tr("Payment request file handling"), tr(
-                "Payment request file handling is disabled by default. "
-                "Restart with -enable-bip70 if you absolutely have to use this functionality.\n\n"
-                "Use this functionality with extreme caution."),
-            CClientUIInterface::MSG_ERROR);
-        return;
-    }
-
-    if (QFile::exists(s))
-    {
-        PaymentRequestPlus request;
         SendCoinsRecipient recipient;
-        if (!readPaymentRequestFromFile(s, request))
+        if (GUIUtil::parseBitcoinURI(s, &recipient))
         {
-            Q_EMIT message(tr("Payment request file handling"),
-                tr("Payment request file cannot be read! This can be caused by an invalid payment request file."),
-                CClientUIInterface::ICON_WARNING);
+            CBitcoinAddress address(recipient.address.toStdString());
+            if (!address.IsValid()) {
+                Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
+                    CClientUIInterface::MSG_ERROR);
+            }
+            else
+                Q_EMIT receivedPaymentRequest(recipient);
         }
-        else if (processPaymentRequest(request, recipient))
-            Q_EMIT receivedPaymentRequest(recipient);
+        else
+            Q_EMIT message(tr("URI handling"),
+                tr("URI cannot be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters."),
+                CClientUIInterface::ICON_WARNING);
 
         return;
     }
@@ -537,305 +302,9 @@ void PaymentServer::handleURIConnection()
     handleURIOrFile(msg);
 }
 
-//
-// Warning: readPaymentRequestFromFile() is used in ipcSendCommandLine()
-// so don't use "Q_EMIT message()", but "QMessageBox::"!
-//
-bool PaymentServer::readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request)
-{
-    QFile f(filename);
-    if (!f.open(QIODevice::ReadOnly)) {
-        qWarning() << QString("PaymentServer::%1: Failed to open %2").arg(__func__).arg(filename);
-        return false;
-    }
-
-    // BIP70 DoS protection
-    if (!verifySize(f.size())) {
-        return false;
-    }
-
-    QByteArray data = f.readAll();
-
-    return request.parse(data);
-}
-
-bool PaymentServer::processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient)
-{
-    if (!optionsModel)
-        return false;
-
-    if (request.IsInitialized()) {
-        // Payment request network matches client network?
-        if (!verifyNetwork(request.getDetails())) {
-            Q_EMIT message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
-                CClientUIInterface::MSG_ERROR);
-
-            return false;
-        }
-
-        // Make sure any payment requests involved are still valid.
-        // This is re-checked just before sending coins in WalletModel::sendCoins().
-        if (verifyExpired(request.getDetails())) {
-            Q_EMIT message(tr("Payment request rejected"), tr("Payment request expired."),
-                CClientUIInterface::MSG_ERROR);
-
-            return false;
-        }
-    } else {
-        Q_EMIT message(tr("Payment request error"), tr("Payment request is not initialized."),
-            CClientUIInterface::MSG_ERROR);
-
-        return false;
-    }
-
-    recipient.paymentRequest = request;
-    recipient.message = GUIUtil::HtmlEscape(request.getDetails().memo());
-
-    request.getMerchant(certStore.get(), recipient.authenticatedMerchant);
-
-    QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
-    QStringList addresses;
-
-    for (const PAIRTYPE(CScript, CAmount)& sendingTo : sendingTos) {
-        // Extract and check destination addresses
-        CTxDestination dest;
-        if (ExtractDestination(sendingTo.first, dest)) {
-            // Append destination address
-            addresses.append(QString::fromStdString(CBitcoinAddress(dest).ToString()));
-        }
-        else if (!recipient.authenticatedMerchant.isEmpty()) {
-            // Unauthenticated payment requests to custom bitcoin addresses are not supported
-            // (there is no good way to tell the user where they are paying in a way they'd
-            // have a chance of understanding).
-            Q_EMIT message(tr("Payment request rejected"),
-                tr("Unverified payment requests to custom payment scripts are unsupported."),
-                CClientUIInterface::MSG_ERROR);
-            return false;
-        }
-
-        // Bitcoin amounts are stored as (optional) uint64 in the protobuf messages (see paymentrequest.proto),
-        // but CAmount is defined as int64_t. Because of that we need to verify that amounts are in a valid range
-        // and no overflow has happened.
-        if (!verifyAmount(sendingTo.second)) {
-            Q_EMIT message(tr("Payment request rejected"), tr("Invalid payment request."), CClientUIInterface::MSG_ERROR);
-            return false;
-        }
-
-        // Extract and check amounts
-        CTxOut txOut(sendingTo.second, sendingTo.first);
-        if (txOut.IsDust(CWallet::discardThreshold)) {
-            Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (below discard threshold).")
-                .arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
-                CClientUIInterface::MSG_ERROR);
-
-            return false;
-        }
-
-        recipient.amount += sendingTo.second;
-        // Also verify that the final amount is still in a valid range after adding additional amounts.
-        if (!verifyAmount(recipient.amount)) {
-            Q_EMIT message(tr("Payment request rejected"), tr("Invalid payment request."), CClientUIInterface::MSG_ERROR);
-            return false;
-        }
-    }
-    // Store addresses and format them to fit nicely into the GUI
-    recipient.address = addresses.join("<br />");
-
-    if (!recipient.authenticatedMerchant.isEmpty()) {
-        qDebug() << "PaymentServer::processPaymentRequest: Secure payment request from " << recipient.authenticatedMerchant;
-    }
-    else {
-        qDebug() << "PaymentServer::processPaymentRequest: Insecure payment request to " << addresses.join(", ");
-    }
-
-    return true;
-}
-
-void PaymentServer::fetchRequest(const QUrl& url)
-{
-    QNetworkRequest netRequest;
-    netRequest.setAttribute(QNetworkRequest::User, BIP70_MESSAGE_PAYMENTREQUEST);
-    netRequest.setUrl(url);
-    netRequest.setRawHeader("User-Agent", CLIENT_NAME.c_str());
-    netRequest.setRawHeader("Accept", BIP71_MIMETYPE_PAYMENTREQUEST);
-    netManager->get(netRequest);
-}
-
-void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction)
-{
-    const payments::PaymentDetails& details = recipient.paymentRequest.getDetails();
-    if (!details.has_payment_url())
-        return;
-
-    QNetworkRequest netRequest;
-    netRequest.setAttribute(QNetworkRequest::User, BIP70_MESSAGE_PAYMENTACK);
-    netRequest.setUrl(QString::fromStdString(details.payment_url()));
-    netRequest.setHeader(QNetworkRequest::ContentTypeHeader, BIP71_MIMETYPE_PAYMENT);
-    netRequest.setRawHeader("User-Agent", CLIENT_NAME.c_str());
-    netRequest.setRawHeader("Accept", BIP71_MIMETYPE_PAYMENTACK);
-
-    payments::Payment payment;
-    payment.set_merchant_data(details.merchant_data());
-    payment.add_transactions(transaction.data(), transaction.size());
-
-    // Create a new refund address, or re-use:
-    QString account = tr("Refund from %1").arg(recipient.authenticatedMerchant);
-    std::string strAccount = account.toStdString();
-    std::set<CTxDestination> refundAddresses = wallet->GetAccountAddresses(strAccount);
-    if (!refundAddresses.empty()) {
-        CScript s = GetScriptForDestination(*refundAddresses.begin());
-        payments::Output* refund_to = payment.add_refund_to();
-        refund_to->set_script(&s[0], s.size());
-    }
-    else {
-        CPubKey newKey;
-        if (wallet->GetKeyFromPool(newKey)) {
-            CKeyID keyID = newKey.GetID();
-            wallet->SetAddressBook(keyID, strAccount, "refund");
-
-            CScript s = GetScriptForDestination(keyID);
-            payments::Output* refund_to = payment.add_refund_to();
-            refund_to->set_script(&s[0], s.size());
-        }
-        else {
-            // This should never happen, because sending coins should have
-            // just unlocked the wallet and refilled the keypool.
-            qWarning() << "PaymentServer::fetchPaymentACK: Error getting refund key, refund_to not set";
-        }
-    }
-
-    quint64 length = payment.ByteSizeLong();
-    netRequest.setHeader(QNetworkRequest::ContentLengthHeader, length);
-    QByteArray serData(length, '\0');
-    if (payment.SerializeToArray(serData.data(), length)) {
-        netManager->post(netRequest, serData);
-    }
-    else {
-        // This should never happen, either.
-        qWarning() << "PaymentServer::fetchPaymentACK: Error serializing payment message";
-    }
-}
-
-void PaymentServer::netRequestFinished(QNetworkReply* reply)
-{
-    reply->deleteLater();
-
-    // BIP70 DoS protection
-    if (!verifySize(reply->size())) {
-        Q_EMIT message(tr("Payment request rejected"),
-            tr("Payment request %1 is too large (%2 bytes, allowed %3 bytes).")
-                .arg(reply->request().url().toString())
-                .arg(reply->size())
-                .arg(BIP70_MAX_PAYMENTREQUEST_SIZE),
-            CClientUIInterface::MSG_ERROR);
-        return;
-    }
-
-    if (reply->error() != QNetworkReply::NoError) {
-        QString msg = tr("Error communicating with %1: %2")
-            .arg(reply->request().url().toString())
-            .arg(reply->errorString());
-
-        qWarning() << "PaymentServer::netRequestFinished: " << msg;
-        Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
-        return;
-    }
-
-    QByteArray data = reply->readAll();
-
-    QString requestType = reply->request().attribute(QNetworkRequest::User).toString();
-    if (requestType == BIP70_MESSAGE_PAYMENTREQUEST)
-    {
-        PaymentRequestPlus request;
-        SendCoinsRecipient recipient;
-        if (!request.parse(data))
-        {
-            qWarning() << "PaymentServer::netRequestFinished: Error parsing payment request";
-            Q_EMIT message(tr("Payment request error"),
-                tr("Payment request cannot be parsed!"),
-                CClientUIInterface::MSG_ERROR);
-        }
-        else if (processPaymentRequest(request, recipient))
-            Q_EMIT receivedPaymentRequest(recipient);
-
-        return;
-    }
-    else if (requestType == BIP70_MESSAGE_PAYMENTACK)
-    {
-        payments::PaymentACK paymentACK;
-        if (!paymentACK.ParseFromArray(data.data(), data.size()))
-        {
-            QString msg = tr("Bad response from server %1")
-                .arg(reply->request().url().toString());
-
-            qWarning() << "PaymentServer::netRequestFinished: " << msg;
-            Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
-        }
-        else
-        {
-            Q_EMIT receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
-        }
-    }
-}
-
-void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError> &errs)
-{
-    Q_UNUSED(reply);
-
-    QString errString;
-    Q_FOREACH (const QSslError& err, errs) {
-        qWarning() << "PaymentServer::reportSslErrors: " << err;
-        errString += err.errorString() + "\n";
-    }
-    Q_EMIT message(tr("Network request error"), errString, CClientUIInterface::MSG_ERROR);
-}
-
 void PaymentServer::setOptionsModel(OptionsModel *_optionsModel)
 {
     this->optionsModel = _optionsModel;
-}
-
-void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
-{
-    // currently we don't further process or store the paymentACK message
-    Q_EMIT message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
-}
-
-bool PaymentServer::verifyNetwork(const payments::PaymentDetails& requestDetails)
-{
-    Consensus::Params consensus = Params().GetConsensus(0);
-    bool fVerified = requestDetails.genesis() == consensus.hashGenesisBlock.GetHex();
-    if (!fVerified) {
-        qWarning() << QString("PaymentServer::%1: Payment request network \"%2\" doesn't match client network \"%3\".")
-            .arg(__func__)
-            .arg(QString::fromStdString(requestDetails.genesis()))
-            .arg(QString::fromStdString(consensus.hashGenesisBlock.GetHex()));
-    }
-    return fVerified;
-}
-
-bool PaymentServer::verifyExpired(const payments::PaymentDetails& requestDetails)
-{
-    bool fVerified = (requestDetails.has_expires() && (int64_t)requestDetails.expires() < GetTime());
-    if (fVerified) {
-        const QString requestExpires = QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", (int64_t)requestDetails.expires()));
-        qWarning() << QString("PaymentServer::%1: Payment request expired \"%2\".")
-            .arg(__func__)
-            .arg(requestExpires);
-    }
-    return fVerified;
-}
-
-bool PaymentServer::verifySize(qint64 requestSize)
-{
-    bool fVerified = (requestSize <= BIP70_MAX_PAYMENTREQUEST_SIZE);
-    if (!fVerified) {
-        qWarning() << QString("PaymentServer::%1: Payment request too large (%2 bytes, allowed %3 bytes).")
-            .arg(__func__)
-            .arg(requestSize)
-            .arg(BIP70_MAX_PAYMENTREQUEST_SIZE);
-    }
-    return fVerified;
 }
 
 bool PaymentServer::verifyAmount(const CAmount& requestAmount)
@@ -848,9 +317,4 @@ bool PaymentServer::verifyAmount(const CAmount& requestAmount)
             .arg(MAX_MONEY);
     }
     return fVerified;
-}
-
-X509_STORE* PaymentServer::getCertStore()
-{
-    return certStore.get();
 }

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -33,7 +33,6 @@
 // sends them to the server.
 //
 
-#include "paymentrequestplus.h"
 #include "walletmodel.h"
 
 #include <QObject>
@@ -47,14 +46,8 @@ QT_BEGIN_NAMESPACE
 class QApplication;
 class QByteArray;
 class QLocalServer;
-class QNetworkAccessManager;
-class QNetworkReply;
-class QSslError;
 class QUrl;
 QT_END_NAMESPACE
-
-// BIP70 max payment request size in bytes (DoS protection)
-static const qint64 BIP70_MAX_PAYMENTREQUEST_SIZE = 50000;
 
 class PaymentServer : public QObject
 {
@@ -74,39 +67,17 @@ public:
 
     // parent should be QApplication object
     PaymentServer(QObject* parent, bool startLocalServer = true);
-    PaymentServer(QObject* parent, bool startLocalServer = true, bool enableBip70Flag = false);
     PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer = true);
-    PaymentServer(QObject* parent, QString ipcServerName, bool startLocalServer = true, bool enableBip70Flag = false);
-    ~PaymentServer();
-
-    // Load root certificate authorities. Pass NULL (default)
-    // to read from the file specified in the -rootcertificates setting,
-    // or, if that's not set, to use the system default root certificates.
-    // If you pass in a store, you should not X509_STORE_free it: it will be
-    // freed either at exit or when another set of CAs are loaded.
-    static void LoadRootCAs(X509_STORE* store = NULL);
-
-    // Return certificate store
-    static X509_STORE* getCertStore();
 
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
 
-    // Verify that the payment request network matches the client network
-    static bool verifyNetwork(const payments::PaymentDetails& requestDetails);
-    // Verify if the payment request is expired
-    static bool verifyExpired(const payments::PaymentDetails& requestDetails);
-    // Verify the payment request size is valid as per BIP70
-    static bool verifySize(qint64 requestSize);
     // Verify the payment request amount is valid
     static bool verifyAmount(const CAmount& requestAmount);
 
 Q_SIGNALS:
     // Fired when a valid payment request is received
     void receivedPaymentRequest(SendCoinsRecipient);
-
-    // Fired when a valid PaymentACK is received
-    void receivedPaymentACK(const QString &paymentACKMsg);
 
     // Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);
@@ -116,17 +87,11 @@ public Q_SLOTS:
     // to display payment requests to the user
     void uiReady();
 
-    // Submit Payment message to a merchant, get back PaymentACK:
-    void fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction);
-
     // Handle an incoming URI, URI with local file scheme or file
     void handleURIOrFile(const QString& s);
 
 private Q_SLOTS:
     void handleURIConnection();
-    void netRequestFinished(QNetworkReply*);
-    void reportSslErrors(QNetworkReply*, const QList<QSslError> &);
-    void handlePaymentACK(const QString& paymentACKMsg);
 
 protected:
     // Constructor registers this on the parent QApplication to
@@ -134,20 +99,10 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
-    static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
-    bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
-    void fetchRequest(const QUrl& url);
-
-    // Setup networking
-    void initNetManager();
-
     bool saveURIs;                      // true during startup
 
-    void initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer, bool enableBip70Flag);
-    bool enableBip70;                   // false by default
+    void initializeServer(QObject* parent, QString ipcServerName, bool startLocalServer);
     QLocalServer* uriServer;
-
-    QNetworkAccessManager* netManager;  // Used to fetch payment requests
 
     OptionsModel *optionsModel;
 };


### PR DESCRIPTION
- Update IPC Server Name handling to QFile so random hashing can be preserved, prioritize attempts to open instances, and generate new sockets if new server is initialized
- Moves debug handler up for IPC URI/Initialize visibility
- Removes unused PaymentServer bip70 arguments
- NOTE: contains patricklodder::1.15.0-remove-bip70 branch (Sorry I didn't isolate my changes! I'm still learning Git!)