### PR TITLE
rpc: unify auxpow caching / simplify implementation

### DIFF
--- a/qa/rpc-tests/createauxblock.py
+++ b/qa/rpc-tests/createauxblock.py
@@ -82,25 +82,39 @@ class CreateAuxBlockTest(BitcoinTestFramework):
     assert_equal(auxblock["chainid"], auxblock3["chainid"])
     assert_equal(auxblock["target"], auxblock3["target"])
 
-    # If we receive a new block, the template cache must be emptied.
-    self.sync_all()
-    self.nodes[1].generate(1)
-    self.sync_all()
-
-    auxblock4 = self.nodes[0].createauxblock(dummy_p2pkh_addr)
-    assert auxblock["hash"] != auxblock4["hash"]
+    # Invalid format for hash - fails before checking auxpow
     try:
-      self.nodes[0].submitauxblock(auxblock["hash"], "x")
-      raise AssertionError("invalid block hash accepted")
+      self.nodes[0].submitauxblock("00", "x")
+      raise AssertionError("malformed hash accepted")
     except JSONRPCException as exc:
-      assert_equal(exc.error["code"], -8)
+      assert_equal(exc.error['code'], -8)
+      assert("hash must be of length 64" in exc.error["message"])
 
     # Invalid format for auxpow.
     try:
-      self.nodes[0].submitauxblock(auxblock4["hash"], "x")
+      self.nodes[0].submitauxblock(auxblock2['hash'], "x")
       raise AssertionError("malformed auxpow accepted")
     except JSONRPCException as exc:
-      assert_equal(exc.error["code"], -1)
+      assert_equal(exc.error['code'], -22)
+      assert("decode failed" in exc.error["message"])
+
+    # If we receive a new block, the old hash will be replaced.
+    self.sync_all()
+    self.nodes[1].generate(1)
+    self.sync_all()
+    auxblock2 = self.nodes[0].createauxblock(dummy_p2pkh_addr)
+    assert auxblock['hash'] != auxblock2['hash']
+    apow = auxpow.computeAuxpowWithChainId(auxblock['hash'], auxpow.reverseHex(auxblock['target']), "98", True)
+    try:
+        self.nodes[0].submitauxblock(auxblock['hash'], apow)
+        raise AssertionError("invalid block hash accepted")
+    except JSONRPCException as exc:
+        assert_equal(exc.error['code'], -8)
+        assert("block hash unknown" in exc.error["message"])
+
+    # Auxpow doesn't match given hash
+    res = self.nodes[0].submitauxblock(auxblock2['hash'], apow)
+    assert not res
 
     # Invalidate the block again, send a transaction and query for the
     # auxblock to solve that contains the transaction.

--- a/qa/rpc-tests/getauxblock.py
+++ b/qa/rpc-tests/getauxblock.py
@@ -51,24 +51,39 @@ class GetAuxBlockTest (BitcoinTestFramework):
     auxblock2 = self.nodes[0].getauxblock ()
     assert_equal (auxblock2, auxblock)
 
-    # If we receive a new block, the old hash will be replaced.
-    self.sync_all ()
-    self.nodes[1].generate (1)
-    self.sync_all ()
-    auxblock2 = self.nodes[0].getauxblock ()
-    assert auxblock['hash'] != auxblock2['hash']
+    # Invalid format for hash - fails before checking auxpow
     try:
-      self.nodes[0].getauxblock (auxblock['hash'], "x")
-      raise AssertionError ("invalid block hash accepted")
+      self.nodes[0].getauxblock("00", "x")
+      raise AssertionError("malformed hash accepted")
     except JSONRPCException as exc:
-      assert_equal (exc.error['code'], -8)
+      assert_equal(exc.error['code'], -8)
+      assert("hash must be of length 64" in exc.error["message"])
 
     # Invalid format for auxpow.
     try:
-      self.nodes[0].getauxblock (auxblock2['hash'], "x")
-      raise AssertionError ("malformed auxpow accepted")
+      self.nodes[0].getauxblock(auxblock2['hash'], "x")
+      raise AssertionError("malformed auxpow accepted")
     except JSONRPCException as exc:
