### PR TITLE
Add RPC connectivity check script for local Dogecoin Core nodes

### DIFF
--- a/contrib/devtools/check_rpc_connection.py
+++ b/contrib/devtools/check_rpc_connection.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+check_rpc_connection.py — simple RPC connectivity tester for Dogecoin Core
+"""
+
+import json
+import requests
+from requests.auth import HTTPBasicAuth
+
+RPC_USER = "dogeuser"
+RPC_PASSWORD = "dogepass"
+RPC_PORT = 22555
+RPC_HOST = "127.0.0.1"
+
+def test_rpc_connection():
+    url = f"http://{RPC_HOST}:{RPC_PORT}"
+    headers = {"content-type": "application/json"}
+    payload = json.dumps({"method": "getblockcount", "params": [], "id": 1})
+
+    try:
+        response = requests.post(url, headers=headers, data=payload, auth=HTTPBasicAuth(RPC_USER, RPC_PASSWORD))
+        if response.status_code == 200:
+            result = response.json()
+            print(f"✅ RPC connection successful. Current block height: {result.get('result')}")
+        else:
+            print(f"❌ RPC error: HTTP {response.status_code}")
+    except Exception as e:
+        print(f"⚠️  Connection failed: {e}")
+
+if __name__ == "__main__":
+    test_rpc_connection()


### PR DESCRIPTION
This PR adds a small Python script under contrib/devtools/ that helps developers quickly verify whether their local Dogecoin Core node is reachable via JSON-RPC.

It’s a lightweight tool intended for developers who set up testnet or regtest nodes and want a simple way to confirm the RPC interface is active and responding.

Key points:

Sends a basic getblockcount RPC call.

Prints block height if connection succeeds.

Provides clear error handling for failed or misconfigured setups.

Tested locally with Dogecoin Core v1.14.9.

Much connection. Such debug. Wow.