### PR TITLE
Build: remove autoconf boost debt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -740,7 +740,7 @@ dnl Minimum required Boost version
 define(MINIMUM_REQUIRED_BOOST, 1.60.0)
 
 dnl Check for boost libs
-AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST], AC_MSG_RESULT(ok), AC_MSG_ERROR(Need at least boost 1.60.0))
+AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST], , AC_MSG_ERROR(Need at least boost 1.60.0))
 
 dnl As of boost 1.69.0, boost_system is header-only and
 dnl as of version 1.89.0 it is fully removed.


### PR DESCRIPTION
Removes 2 trivial issues with `configure.ac`:

1. A check for boost < 1.49 is performed after a check for boost > 1.60, so that makes no sense. Removed.
2. When checking for boost > 1.60, an additional line with `ok` was printed after it was successfully found. Removed the extra message.

Opening as draft because it would otherwise conflict with #3928.
