### PR TITLE
Check auxpow PoW before the auxpow itself.

### DIFF
--- a/src/auxpow.cpp
+++ b/src/auxpow.cpp
@@ -101,6 +101,10 @@ CAuxPow::check(const uint256& hashAuxBlock, int nChainId,
           != parentBlock.hashMerkleRoot)
         return error("Aux POW merkle root incorrect");
 
+    // Check that there is at least one input.
+    if (tx->vin.empty())
+        return error("Aux POW coinbase has no inputs");
+
     const CScript script = tx->vin[0].scriptSig;
 
     // Check that the same work is not submitted twice to our chain.

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -115,10 +115,11 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
     if (!block.IsAuxpow())
         return error("%s : auxpow on block with non-auxpow version", __func__);
 
-    if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
-        return error("%s : AUX POW is not valid", __func__);
     if (!CheckProofOfWork(block.auxpow->getParentBlockPoWHash(), block.nBits, params))
         return error("%s : AUX proof of work failed", __func__);
+
+    if (!block.auxpow->check(block.GetHash(), block.GetChainId(), params))
+        return error("%s : AUX POW is not valid", __func__);
 
     return true;
 }

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -203,6 +203,15 @@ BOOST_AUTO_TEST_CASE(check_auxpow)
     builder.setCoinbase(scr);
     BOOST_CHECK(builder.get().check(hashAux, ourChainId, params));
 
+    /* An auxpow without any inputs in the parent coinbase tx should be
+     handled gracefully (and be considered invalid).  */
+    CMutableTransaction mtx(*builder.parentBlock.vtx[0]);
+    mtx.vin.clear();
+    builder.parentBlock.vtx.clear();
+    builder.parentBlock.vtx.push_back (MakeTransactionRef(std::move (mtx)));
+    builder.parentBlock.hashMerkleRoot = BlockMerkleRoot(builder.parentBlock);
+    BOOST_CHECK(!builder.get().check(hashAux, ourChainId, params));
+
     /* Check that the auxpow is invalid if we change either the aux block's
      hash or the chain ID.  */
     uint256 modifiedAux(hashAux);


### PR DESCRIPTION
Upstream fix from Namecoin Core that reverses the order in which the auxpow structure and the PoW on it are verified.  By checking the PoW first, we make it harder for random nodes to pass data of their choosing into CAuxPow::check.

Cherry-picked from: namecoin/namecoin-core@b6e3241b
