### PR TITLE
Enable importprivkey, importpubkey, importaddress in pruned mode 

### DIFF
--- a/qa/rpc-tests/import-rescan.py
+++ b/qa/rpc-tests/import-rescan.py
@@ -163,7 +163,7 @@ class ImportRescanTest(BitcoinTestFramework):
         # For each variation of wallet key import, invoke the import RPC and
         # check the results from getbalance and listtransactions.
         for variant in IMPORT_VARIANTS:
-            variant.expect_disabled = variant.rescan == Rescan.yes and variant.prune and variant.call == Call.single
+            variant.expect_disabled = False # enable rescan for pruned mode
             expect_rescan = variant.rescan == Rescan.yes and not variant.expect_disabled
             variant.node = self.nodes[2 + IMPORT_NODES.index(ImportNode(variant.prune, expect_rescan))]
             variant.do_import(timestamp)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -125,9 +125,6 @@ UniValue importprivkey(const JSONRPCRequest& request)
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
-    if (fRescan && fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
-
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
@@ -152,9 +149,19 @@ UniValue importprivkey(const JSONRPCRequest& request)
         if (!pwalletMain->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 
-        if (fRescan) {
-            const uint32_t nHeight = getHeightParamFromRequest(request, 3);
-            attemptRescanFromHeight(nHeight);
+        if (fRescan) 
+        {
+            if (fPruneMode)
+            {
+                const uint32_t npHeight = pwalletMain->GetPrunedRescanHeight();
+                attemptRescanFromHeight(npHeight);
+            }
+
+            else
+            {
+                const uint32_t nHeight = getHeightParamFromRequest(request, 3);
+                attemptRescanFromHeight(nHeight);
+            }
         }
     }
 
@@ -173,6 +180,7 @@ uint32_t getHeightParamFromRequest(const JSONRPCRequest& request, const size_t p
 
     return nHeight;
 }
+
 
 void attemptRescanFromHeight(const uint32_t nHeight)
 {
@@ -260,9 +268,6 @@ UniValue importaddress(const JSONRPCRequest& request)
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
-    if (fRescan && fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
-
     // Whether to import a p2sh version, too
     bool fP2SH = false;
     if (request.params.size() > 3)
@@ -282,9 +287,19 @@ UniValue importaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Dogecoin address or script");
     }
 
-    if (fRescan) {
-        const uint32_t nHeight = getHeightParamFromRequest(request, 4);
-        attemptRescanFromHeight(nHeight);
+    if (fRescan) 
+    {
+        if (fPruneMode)
+        {
+            const uint32_t npHeight = pwalletMain->GetPrunedRescanHeight();
+            attemptRescanFromHeight(npHeight);
+        }
+        
+        else
+        {
+            const uint32_t nHeight = getHeightParamFromRequest(request, 4);
+            attemptRescanFromHeight(nHeight);
+        }    
     }
 
     return NullUniValue;
@@ -421,9 +436,6 @@ UniValue importpubkey(const JSONRPCRequest& request)
     if (request.params.size() > 2)
         fRescan = request.params[2].get_bool();
 
-    if (fRescan && fPruneMode)
-        throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
-
     if (!IsHex(request.params[0].get_str()))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey must be a hex string");
     std::vector<unsigned char> data(ParseHex(request.params[0].get_str()));
@@ -436,9 +448,19 @@ UniValue importpubkey(const JSONRPCRequest& request)
     ImportAddress(CBitcoinAddress(pubKey.GetID()), strLabel);
     ImportScript(GetScriptForRawPubKey(pubKey), strLabel, false);
 
-    if (fRescan) {
-        const uint32_t nHeight = getHeightParamFromRequest(request, 3);
-        attemptRescanFromHeight(nHeight);
+    if (fRescan) 
+    {
+        if (fPruneMode)
+        {
+                const uint32_t npHeight = pwalletMain->GetPrunedRescanHeight();
+                attemptRescanFromHeight(npHeight);
+        }
+
+        else
+        {
+            const uint32_t nHeight = getHeightParamFromRequest(request, 3);
+            attemptRescanFromHeight(nHeight);
+        }
     }
 
     return NullUniValue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3863,6 +3863,23 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     return walletInstance;
 }
 
+// public accessor for block rescan index 
+uint32_t CWallet::GetPrunedRescanHeight() const
+{
+    //Get starting block index for rescan
+    return CWallet::GetHeightForRescan();
+}
+
+uint32_t CWallet::GetHeightForRescan() const
+{
+    CBlockIndex *block = chainActive.Tip();
+    
+    while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA) && block->pprev->nTx > 0)
+                block = block->pprev;
+
+    return (uint32_t) (block->nHeight);
+}
+
 bool CWallet::InitLoadWallet()
 {
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -599,6 +599,9 @@ private:
      */
     bool AddWatchOnly(const CScript& dest) override;
 
+    /* Get starting block index for rescanning in pruned mode */
+    uint32_t GetHeightForRescan() const;
+
 public:
     /*
      * Main wallet lock.
@@ -971,6 +974,9 @@ public:
     
     /* Set the current HD master key (will reset the chain child index counters) */
     bool SetHDMasterKey(const CPubKey& key);
+
+    /* Get starting rescan height for pruned node */
+    uint32_t GetPrunedRescanHeight() const;
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
Greetings!

This PR aims to "unlock" `importprivkey`, `importpubkey`, `importaddress` RPC methods in pruned mode mentioned in #3631.  

The testing I did (in addition to `rpc-tests` and boost test runs) was as follows: have 3 Dogecoin Core installations A (full blockchain version 1.14.8) , B (pruned mode `-prune=2201` from 'master' with this implementation), C (same as B).  I would send small funds from A to B, then import private key, public address, or public key from B into C.  Then send funds back from C to A (having some amount also debited from B because B and C share a private key and address when C is generating input for TX) and do this in circle several times at each code change I did and the RPC methods worked every time.  Here is the relevant excerpt from from `debug.log` (with added printout for debugging) for C:

```
...
2024-09-18 00:29:56 LoadBlockIndexDB: last block file = 1123
2024-09-18 00:29:56 LoadBlockIndexDB: last block file info: CBlockFileInfo(blocks=1291, size=93637696, heights=5381480...5382771, time=2024-09-17...2024-09-17)
2024-09-18 00:29:56 Checking all blk files are present...
2024-09-18 00:29:57 LoadBlockIndexDB(): Block files have previously been pruned
2024-09-18 00:29:57 LoadBlockIndexDB: transaction index disabled
2024-09-18 00:29:58 LoadBlockIndexDB: hashBestChain=d75d305e6a9a548a8e479b2b9691ee6e9327d3398ea67ec045981444150f7480 height=5382771 date=2024-09-17 23:59:29 progress=0.999978
2024-09-18 00:29:58 init message: Rewinding blocks...
2024-09-18 00:30:09 init message: Verifying blocks...
2024-09-18 00:30:09 Verifying last 6 blocks at level 3
2024-09-18 00:30:09 [0%]...[16%]...[33%]...[50%]...[66%]...[83%]...[99%]...[DONE].
2024-09-18 00:30:09 No coin database inconsistencies in last 7 blocks (249 transactions)
2024-09-18 00:30:09  block index           36461ms
2024-09-18 00:30:09 init message: Loading wallet...
2024-09-18 00:30:09 nFileVersion = 1210000
2024-09-18 00:30:09 Keys: 0 plaintext, 6028 encrypted, 6035 w/ metadata, 6028 total
2024-09-18 00:30:09  wallet                   60ms
2024-09-18 00:30:09 setKeyPool.size() = 1993
2024-09-18 00:30:09 mapWallet.size() = 27
2024-09-18 00:30:09 mapAddressBook.size() = 36
2024-09-18 00:30:09 Unsetting NODE_NETWORK on prune mode
2024-09-18 00:30:09 init message: Pruning blockstore...
2024-09-18 00:30:09 mapBlockIndex.size() = 5382791
2024-09-18 00:30:09 nBestHeight = 5382771
2024-09-18 00:30:09 torcontrol thread start
2024-09-18 00:30:09 AddLocal([2001:569:50fd:cd00:f8fd:b0be:653b:2716]:22556,1)
2024-09-18 00:30:09 Discover: IPv6 wlp59s0: 2001:569:50fd:cd00:f8fd:b0be:653b:2716
2024-09-18 00:30:09 AddLocal([2001:569:50fd:cd00:fce0:614e:fe2d:137e]:22556,1)
2024-09-18 00:30:09 Discover: IPv6 wlp59s0: 2001:569:50fd:cd00:fce0:614e:fe2d:137e
2024-09-18 00:30:09 init message: Loading addresses...
2024-09-18 00:30:09 Imported mempool transactions from disk: 1 successes, 0 failed, 0 expired
2024-09-18 00:30:09 Loaded 24401 addresses from peers.dat  63ms
2024-09-18 00:30:09 init message: Loading banlist...
2024-09-18 00:30:09 init message: Starting network threads...
2024-09-18 00:30:09 net thread start
2024-09-18 00:30:09 dnsseed thread start
2024-09-18 00:30:09 addcon thread start
2024-09-18 00:30:09 opencon thread start
2024-09-18 00:30:09 init message: Done loading
2024-09-18 00:30:09 msghand thread start
2024-09-18 00:30:09 GUI: Platform customization: "other"
2024-09-18 00:30:10 receive version message: /Shibetoshi:1.14.8/: version 70015, blocks=5382799, us=50.92.239.94:38084, peer=0
2024-09-18 00:30:20 Loading addresses from DNS seeds (could take a while)
2024-09-18 00:30:20 75 addresses found from DNS seeds
2024-09-18 00:30:20 dnsseed thread exit
2024-09-18 00:30:24 UpdateTip: new log2_work=76.272804 tx=350348918 date='2024-09-18 00:29:07' progress=0.999999 
...
cache=1.6MiB(2314tx)
2024-09-18 00:30:30 -> current chainActive.tip() height: 5382799 
2024-09-18 00:30:30 -> value of starting rescan index: 5347545 
2024-09-18 00:30:36 AddToWallet debaa0697b1c87fb3915d9bef55a0890084c7465af737a6e26fbb18eb3943202  
2024-09-18 00:30:39 AddToWallet 26936d475cdc3fce4e7004c918a546c06b50d0b768298c35e57e978112d2ae48  
2024-09-18 00:30:39 AddToWallet f1a7316a8aa6ce378f9cd934743d85885995f016221e8f79c8f70436eebffd87  
2024-09-18 00:30:39 AddToWallet c98e104f27475966e7dc37fd30c2e5d87cde90f4ae3efe1fb0146b32856d8882  
2024-09-18 00:30:40 AddToWallet 01f5a3fc5ddbbe4b4e39c04caa7069c233852fb23965c1a2c248bdb5a11d43e4  
2024-09-18 00:30:41 AddToWallet cba15455727d97f042a7853e2f2dfa1ea65ef15a973196dbb4008d04d0d4f607  
2024-09-18 00:30:58 AddToWallet e505aae05353c6c6721a238d9b8be98542b38997a31b5794a98b7a5ec35faa65  
2024-09-18 00:30:58 AddToWallet e6ef8c66b89f9fe25b37555c3e73e144d9b2b67f8433bdf18d047c6ecc5ffee2  
2024-09-18 00:30:58 AddToWallet a1e2c7fa9c4098a43cb79fbebc1e97d2bc374eba4e11dd62a8cdade3e065eaaf  
2024-09-18 00:30:58 AddToWallet 4ebb0f50b3ff949eb11e78e3e7be3e55351499ccca6905f9f3590e660cb35435  
2024-09-18 00:31:00 AddToWallet 48aaa8cf391c06508e724aa22eb2f9062b0f7b7c767e643562db749bad1791ea  
2024-09-18 00:31:01 AddToWallet 4155d46facd9e5d871cfd315d76312e89484df987497d355c8aefa1594b71014  
2024-09-18 00:31:03 AddToWallet 1e93422f3641d7f3fdd75e6ac09daaaee3d528da143fed035668d6064c047f60  
2024-09-18 00:31:03 AddToWallet dfe1383efa73ed7705ae0d61a7efbe39c69e55561ab7f7d4f23d474f6c5c9758  
2024-09-18 00:31:03 AddToWallet 10d45ceaff5c381bb54792713e51ac17339743853fe42a589eb19e7ad3546bdb  
2024-09-18 00:31:03 AddToWallet 5ea3d74c24eb4dc7ade2ec4a6d9328d9eb6ba10cd0beb2edb34e6edf06e26c21  
2024-09-18 00:31:03 AddToWallet 60152e80e962d41138b9e580553cf7d24ea23ef0e642663085d11736f4138f0c  
...
```
This implementation works thanks to the loop in `GetHeightForRescan() ` function implemented previously by other developers which also terminates at the cut off point of a pruned blockchain and the block index can serve as a starting index for rescanning.  If this approach is accepted, then maybe we introduce additional scanning functionalities in pruned mode suggested previously?  "small moves"  🙂  Thank you.