### PR TITLE
small utility to print Dogecoin Core version for debugging

### DIFF
--- a/src/utils/log_dogecoin_version.cpp
+++ b/src/utils/log_dogecoin_version.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2025
+// Simple utility to print Dogecoin Core version info
+// Author: Marta
+
+#include <iostream>
+#include "clientversion.h"
+
+namespace dogeutils {
+
+/**
+ * Prints the current Dogecoin Core version in a friendly format.
+ * Intended for debugging or verifying build information.
+ */
+void PrintCoreVersion()
+{
+    std::cout << "🐶 Dogecoin Core Version: " << CLIENT_VERSION_MAJOR << "."
+              << CLIENT_VERSION_MINOR << "."
+              << CLIENT_VERSION_REVISION << std::endl;
+}
+
+} // namespace dogeutils


### PR DESCRIPTION
This PR introduces a lightweight helper PrintCoreVersion() under src/utils/.
It prints the current Dogecoin Core version to standard output, using existing constants from clientversion.h.

Motivation:
Developers and testers often need a simple way to confirm which version of Dogecoin Core is running when debugging local builds or CI runs.
This helper makes it easy to print that info programmatically.

Impact:

No dependencies or functional changes

Compatible with all current build systems

Useful for development and diagnostics