### PR TITLE
Remove IPC Socket Hash Randomization

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -53,7 +53,6 @@ const char* BIP70_MESSAGE_PAYMENTREQUEST = "PaymentRequest";
 const char* BIP71_MIMETYPE_PAYMENT = "application/bitcoin-payment";
 const char* BIP71_MIMETYPE_PAYMENTACK = "application/bitcoin-paymentack";
 const char* BIP71_MIMETYPE_PAYMENTREQUEST = "application/bitcoin-paymentrequest";
-const int IPC_SOCKET_HASH = GetRandInt(INT_MAX);
 
 struct X509StoreDeleter {
       void operator()(X509_STORE* b) {
@@ -83,7 +82,7 @@ static QString ipcServerName()
     // Note that GetDataDir(true) returns a different path
     // for -testnet versus main net
     QString ddir(GUIUtil::boostPathToQString(GetDataDir(true)));
-    name.append(QString::number(qHash(ddir, IPC_SOCKET_HASH)));
+    name.append(QString::number(qHash(ddir)));
 
     return name;
 }


### PR DESCRIPTION
Removes the randomization of the IPC Server Name (to align with Bitcoin paymentserver.cpp repo) to allow for URI handling in Windows while an existing application is open.

Reverted change that several users reported resulted in the error: "Cannot obtain a lock on data directory [drive:path\to\dogecoin\datadir]. Dogecoin Core is probably already running"

This is to replace #3637 and simplify/isolate changes & discussion as a PR. 