### PR TITLE
Increase OP_RETURN relay limit from 80 bytes -> 420 bytes

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83; //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY = 423; //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 


### PR DESCRIPTION
From discussion: https://github.com/dogecoin/dogecoin/discussions/3829

This changes the standard transaction definition to include op_return utxos up to 420 bytes.