### PR TITLE
Add '-datacarriercount' argument and change '-datacarriersize' default to 1654

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -481,7 +481,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-harddustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_HARD_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
-    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data per data carrier output we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-datacarriercount", strprintf(_("Maximum number of data carrier outputs per transaction we relay and mine (0 for unlimited, default: %u)"), DEFAULT_DATACARRIER_COUNT));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
@@ -1099,6 +1100,7 @@ bool AppInitParameterInteraction()
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
+    nMaxDatacarrierCount = GetArg("-datacarriercount", nMaxDatacarrierCount);
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -112,8 +112,8 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         }
     }
 
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
+    // Enforce limits on OP_RETURN output count
+    if (nMaxDatacarrierCount > 0 && nDataOut > nMaxDatacarrierCount) {
         reason = "multi-op-return";
         return false;
     }

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -18,6 +18,7 @@ typedef vector<unsigned char> valtype;
 
 bool fAcceptDatacarrier = DEFAULT_ACCEPT_DATACARRIER;
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
+unsigned nMaxDatacarrierCount = DEFAULT_DATACARRIER_COUNT;
 
 CScriptID::CScriptID(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -14,6 +14,7 @@
 #include <stdint.h>
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
+static const int DEFAULT_DATACARRIER_COUNT = 0;
 
 class CKeyID;
 class CScript;
@@ -27,9 +28,10 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83; //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY = 1654; //!< bytes (+1 for OP_RETURN, +1 for the pushdata opcode, +2 for pushdata length)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
+extern unsigned nMaxDatacarrierCount; 
 
 /**
  * Mandatory script verification flags that all new blocks must comply with for


### PR DESCRIPTION
Per discussion #3829 (Removing OP_RETURN limits)
Replaces previous pull request #3836

This pull request adds a new argument `-datacarriercount` and changes the `-datacarriersize` default to 1654 bytes.

`-datacarriercount` provides a configurable limit on the number of `OP_RETURN` outputs a standard transaction can have. This defaults to 0 representing unlimited. The current `-datacarrier` argument can still be used to disallow any OP_RETURN outputs.

`-datacarriersize` default is increased from 83 bytes to 1654 bytes (80->1650 without op bytes).

<img width="614" height="392" alt="image" src="https://github.com/user-attachments/assets/1633d351-ae27-4e96-a78f-4d60ebedaf5a" />
