### PR TITLE
Add Dogecoin version check utility for development

### DIFF
--- a/src/utils/dogecoin_version_check.cpp
+++ b/src/utils/dogecoin_version_check.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2025
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+#include <string>
+
+namespace dogecoin {
+
+/**
+ * Simple utility to print the current Dogecoin Core version.
+ * Intended for quick verification in development and CI scripts.
+ */
+void PrintVersionInfo(const std::string& version) {
+    std::cout << "Dogecoin Core version: " << version << std::endl;
+}
+
+} // namespace dogecoin
+
+#ifdef DOGE_VERSION_MAIN
+int main() {
+    dogecoin::PrintVersionInfo("v1.14.8-dev");
+    return 0;
+}
+#endif


### PR DESCRIPTION
### Summary
Adds a minimal C++ helper to print the current Dogecoin Core version to stdout.  
Useful for developers and CI/CD pipelines to verify build version without running the full node.

### Changes
- New file: `src/utils/dogecoin_version_check.cpp`
- Prints version when compiled with `DOGE_VERSION_MAIN` flag

### Motivation
This small addition allows contributors and automated workflows to quickly confirm the current build version string, especially useful when testing development or pre-release builds.

### Example Usage
```bash
g++ src/utils/dogecoin_version_check.cpp -DDOGE_VERSION_MAIN -o dogecoin_version_check
./dogecoin_version_check
# Output: Dogecoin Core version: v1.14.8-dev
