### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -3891,7 +3891,7 @@ Gebruik deze functie met extreme voorzichtigheid.</translation>
     </message>
     <message>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Stel maximum blokgrootte in in bytes (standaard: %d)</translation>
+        <translation>Stel maximum blokgrootte in bytes (standaard: %d)</translation>
     </message>
     <message>
         <source>Specify wallet file (within data directory)</source>

--- a/src/secp256k1/src/modinv32_impl.h
+++ b/src/secp256k1/src/modinv32_impl.h
@@ -80,7 +80,7 @@ static void secp256k1_modinv32_normalize_30(secp256k1_modinv32_signed30 *r, int3
     /* In a first step, add the modulus if the input is negative, and then negate if requested.
      * This brings r from range (-2*modulus,modulus) to range (-modulus,modulus). As all input
      * limbs are in range (-2^30,2^30), this cannot overflow an int32_t. Note that the right
-     * shifts below are signed sign-extending shifts (see assumptions.h for tests that that is
+     * shifts below are signed sign-extending shifts (see assumptions.h for tests that is
      * indeed the behavior of the right shift operator). */
     cond_add = r8 >> 31;
     r0 += modinfo->modulus.v[0] & cond_add;

--- a/src/secp256k1/src/modinv64_impl.h
+++ b/src/secp256k1/src/modinv64_impl.h
@@ -85,7 +85,7 @@ static void secp256k1_modinv64_normalize_62(secp256k1_modinv64_signed62 *r, int6
     /* In a first step, add the modulus if the input is negative, and then negate if requested.
      * This brings r from range (-2*modulus,modulus) to range (-modulus,modulus). As all input
      * limbs are in range (-2^62,2^62), this cannot overflow an int64_t. Note that the right
-     * shifts below are signed sign-extending shifts (see assumptions.h for tests that that is
+     * shifts below are signed sign-extending shifts (see assumptions.h for tests that is
      * indeed the behavior of the right shift operator). */
     cond_add = r4 >> 63;
     r0 += modinfo->modulus.v[0] & cond_add;

--- a/src/secp256k1/src/secp256k1.c
+++ b/src/secp256k1/src/secp256k1.c
@@ -482,7 +482,7 @@ static int secp256k1_ecdsa_sign_inner(const secp256k1_context* ctx, secp256k1_sc
             break;
         }
         is_nonce_valid = secp256k1_scalar_set_b32_seckey(&non, nonce32);
-        /* The nonce is still secret here, but it being invalid is is less likely than 1:2^255. */
+        /* The nonce is still secret here, but it being invalid is less likely than 1:2^255. */
         secp256k1_declassify(ctx, &is_nonce_valid, sizeof(is_nonce_valid));
         if (is_nonce_valid) {
             ret = secp256k1_ecdsa_sig_sign(&ctx->ecmult_gen_ctx, r, s, &sec, &msg, &non, recid);

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -22,7 +22,7 @@
  * The following information is tracked per peer/tx combination ("announcement"):
  * - Which peer announced it (through their NodeId)
  * - The txhash of the transaction
- * - What the earliest permitted time is that that transaction can be requested from that peer (called "reqtime").
+ * - What the earliest permitted time is that transaction can be requested from that peer (called "reqtime").
  * - Whether it's from a "preferred" peer or not. Which announcements get this flag is determined by the caller, but
  *   this is designed for outbound peers, or other peers that we have a higher level of trust in. Even when the
  *   peers' preferredness changes, the preferred flag of existing announcements from that peer won't change.


### PR DESCRIPTION
 remove redundant words in comment