-      assert_equal (exc.error['code'], -1)
+      assert_equal(exc.error['code'], -22)
+      assert("decode failed" in exc.error["message"])
+
+    # If we receive a new block, the old hash will be replaced.
+    self.sync_all()
+    self.nodes[1].generate(1)
+    self.sync_all()
+    auxblock2 = self.nodes[0].getauxblock()
+    assert auxblock['hash'] != auxblock2['hash']
+    apow = auxpow.computeAuxpowWithChainId(auxblock['hash'], auxpow.reverseHex(auxblock['target']), "98", True)
+    try:
+        self.nodes[0].getauxblock(auxblock['hash'], apow)
+        raise AssertionError("invalid block hash accepted")
+    except JSONRPCException as exc:
+        assert_equal(exc.error['code'], -8)
+        assert("block hash unknown" in exc.error["message"])
+
+    # Auxpow doesn't match given hash
+    res = self.nodes[0].getauxblock(auxblock2['hash'], apow)
+    assert not res
 
     # Invalidate the block again, send a transaction and query for the
     # auxblock to solve that contains the transaction.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,6 +130,7 @@ BITCOIN_CORE_H = \
   protocol.h \
   random.h \
   reverselock.h \
+  rpc/auxcache.h \
   rpc/blockchain.h \
   rpc/client.h \
   rpc/mining.h \
@@ -209,6 +210,7 @@ libdogecoin_server_a_SOURCES = \
   policy/policy.cpp \
   pow.cpp \
   rest.cpp \
+  rpc/auxcache.cpp \
   rpc/auxpow.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -82,6 +82,7 @@ BITCOIN_TESTS =\
   test/addrman_tests.cpp \
   test/amount_tests.cpp \
   test/allocator_tests.cpp \
+  test/auxcache_tests.cpp \
   test/auxpow_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+class CAuxPow;
 class CBlock;
 class CScript;
 class CTransaction;
@@ -20,6 +21,7 @@ CScript ParseScript(const std::string& s);
 std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
 bool DecodeHexTx(CMutableTransaction& tx, const std::string& strHexTx, bool fTryNoWitness = false);
 bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
+bool DecodeAuxPow(CAuxPow& auxpow, const std::string& strHexAuxPow);
 uint256 ParseHashUV(const UniValue& v, const std::string& strName);
 uint256 ParseHashStr(const std::string&, const std::string& strName);
 std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -138,6 +138,24 @@ bool DecodeHexBlk(CBlock& block, const std::string& strHexBlk)
     return true;
 }
 
