### PR TITLE
ci: check subtrees

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,3 +15,18 @@ jobs:
     - uses: actions/checkout@v4
     - name: Lint translation files
       run: python3 contrib/devtools/check-translations.py
+  subtrees:
+    name: Check Subtrees
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Install prerequisites
+      run: sudo apt update && sudo apt install -y bash git jq
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check subtree integrity
+      run: |
+        jq -r '.[] | [.name, .remote] | join(" ")' contrib/subtrees.json | xargs -n2 git remote add
+        jq -r '.[].name' contrib/subtrees.json | xargs -n1 git fetch
+        jq -r '.[].path' contrib/subtrees.json | xargs -n1 bash contrib/devtools/git-subtree-check.sh

--- a/contrib/subtrees.json
+++ b/contrib/subtrees.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "univalue-subtree",
+    "path": "src/univalue",
+    "remote": "https://github.com/dogecoin/univalue-subtree.git"
+  },
+  {
+    "name": "secp256k1-subtree",
+    "path": "src/secp256k1",
+    "remote": "https://github.com/bitcoin-core/secp256k1.git"
+  },
+  {
+    "name": "leveldb-subtree",
+    "path": "src/leveldb",
+    "remote": "https://github.com/bitcoin-core/leveldb-subtree"
+  }
+]


### PR DESCRIPTION
Does a checkout of the full commit history and checks the status integrity of each subtree using the `git-subtree-check.sh` provided in `contrib/devtools`. Default subtree remotes are defined in the new file `contrib/subtrees.json`

----

~As of opening this pull request, the subtree on `src/leveldb` fails this check because the subtree information was stripped when upstream commits were cherry-picked in #2637. This has to be fixed first - opening as draft for visibility.~