### PR TITLE
Improve contrib/devtools handling

### DIFF
--- a/contrib/devtools/optimize-pngs.py
+++ b/contrib/devtools/optimize-pngs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -27,7 +27,11 @@ def content_hash(filename):
 pngcrush = 'pngcrush'
 git = 'git'
 folders = ["src/qt/res/movies", "src/qt/res/icons", "share/pixmaps"]
-basePath = subprocess.check_output([git, 'rev-parse', '--show-toplevel']).rstrip('\n')
+basePath = (
+    subprocess.check_output([git, 'rev-parse', '--show-toplevel'])
+    .decode()
+    .rstrip('\n')
+)
 totalSaveBytes = 0
 noHashChange = True
 
@@ -37,42 +41,77 @@ for folder in folders:
     for file in os.listdir(absFolder):
         extension = os.path.splitext(file)[1]
         if extension.lower() == '.png':
-            print("optimizing "+file+"..."),
+            print("optimizing " + file + "...", end='')
             file_path = os.path.join(absFolder, file)
             fileMetaMap = {'file' : file, 'osize': os.path.getsize(file_path), 'sha256Old' : file_hash(file_path)}
             fileMetaMap['contentHashPre'] = content_hash(file_path)
         
             pngCrushOutput = ""
             try:
-                pngCrushOutput = subprocess.check_output(
-                        [pngcrush, "-brute", "-ow", "-rem", "gAMA", "-rem", "cHRM", "-rem", "iCCP", "-rem", "sRGB", "-rem", "alla", "-rem", "text", file_path],
-                        stderr=subprocess.STDOUT).rstrip('\n')
-            except:
-                print "pngcrush is not installed, aborting..."
+                pngCrushOutput = (
+                    subprocess.check_output(
+                        [
+                            pngcrush,
+                            "-brute",
+                            "-ow",
+                            "-rem",
+                            "gAMA",
+                            "-rem",
+                            "cHRM",
+                            "-rem",
+                            "iCCP",
+                            "-rem",
+                            "sRGB",
+                            "-rem",
+                            "alla",
+                            "-rem",
+                            "text",
+                            file_path,
+                        ],
+                        stderr=subprocess.STDOUT,
+                    )
+                    .decode()
+                    .rstrip("\n")
+                )
+            except Exception:
+                print("pngcrush is not installed, aborting...")
                 sys.exit(0)
         
             #verify
-            if "Not a PNG file" in subprocess.check_output([pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT):
-                print "PNG file "+file+" is corrupted after crushing, check out pngcursh version"
+            if "Not a PNG file" in subprocess.check_output(
+                [pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT
+            ).decode():
+                print(
+                    "PNG file " + file + " is corrupted after crushing, check out pngcrush version"
+                )
                 sys.exit(1)
             
             fileMetaMap['sha256New'] = file_hash(file_path)
             fileMetaMap['contentHashPost'] = content_hash(file_path)
 
             if fileMetaMap['contentHashPre'] != fileMetaMap['contentHashPost']:
-                print "Image contents of PNG file "+file+" before and after crushing don't match"
+                print("Image contents of PNG file " + file + " before and after crushing don't match")
                 sys.exit(1)
 
             fileMetaMap['psize'] = os.path.getsize(file_path)
             outputArray.append(fileMetaMap)
-            print("done\n"),
+            print("done\n")
 
-print "summary:\n+++++++++++++++++"
+print("summary:\n+++++++++++++++++")
 for fileDict in outputArray:
     oldHash = fileDict['sha256Old']
     newHash = fileDict['sha256New']
     totalSaveBytes += fileDict['osize'] - fileDict['psize']
     noHashChange = noHashChange and (oldHash == newHash)
-    print fileDict['file']+"\n  size diff from: "+str(fileDict['osize'])+" to: "+str(fileDict['psize'])+"\n  old sha256: "+oldHash+"\n  new sha256: "+newHash+"\n"
+    print(
+        f"{fileDict['file']}\n  size diff from: {fileDict['osize']} to: {fileDict['psize']}\n  "
+        f"old sha256: {oldHash}\n  new sha256: {newHash}\n"
+    )
     
-print "completed. Checksum stable: "+str(noHashChange)+". Total reduction: "+str(totalSaveBytes)+" bytes"
+print(
+    "completed. Checksum stable: "
+    + str(noHashChange)
+    + ". Total reduction: "
+    + str(totalSaveBytes)
+    + " bytes"
+)

--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -11,7 +11,11 @@ Otherwise the exit status will be 1 and it will log which executables failed whi
 import sys
 from typing import List
 
-import lief #type:ignore
+try:
+    import lief  # type: ignore
+except ModuleNotFoundError:
+    sys.stderr.write("The 'lief' module is required. Install it to run security checks.\n")
+    sys.exit(1)
 
 def check_ELF_RELRO(binary) -> bool:
     '''

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -6,7 +6,12 @@
 '''
 Test script for security-check.py
 '''
-import lief #type:ignore
+import sys
+try:
+    import lief  # type: ignore
+except ModuleNotFoundError:
+    print("The 'lief' module is missing. Skipping security-check tests.")
+    sys.exit(0)
 import os
 import subprocess
 from typing import List


### PR DESCRIPTION
## optimize optimize-pngs handling:
-    Switch to Python 3, fix errors caused by subprocess output being bytes, and adjust the print format.

## Improve security-check error handling
-    Added a check in the security checker to ensure the required lief module is available and to exit gracefully with a helpful message if it isn’t found.

## Testing
- `python3 contrib/devtools/check-translations.py`
- `python3 contrib/devtools/security-check.py`
- `python3 contrib/devtools/test-security-check.py`


------