+bool DecodeAuxPow(CAuxPow& auxpow, const std::string& strHexAuxPow)
+{
+    if (!IsHex(strHexAuxPow))
+        return false;
+
+    std::vector<unsigned char> auxData(ParseHex(strHexAuxPow));
+
+    CDataStream ssAuxPow(auxData, SER_NETWORK, PROTOCOL_VERSION);
+    try {
+        ssAuxPow >> auxpow;
+    }
+    catch (const std::exception&) {
+        return false;
+    }
+
+    return true;
+}
+
 uint256 ParseHashUV(const UniValue& v, const std::string& strName)
 {
     std::string strHex;

--- a/src/rpc/auxcache.cpp
+++ b/src/rpc/auxcache.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpc/auxcache.h"
+
+#include "script/standard.h"  // for CScriptID
+#include "primitives/block.h" // for CBlock
+#include "uint256.h"          // for uint256
+#include "utilmemory.h"       // for MakeUnique
+#include "utiltime.h"         // for GetTimeMicros
+
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+
+#include <cstdint>            // for uint64_t
+#include <memory>             // for std::unique_ptr, std::shared_ptr
+#include <mutex>              // for std::mutex
+#include <tuple>              // for std::tuple
+
+namespace {
+
+//! Type that is stored in the cache
+struct AuxCacheItem {
+  int64_t cache_time;
+  CScriptID scriptId;
+  uint256 hash;
+  std::shared_ptr<CBlock> pblock;
+};
+
+// The ByScriptId index sorts by CScriptID and item age
+struct ByScriptId {};
+using ByScriptIdView = std::tuple<const CScriptID&, const int64_t>;
+struct ByScriptIdExtractor
+{
+    using result_type = ByScriptIdView;
+    result_type operator()(const AuxCacheItem& item) const
+    {
+        // calculate age
+        const int64_t age = GetMockableTimeMicros() - item.cache_time;
+        return ByScriptIdView{item.scriptId, age};
+    }
+};
+
+// The ByBlockHash index sorts by blockhash (uint256)
+struct ByBlockHash {};
+struct ByBlockHashExtractor
+{
+    using result_type = uint256;
+    result_type operator()(const AuxCacheItem& item) const
+    {
+        return item.hash;
+    }
+};
+
+/** Data type for the main data structure (AuxCacheItem objects with ByScriptID/ByBlockHash indexes). */
+using AuxCacheIndex = boost::multi_index_container<
+    AuxCacheItem,
+    boost::multi_index::indexed_by<
+        boost::multi_index::ordered_non_unique<boost::multi_index::tag<ByScriptId>, ByScriptIdExtractor>,
+        boost::multi_index::ordered_unique<boost::multi_index::tag<ByBlockHash>, ByBlockHashExtractor>
+    >
+>;
+
+} //anon namespace
+
+class CAuxBlockCache::Impl {
+    AuxCacheIndex m_index;
+
+private:
+  std::mutex mut;
+
+public:
+    Impl() : m_index(boost::make_tuple(
+        boost::make_tuple(ByScriptIdExtractor(), std::less<ByScriptIdView>()),
+        boost::make_tuple(ByBlockHashExtractor(), std::less<uint256>())
+    )) {};
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+
+    bool Add(const CScriptID scriptId, std::shared_ptr<CBlock> pblock) {
+
+        uint256 hash = pblock->GetHash();
+        int64_t micros = GetMockableTimeMicros();
+
+        std::lock_guard<std::mutex> guard(mut);
+        auto ret = m_index.get<ByBlockHash>().emplace(AuxCacheItem{micros, scriptId, hash, pblock});
+
+        return ret.second;
+    }
+
+    void Reset() {
+        m_index.clear();
+    }
+
+    bool Get(const CScriptID scriptId, std::shared_ptr<CBlock>& pblock) const {
+        auto it = m_index.get<ByScriptId>().lower_bound(ByScriptIdView{scriptId, 0LL});
+        if (it != m_index.get<ByScriptId>().end() && it->scriptId == scriptId) {
+            pblock = it->pblock;
+            return true;
+        }
+        pblock.reset();
+        return false;
+    }
+
+    bool Get(const uint256 blockhash, std::shared_ptr<CBlock>& pblock) const {
+        auto it = m_index.get<ByBlockHash>().lower_bound(blockhash);
+        if (it != m_index.get<ByBlockHash>().end() && it->hash == blockhash) {
+            pblock = it->pblock;
+            return true;
+        }
+        pblock.reset();
+        return false;
+    }
+};
+
+CAuxBlockCache::CAuxBlockCache() : m_impl(MakeUnique<CAuxBlockCache::Impl>()) {};
+CAuxBlockCache::~CAuxBlockCache() = default;
+
+bool CAuxBlockCache::Add(const CScriptID scriptId, std::shared_ptr<CBlock> pblock) {
+    return m_impl->Add(scriptId, pblock);
+}
+
+void CAuxBlockCache::Reset() {
+    m_impl->Reset();
+}
+
+bool CAuxBlockCache::Get(const CScriptID scriptId, std::shared_ptr<CBlock>& pblock) {
+    return m_impl->Get(scriptId, pblock);
+}
+
+bool CAuxBlockCache::Get(const uint256 blockhash, std::shared_ptr<CBlock>& pblock) {
+    return m_impl->Get(blockhash, pblock);
+}

--- a/src/rpc/auxcache.h
+++ b/src/rpc/auxcache.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DOGECOIN_AUXCACHE_H
+#define DOGECOIN_AUXCACHE_H
+
+#include "script/standard.h"  // for CScriptID
+#include "primitives/block.h" // for CBlock
+#include "uint256.h"          // for uint256
+
+#include <memory>             // for std::unique_ptr, std::shared_ptr
+
+/** Cache to keep track of blocks templated for AuxPoW mining, by CScriptID
+ *  (coinbase output script.)
+ *
+ *  Searchable by coinbase scriptpubkey (CScriptID) and blockhash (uint256)
+ *
+ */
+class CAuxBlockCache {
+    // Do not put impementation details in the header because they are
+    // heavy on includes. Instead use an implementation class.
+    class Impl;
+    const std::unique_ptr<Impl> m_impl;
+
+public:
+    explicit CAuxBlockCache();
+    ~CAuxBlockCache();
+
+    /** Adds a block to the cache */
+    bool Add(const CScriptID scriptId, std::shared_ptr<CBlock> pblock);
+
+    /** Resets the entire cache */
+    void Reset();
+
+    /** Get the cached CBlock (optional) for a CScriptID */
+    bool Get(const CScriptID scriptId, std::shared_ptr<CBlock>& pblock);
+
+    /** Get the cached CBlock (optional) by block hash */
+    bool Get(const uint256 blockhash, std::shared_ptr<CBlock>& pblock);
+
+};
+
+#endif //DOGECOIN_AUXCACHE_H

--- a/src/test/auxcache_tests.cpp
+++ b/src/test/auxcache_tests.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 The Dogecoin Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "amount.h"
+#include "consensus/merkle.cpp"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "rpc/auxcache.h"
+#include "script/script.h"
+#include "utiltime.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <memory>
+
+BOOST_FIXTURE_TEST_SUITE(auxcache_tests, TestingSetup)
+
+static const std::string cb_pk_1 = "03c758272b121a3e50a1a6a25aad800a45af51486227bb8f06257df80a15120135";
+static const std::string cb_pk_2 = "020c163123e1e3b8bcf9114e2df152b5aa0bc5f69458991236746be48adce96bed";
+
+// creates a bare dummy block with auxpow on
+std::shared_ptr<CBlock> CreateDummyBlock(CScript scriptPubKey, CAmount amount) {
+  CMutableTransaction coinbase{};
+  coinbase.nVersion = 1;
+  coinbase.vin.push_back(CTxIn(uint256::ZERO, 0));
+  coinbase.vout.push_back(CTxOut(amount, scriptPubKey));
+
+  CBlock block{};
+  block.nVersion = 4;
+  block.hashPrevBlock = uint256::ZERO;
+  block.nTime = GetTime();
+  block.nBits = 0x1e0ffff0;
+  block.nNonce = 0;
+  block.SetChainId(98);
+  block.SetAuxpowFlag(true);
+
+  block.vtx.resize(1);
+  block.vtx[0] = MakeTransactionRef(std::move(coinbase));
+
+  block.hashMerkleRoot = BlockMerkleRoot(block);
+
+  return std::make_shared<CBlock>(block);
+}
+
+
+BOOST_AUTO_TEST_CASE(check_auxpow) {
+  CAuxBlockCache cache;
+  std::shared_ptr<CBlock> cached_block;
+  bool res;
+
+  CScript cb_script_1 = CScript() << ParseHex(cb_pk_1) << OP_CHECKSIG;
+  CScriptID scriptId_1(cb_script_1);
+  std::shared_ptr<CBlock> created_block_1 = CreateDummyBlock(cb_script_1, CAmount(69));
+  uint256 blockhash_1 = created_block_1->GetHash();
+
+  // add to cache
+  res = cache.Add(scriptId_1, created_block_1);
+  BOOST_CHECK(res);
+
+  // get by scriptId
+  res = cache.Get(scriptId_1, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_1.GetHex(), cached_block->GetHash().GetHex());
+
+  // get by hash
+  res = cache.Get(blockhash_1, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_1.GetHex(), cached_block->GetHash().GetHex());
+
+  // Adding the same block again fails
+  res = cache.Add(scriptId_1, created_block_1);
+  BOOST_CHECK(!res);
+
+  CScript cb_script_2 = CScript() << ParseHex(cb_pk_2) << OP_CHECKSIG;
+  CScriptID scriptId_2(cb_script_2);
+  std::shared_ptr<CBlock> created_block_2 = CreateDummyBlock(cb_script_2, CAmount(169));
+  uint256 blockhash_2 = created_block_2->GetHash();
+
+  // Make sure the block hashes are different
+  BOOST_CHECK_NE(blockhash_1.GetHex(), blockhash_2.GetHex());
+
+  // add second block to cache
+  res = cache.Add(scriptId_2, created_block_2);
+  BOOST_CHECK(res);
+
+  // get second block by scriptId
+  res = cache.Get(scriptId_2, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_2.GetHex(), cached_block->GetHash().GetHex());
+
+  // get second block by hash
+  res = cache.Get(blockhash_2, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_2.GetHex(), cached_block->GetHash().GetHex());
+
+  // get first block by scriptId
+  res = cache.Get(scriptId_1, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_1.GetHex(), cached_block->GetHash().GetHex());
+
+  // NOTE: since not all OS' have high precision time, we mock +1 second here
+  SetMockTime(GetTime() + 1LL);
+
+  // create another block with the first scriptId
+  std::shared_ptr<CBlock> created_block_3 = CreateDummyBlock(cb_script_1, CAmount(269));
+  uint256 blockhash_3 = created_block_3->GetHash();
+
+  // Make sure the block hashes are different
+  BOOST_CHECK_NE(blockhash_1.GetHex(), blockhash_3.GetHex());
+
+  // add third block to cache
+  res = cache.Add(scriptId_1, created_block_3);
+  BOOST_CHECK(res);
+
+  // get third block by scriptId
+  res = cache.Get(scriptId_1, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_3.GetHex(), cached_block->GetHash().GetHex());
+
+  // the first block is still available by hash
+  res = cache.Get(blockhash_1, cached_block);
+  BOOST_CHECK(res);
+  BOOST_CHECK_EQUAL(blockhash_1.GetHex(), cached_block->GetHash().GetHex());
+
+  // clearing the cache removes all data
+  cache.Reset();
+  res = cache.Get(scriptId_1, cached_block);
+  BOOST_CHECK(!res);
+  BOOST_CHECK(!cached_block);
+  res = cache.Get(scriptId_2, cached_block);
+  BOOST_CHECK(!res);
+  BOOST_CHECK(!cached_block);
+  res = cache.Get(blockhash_1, cached_block);
+  BOOST_CHECK(!res);
+  BOOST_CHECK(!cached_block);
+  res = cache.Get(blockhash_2, cached_block);
+  BOOST_CHECK(!res);
+  BOOST_CHECK(!cached_block);
+  res = cache.Get(blockhash_3, cached_block);
+  BOOST_CHECK(!res);
+  BOOST_CHECK(!cached_block);
+
+  // Unmock time
+  SetMockTime(0LL);
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Unifies the implementation of auxpow block template methods on the RPC, and with that, fixes #3828.

1. Introduces a single cache for templated blocks `CAuxBlockCache`, that is indexed and searchable by both coinbase script and block hash. This replaces multiple separate caches implemented in `std::map` structures.
2. Integrates the new cache into `AuxMiningCreateBlock` and `AuxMiningSubmitBlock` rpc helper functions
3. Modifies `AuxMiningSubmitBlock` to return the BIP-22 response
4. Merges `getauxblockbip22` into `getauxblock`, to decrease code complexity.
5. Improves error handling on submitting auxpow blocks on all rpc methods, failing safely and early, with improved error messages.

Note: although we return the BIP-22 response in `AuxMiningSubmitBlock`, there is currently no method or configuration that returns this over rpc. All methods return a boolean response and this remains unchanged, for backward compatibility.