### PR TITLE
build: do not link boost_system if boost >= 1.69.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -741,7 +741,34 @@ define(MINIMUM_REQUIRED_BOOST, 1.60.0)
 
 dnl Check for boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST], AC_MSG_RESULT(ok), AC_MSG_ERROR(Need at least boost 1.60.0))
-AX_BOOST_SYSTEM
+
+dnl As of boost 1.69.0, boost_system is header-only and
+dnl as of version 1.89.0 it is fully removed.
+dnl We conditionally check whether to include boost_system
+dnl based on the value specified in version.hpp
+
+AC_MSG_CHECKING([for boost >= 1.69.0])
+CHECK_BOOST_SYSTEM=yes
+TEMP_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$BOOST_CPPFLAGS $CPPFLAGS"
+AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
+    @%:@include <boost/version.hpp>
+  ]], [[
+    #if BOOST_VERSION >= 106900
+    // No boost_system needed
+    #else
+    #  error we need to include boost_system
+    #endif
+  ]])],
+  [ AC_MSG_RESULT(yes); CHECK_BOOST_SYSTEM=no ],
+  [ AC_MSG_RESULT(no); CHECK_BOOST_SYSTEM=yes ]
+)
+CPPFLAGS="$TEMP_CPPFLAGS"
+
+if test x$CHECK_BOOST_SYSTEM = xyes; then
+  AX_BOOST_SYSTEM
+fi
+
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_THREAD


### PR DESCRIPTION
Implements #3926, removing `boost_system` conditionally, to support boost 1.89 and onward.

Because our minimum supported boost version is 1.60.0 and the pinned version is 1.63.0, we need to have conditional inclusion of `boost_system` in the build process. This change to `configure.ac` realizes that by checking if the boost version is < 1.69, and if it is, it then runs `AX_BOOST_SYSTEM` from `build-aux/m4/ax_boost_system.m4`. If not, it simply skips that check and the inclusion of the dependency.

I've used the Dockerfile [^include] from https://github.com/dogecoin/dogecoin/pull/3732#pullrequestreview-2487258510 to test this against 1.60, 1.68, 1.69, 1.74, 1.75, 1.82, 1.84, 1.88 and 1.89 on Linux, which should cover most of the distro-provided versions out there, and manually tested on macOS 26 w/ 1.89.

PS: I spotted some outdated boost checks / misc debt in `configure.ac` that I will remove separately, to not overcomplicate or block this particular change.

[^include]: I'll open a separate PR to add the Dockerfile to `contrib/` because it's kind of tedious to copy it from PRs all the time.