### PR TITLE
fix compatibility with boost 1.83

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1650,7 +1650,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
     // No locking, as this happens before any background thread is started.
     if (chainActive.Tip() == NULL) {
-        uiInterface.NotifyBlockTip.connect(BlockNotifyGenesisWait);
+        uiInterface.NotifyBlockTip.connect(&BlockNotifyGenesisWait);
     } else {
         fHaveGenesis = true;
     }
@@ -1673,7 +1673,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         while (!fHaveGenesis) {
             condvar_GenesisWait.wait(lock);
         }
-        uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
+        uiInterface.NotifyBlockTip.disconnect(&BlockNotifyGenesisWait);
     }
 
     // ********************************************************* Step 11: start node


### PR DESCRIPTION
[Bugfix] Fix incorrect disconnect call for static functions

Problem:
When using `uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait)` to disconnect a static function, the compilation fails because `boost::signals2::disconnect` requires the exact type signature match of the slot. Using the function name directly doesn't resolve to the correct function pointer for static functions.

Solution:
The fix explicitly uses `&BlockNotifyGenesisWait` to pass the function pointer. This resolves the compilation error.

Impact:
Only affects the disconnect mechanism for static functions in `uiInterface.NotifyBlockTip`.