### PR TITLE
compat: fix endian.h compatibility with BSD(-like) systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -607,19 +607,29 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
+AC_CHECK_HEADERS([endian.h machine/endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
 
 AC_CHECK_DECLS([strnlen])
 
 # Check for daemon(3), unrelated to --with-daemon (although used by it)
 AC_CHECK_DECLS([daemon])
 
-AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64],,,
-		[#if HAVE_ENDIAN_H
-                 #include <endian.h>
-                 #elif HAVE_SYS_ENDIAN_H
-                 #include <sys/endian.h>
-                 #endif])
+dnl perform the endian.h variant inclusion order exactly like boost_predef
+dnl which excludes FreeBSD and MAC_OSX from including endian.h but instead
+dnl includes sys/endian.h and machine/endian.h respectively
+dnl see: https://github.com/boostorg/predef/blob/9aca7f5b609a731106a6d70e8dca9a4196dca968/include/boost/predef/other/endian.h#L57-L67
+dnl also make sure that this is matched in compat/endian.h
+
+AC_CHECK_DECLS([le16toh, le32toh, le64toh, htole16, htole32, htole64, be16toh, be32toh, be64toh, htobe16, htobe32, htobe64, be32dec, be32enc, le32dec, le32enc],,,
+		[#if !defined(__FreeBSD__) && !defined(MAC_OSX)
+               #if HAVE_ENDIAN_H
+                       #include <endian.h>
+               #endif
+     #elif defined(MAC_OSX) && HAVE_MACHINE_ENDIAN_H
+               #include <machine/endian.h>
+     #elif HAVE_SYS_ENDIAN_H
+               #include <sys/endian.h>
+     #endif])
 
 AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
 		[#if HAVE_BYTESWAP_H

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -13,10 +13,14 @@
 
 #include "compat/byteswap.h"
 
-#if defined(HAVE_ENDIAN_H)
-#include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
-#include <sys/endian.h>
+#if !defined(__FreeBSD__) && !defined(MAC_OSX)
+#  if HAVE_ENDIAN_H
+#    include <endian.h>
+#  endif
+#elif defined(MAC_OSX) && HAVE_MACHINE_ENDIAN_H
+#  include <machine/endian.h>
+#elif HAVE_SYS_ENDIAN_H
+#  include <sys/endian.h>
 #endif
 
 #if defined(WORDS_BIGENDIAN)
@@ -192,5 +196,45 @@ inline uint64_t le64toh(uint64_t little_endian_64bits)
 #endif // HAVE_DECL_LE64TOH
 
 #endif // WORDS_BIGENDIAN
+
+#if HAVE_DECL_LE16DEC == 0
+inline uint32_t le32dec(const void *pp)
+{
+        const uint8_t *p = (uint8_t const *)pp;
+        return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
+            ((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
+}
+#endif // HAVE_DECL_LE16DEC
+
+#if HAVE_DECL_LE32ENC == 0
+inline void le32enc(void *pp, uint32_t x)
+{
+        uint8_t *p = (uint8_t *)pp;
+        p[0] = x & 0xff;
+        p[1] = (x >> 8) & 0xff;
+        p[2] = (x >> 16) & 0xff;
+        p[3] = (x >> 24) & 0xff;
+}
+#endif // HAVE_DECL_LE32ENC
+
+#if HAVE_DECL_BE32DEC == 0
+inline uint32_t be32dec(const void *pp)
+{
+	const uint8_t *p = (uint8_t const *)pp;
+	return ((uint32_t)(p[3]) + ((uint32_t)(p[2]) << 8) +
+	    ((uint32_t)(p[1]) << 16) + ((uint32_t)(p[0]) << 24));
+}
+#endif // HAVE_DECL_BE32DEC
+
+#if HAVE_DECL_BE32ENC == 0
+inline void be32enc(void *pp, uint32_t x)
+{
+	uint8_t *p = (uint8_t *)pp;
+	p[3] = x & 0xff;
+	p[2] = (x >> 8) & 0xff;
+	p[1] = (x >> 16) & 0xff;
+	p[0] = (x >> 24) & 0xff;
+}
+#endif // HAVE_DECL_BE32ENC
 
 #endif // BITCOIN_COMPAT_ENDIAN_H

--- a/src/crypto/scrypt-sse2.cpp
+++ b/src/crypto/scrypt-sse2.cpp
@@ -28,6 +28,8 @@
  */
 
 #include "crypto/scrypt.h"
+
+#include "compat/endian.h"         // for le32dec, le32enc
 #include "support/experimental.h"
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -28,6 +28,8 @@
  */
 
 #include "crypto/scrypt.h"
+
+#include "compat/endian.h"         // for le32dec, le32enc, be32dec, be32enc
 #include "crypto/hmac_sha256.h"
 #include <stdlib.h>
 #include <stdint.h>
@@ -43,24 +45,6 @@
 #endif
 #endif
 
-#ifndef __FreeBSD__
-static inline uint32_t be32dec(const void *pp)
-{
-	const uint8_t *p = (uint8_t const *)pp;
-	return ((uint32_t)(p[3]) + ((uint32_t)(p[2]) << 8) +
-	    ((uint32_t)(p[1]) << 16) + ((uint32_t)(p[0]) << 24));
-}
-
-static inline void be32enc(void *pp, uint32_t x)
-{
-	uint8_t *p = (uint8_t *)pp;
-	p[3] = x & 0xff;
-	p[2] = (x >> 8) & 0xff;
-	p[1] = (x >> 16) & 0xff;
-	p[0] = (x >> 24) & 0xff;
-}
-
-#endif
 /**
  * PBKDF2_SHA256(passwd, passwdlen, salt, saltlen, c, buf, dkLen):
  * Compute PBKDF2(passwd, salt, c, dkLen) using HMAC-SHA256 as the PRF, and

--- a/src/crypto/scrypt.h
+++ b/src/crypto/scrypt.h
@@ -36,21 +36,4 @@ void
 PBKDF2_SHA256(const uint8_t *passwd, size_t passwdlen, const uint8_t *salt,
     size_t saltlen, uint64_t c, uint8_t *buf, size_t dkLen);
 
-#ifndef __FreeBSD__
-static inline uint32_t le32dec(const void *pp)
-{
-        const uint8_t *p = (uint8_t const *)pp;
-        return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
-            ((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
-}
-
-static inline void le32enc(void *pp, uint32_t x)
-{
-        uint8_t *p = (uint8_t *)pp;
-        p[0] = x & 0xff;
-        p[1] = (x >> 8) & 0xff;
-        p[2] = (x >> 16) & 0xff;
-        p[3] = (x >> 24) & 0xff;
-}
-#endif
 #endif // BITCOIN_CRYPTO_SCRYPT_H


### PR DESCRIPTION
Re-do of #3720, copying the logic from boost to specifically include `sys/endian.h` for FreeBSD and `machine/endian.h` for MacOS, to reduce conflicts. Also see https://github.com/dogecoin/dogecoin/pull/3720#issuecomment-2517335234.

Fixes inclusion between the different endian.h implementations:

- endian.h (GNU, OpenBSD)
- sys/endian.h (FreeBSD)
- machine/endian.h (MacOS)

exactly as done by boost_predef, so that we do not get conflicts where symbols get overridden. Even though a system endian.h may be available of another flavor than included by boost, this does not help us with redefinitions, so we limit ourselves to using the boost method exclusively, until we are free of dependencies to boost_predef.

Also moves the declarations to compat/endian.h instead of trying to solve this in scrypt-specific code.
