### PR TITLE
qt: update Spanish (es) translations

### DIFF
--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -596,11 +596,11 @@
     </message>
     <message>
         <source>&amp;Such sending addresses...</source>
-        <translation>&amp;Muchas direcciones de envío...</translation>
+        <translation>&amp;Tan direcciones de envío...</translation>
     </message>
     <message>
         <source>&amp;Much receiving addresses...</source>
-        <translation>&amp;Muchas direcciones de recepción...</translation>
+        <translation>&amp;Tan direcciones de recepción...</translation>
     </message>
     <message>
         <source>&amp;Import Private Key...</source>
@@ -1475,7 +1475,7 @@
     </message>
     <message>
         <source>Very New Address</source>
-        <translation>Nueva dirección</translation>
+        <translation>Muy nueva dirección</translation>
     </message>
     <message>
         <source>So Print</source>
@@ -1575,7 +1575,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>failed to open file, is it writable?</source>
-        <translation>Error al abrir el archivo, ¿es escribible?</translation>
+        <translation>Error al abrir el archivo, ¿tienes permisos de escritura?</translation>
     </message>
     <message>
         <source>Load Paper Wallets</source>
@@ -1607,11 +1607,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation>La cantidad excede su saldo.</translation>
+        <translation>La cantidad excede tu saldo.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the transaction fee is included</source>
-        <translation>El total excede su saldo cuando se incluye la comisión de transacción</translation>
+        <translation>El total excede tu saldo cuando se incluye la comisión de transacción</translation>
     </message>
     <message>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
@@ -1623,7 +1623,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation>¿Seguro que quiere enviar?</translation>
+        <translation>¿Seguro que quieres enviar?</translation>
     </message>
     <message>
         <source>added as transaction fee</source>
@@ -2622,7 +2622,7 @@ Usa esta funcionalidad con extrema precaución.</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation>¿Seguro que quiere enviar?</translation>
+        <translation>¿Seguro que quieres enviar?</translation>
     </message>
     <message>
         <source>added as transaction fee</source>
@@ -2650,11 +2650,11 @@ Usa esta funcionalidad con extrema precaución.</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation>La cantidad excede su saldo.</translation>
+        <translation>La cantidad excede tu saldo.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation>El total excede su saldo cuando la comisión de transacción de %1 es incluida.</translation>
+        <translation>El total excede tu saldo cuando la comisión de transacción de %1 es incluida.</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
@@ -4508,7 +4508,7 @@ Establecer la serialización de las transacciones sin procesar o el bloque hex d
     </message>
     <message>
         <source>Such expensive</source>
-        <translation>Muy caro</translation>
+        <translation>Tan caro</translation>
     </message>
     <message>
         <source>Wow</source>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -5,35 +5,35 @@
     <name>AddPeerDialog</name>
     <message>
         <source>Add Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Agregar par</translation>
     </message>
     <message>
         <source>Enter the peer details below.</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce los detalles del par a continuación.</translation>
     </message>
     <message>
         <source>Be careful! Do not blindly trust anyone that tells you to add their node.</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Ten cuidado! No confíes ciegamente en quien te diga que agregues su nodo.</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s address</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce la dirección del par</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s port</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce el puerto del par</translation>
     </message>
     <message>
         <source>Add!</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Agregar!</translation>
     </message>
     <message>
         <source>Please enter an address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, introduce una dirección.</translation>
     </message>
     <message>
         <source>Please enter a valid peer address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, introduce una dirección de par válida.</translation>
     </message>
 </context>
 <context>
@@ -588,31 +588,31 @@
     </message>
     <message>
         <source>&amp;Print paper wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Imprimir monederos de papel</translation>
     </message>
     <message>
         <source>Print paper wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir monederos de papel</translation>
     </message>
     <message>
         <source>&amp;Such sending addresses...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Muchas direcciones de envío...</translation>
     </message>
     <message>
         <source>&amp;Much receiving addresses...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Muchas direcciones de recepción...</translation>
     </message>
     <message>
         <source>&amp;Import Private Key...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importar clave privada...</translation>
     </message>
     <message>
         <source>Import a Dogecoin private key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar una clave privada de Dogecoin</translation>
     </message>
     <message>
         <source>Runaway exception</source>
-        <translation type="unfinished"></translation>
+        <translation>Excepción no controlada</translation>
     </message>
 </context>
 <context>
@@ -767,7 +767,7 @@
     </message>
     <message>
         <source>Can vary +/- %1 koinu per input.</source>
-        <translation type="unfinished"></translation>
+        <translation>Puede variar +/- %1 koinu por entrada.</translation>
     </message>
 </context>
 <context>
@@ -907,63 +907,63 @@
     <name>ImportKeysDialog</name>
     <message>
         <source>Import Private Key</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar clave privada</translation>
     </message>
     <message>
         <source>&amp;Import Private Key</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importar clave privada</translation>
     </message>
     <message>
         <source>Private Key:</source>
-        <translation type="unfinished"></translation>
+        <translation>Clave privada:</translation>
     </message>
     <message>
         <source>Private key to import into your wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Clave privada a importar en tu monedero</translation>
     </message>
     <message>
         <source>Label for this private key in your wallet</source>
-        <translation type="unfinished"></translation>
+        <translation>Etiqueta para esta clave privada en tu monedero</translation>
     </message>
     <message>
         <source>Label (optional):</source>
-        <translation type="unfinished"></translation>
+        <translation>Etiqueta (opcional):</translation>
     </message>
     <message>
         <source>Rescan</source>
-        <translation type="unfinished"></translation>
+        <translation>Reexplorar</translation>
     </message>
     <message>
         <source>&amp;Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Restablecer</translation>
     </message>
     <message>
         <source>&amp;Import</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importar</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
+        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Invalid private key; please check and try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Clave privada inválida; ¡por favor, verifica e intenta de nuevo!</translation>
     </message>
     <message>
         <source>Invalid address generated from private key; please check and try again!</source>
-        <translation type="unfinished"></translation>
+        <translation>Dirección inválida generada desde la clave privada; ¡por favor, verifica e intenta de nuevo!</translation>
     </message>
     <message>
         <source>Failed to add private key.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al agregar la clave privada.</translation>
     </message>
     <message>
         <source>Rescanning...</source>
-        <translation type="unfinished">Reexplorando...</translation>
+        <translation>Reexplorando...</translation>
     </message>
     <message>
         <source>Reset this form.</source>
-        <translation type="unfinished"></translation>
+        <translation>Restablecer este formulario.</translation>
     </message>
 </context>
 <context>
@@ -1016,7 +1016,7 @@
     </message>
     <message>
         <source>Choose data directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Elegir directorio de datos</translation>
     </message>
 </context>
 <context>
@@ -1329,19 +1329,19 @@
     </message>
     <message>
         <source>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</source>
-        <translation type="unfinished"></translation>
+        <translation>Desactiva algunas funciones avanzadas pero todos los bloques aún serán completamente validados. Revertir esta configuración requiere volver a descargar toda la cadena de bloques. El uso real del disco puede ser algo mayor.</translation>
     </message>
     <message>
         <source>Prune &amp;block storage to</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Podar almacenamiento de bloques a</translation>
     </message>
     <message>
         <source>GB</source>
-        <translation type="unfinished"></translation>
+        <translation>GB</translation>
     </message>
     <message>
         <source>Reverting this setting requires re-downloading the entire blockchain.</source>
-        <translation type="unfinished"></translation>
+        <translation>Revertir esta configuración requiere volver a descargar toda la cadena de bloques.</translation>
     </message>
 </context>
 <context>
@@ -1420,118 +1420,118 @@
     </message>
     <message>
         <source>Helpful tip of the day:</source>
-        <translation type="unfinished"></translation>
+        <translation>Consejo útil del día:</translation>
     </message>
     <message>
         <source>Tip</source>
-        <translation type="unfinished"></translation>
+        <translation>Consejo</translation>
     </message>
     <message>
         <source>Encrypt your wallet with a strong passphrase for maximum security</source>
-        <translation type="unfinished"></translation>
+        <translation>Cifra tu monedero con una contraseña fuerte para máxima seguridad</translation>
     </message>
     <message>
         <source>Backup your private key to recover your coins, using &apos;File&apos; &gt; &apos;Backup Wallet&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Haz una copia de seguridad de tu clave privada para recuperar tus monedas, usando &apos;Archivo&apos; &gt; &apos;Respaldar monedero&apos;</translation>
     </message>
     <message>
         <source>Always do your own research before using an external cryptocurrency service</source>
-        <translation type="unfinished"></translation>
+        <translation>Siempre investiga por tu cuenta antes de usar un servicio externo de criptomonedas</translation>
     </message>
     <message>
         <source>Services that claim to double your dogecoins are always ponzi schemes</source>
-        <translation type="unfinished"></translation>
+        <translation>Los servicios que afirman duplicar tus dogecoins siempre son esquemas Ponzi</translation>
     </message>
     <message>
         <source>Never share your wallet.dat file with anyone</source>
-        <translation type="unfinished"></translation>
+        <translation>Nunca compartas tu archivo wallet.dat con nadie</translation>
     </message>
     <message>
         <source>For advanced operations, use the console in &apos;Help&apos; -&gt; &apos;Debug Window&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Para operaciones avanzadas, usa la consola en &apos;Ayuda&apos; -&gt; &apos;Ventana de depuración&apos;</translation>
     </message>
     <message>
         <source>Make sure to keep your wallet software updated</source>
-        <translation type="unfinished"></translation>
+        <translation>Asegúrate de mantener actualizado el software de tu monedero</translation>
     </message>
     <message>
         <source>Never share your private key with anyone</source>
-        <translation type="unfinished"></translation>
+        <translation>Nunca compartas tu clave privada con nadie</translation>
     </message>
     <message>
         <source>Who owns the private keys, owns the coins</source>
-        <translation type="unfinished"></translation>
+        <translation>Quien posee las claves privadas, posee las monedas</translation>
     </message>
     <message>
         <source>To see ongoing development and contribute, check out the Dogecoin Core repository on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Para ver el desarrollo en curso y contribuir, visita el repositorio de Dogecoin Core en GitHub</translation>
     </message>
 </context>
 <context>
     <name>PaperWalletDialog</name>
     <message>
         <source>Print Your Paper Wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprime tus monederos de papel</translation>
     </message>
     <message>
         <source>Very New Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Nueva dirección</translation>
     </message>
     <message>
         <source>So Print</source>
-        <translation type="unfinished"></translation>
+        <translation>Imprimir</translation>
     </message>
     <message>
         <source>Many Wallets?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Cuántos monederos?</translation>
     </message>
     <message>
         <source>1</source>
-        <translation type="unfinished"></translation>
+        <translation>1</translation>
     </message>
     <message>
         <source>2</source>
-        <translation type="unfinished"></translation>
+        <translation>2</translation>
     </message>
     <message>
         <source>3</source>
-        <translation type="unfinished"></translation>
+        <translation>3</translation>
     </message>
     <message>
         <source>4</source>
-        <translation type="unfinished"></translation>
+        <translation>4</translation>
     </message>
     <message>
         <source>5</source>
-        <translation type="unfinished"></translation>
+        <translation>5</translation>
     </message>
     <message>
         <source>6</source>
-        <translation type="unfinished"></translation>
+        <translation>6</translation>
     </message>
     <message>
         <source>7</source>
-        <translation type="unfinished"></translation>
+        <translation>7</translation>
     </message>
     <message>
         <source>8</source>
-        <translation type="unfinished"></translation>
+        <translation>8</translation>
     </message>
     <message>
         <source>9</source>
-        <translation type="unfinished"></translation>
+        <translation>9</translation>
     </message>
     <message>
         <source>10</source>
-        <translation type="unfinished"></translation>
+        <translation>10</translation>
     </message>
     <message>
         <source>11</source>
-        <translation type="unfinished"></translation>
+        <translation>11</translation>
     </message>
     <message>
         <source>12</source>
-        <translation type="unfinished"></translation>
+        <translation>12</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -1539,107 +1539,111 @@
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Public Key:</source>
-        <translation type="unfinished"></translation>
+        <translation>Clave pública:</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Cerrar</translation>
     </message>
     <message>
         <source>Warning: Network Activity Detected</source>
-        <translation type="unfinished"></translation>
+        <translation>Advertencia: Se detectó actividad de red</translation>
     </message>
     <message>
         <source>It is recommended to disconnect from the internet before printing paper wallets. Even though paper wallets are generated on your local computer, it is still possible to unknowingly have malware that transmits your screen to a remote location. It is also recommended to print to a local printer vs a network printer since that network traffic can be monitored. Some advanced printers also store copies of each printed document. Proceed with caution relative to the amount of value you plan to store on each address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se recomienda desconectarse de Internet antes de imprimir monederos de papel. Aunque los monederos de papel se generan en tu computadora local, es posible tener malware que transmita tu pantalla a una ubicación remota sin que lo sepas. También se recomienda imprimir en una impresora local en lugar de una impresora de red, ya que ese tráfico de red puede ser monitoreado. Algunas impresoras avanzadas también almacenan copias de cada documento impreso. Procede con precaución en relación con la cantidad de valor que planeas almacenar en cada dirección.</translation>
     </message>
     <message>
         <source>Error encoding Address into QR Code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al codificar la dirección en código QR.</translation>
     </message>
     <message>
         <source>Error encoding private key into QR Code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al codificar la clave privada en código QR.</translation>
     </message>
     <message>
         <source>Printing Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de impresión</translation>
     </message>
     <message>
         <source>failed to open file, is it writable?</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al abrir el archivo, ¿es escribible?</translation>
     </message>
     <message>
         <source>Load Paper Wallets</source>
-        <translation type="unfinished"></translation>
+        <translation>Cargar monederos de papel</translation>
     </message>
     <message>
         <source>The paper wallet printing process has begun.&lt;br/&gt;Please wait for the wallets to print completely and verify that everything printed correctly.&lt;br/&gt;Check for misalignments, ink bleeding, smears, or anything else that could make the private keys unreadable.&lt;br/&gt;Now, enter the number of DOGE you wish to send to each wallet:</source>
-        <translation type="unfinished"></translation>
+        <translation>El proceso de impresión de monederos de papel ha comenzado.&lt;br/&gt;Por favor, espera a que los monederos se impriman completamente y verifica que todo se haya impreso correctamente.&lt;br/&gt;Revisa si hay desalineaciones, manchas de tinta, borrones o cualquier otra cosa que pueda hacer ilegibles las claves privadas.&lt;br/&gt;Ahora, ingresa la cantidad de DOGE que deseas enviar a cada monedero:</translation>
     </message>
     <message>
         <source>Paper wallet %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Monedero de papel %1</translation>
     </message>
     <message>
         <source>&lt;b&gt;%1&lt;/b&gt; to Paper Wallet &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; al monedero de papel &lt;span style=&apos;font-family: monospace;&apos;&gt;%2&lt;/span&gt;</translation>
     </message>
     <message>
         <source>Send Coins</source>
-        <translation type="unfinished"></translation>
+        <translation>Enviar monedas</translation>
     </message>
     <message>
         <source>The recipient address is not valid, please recheck.</source>
-        <translation type="unfinished"></translation>
+        <translation>La dirección del destinatario no es válida, por favor verifícala.</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0</source>
-        <translation type="unfinished">La cantidad a pagar debe de ser mayor que 0. {0?}</translation>
+        <translation>La cantidad a pagar debe ser mayor que 0</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished">La cantidad excede su saldo.</translation>
+        <translation>La cantidad excede su saldo.</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the transaction fee is included</source>
-        <translation type="unfinished"></translation>
+        <translation>El total excede su saldo cuando se incluye la comisión de transacción</translation>
     </message>
     <message>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se encontró una dirección duplicada, solo se puede enviar a cada dirección una vez por operación de envío.</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished">¡Falló la creación de transacción!</translation>
+        <translation>¡Falló la creación de transacción!</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation type="unfinished">¿Seguro que quiere enviar?</translation>
+        <translation>¿Seguro que quiere enviar?</translation>
     </message>
     <message>
         <source>added as transaction fee</source>
-        <translation type="unfinished">añadido como comisión de transacción</translation>
+        <translation>añadido como comisión de transacción</translation>
     </message>
     <message>
         <source>Total Amount %1 (= %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad total %1 (= %2)</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished">o</translation>
+        <translation>o</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation type="unfinished">Confirmar enviar monedas</translation>
+        <translation>Confirmar enviar monedas</translation>
     </message>
     <message>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation type="unfinished"></translation>
+        <translation>¡La transacción fue rechazada! Esto puede suceder si algunas de las monedas en tu monedero ya fueron gastadas, como si usaste una copia de wallet.dat y las monedas fueron gastadas en la copia pero no marcadas como gastadas aquí.</translation>
     </message>
 </context>
 <context>
@@ -1730,19 +1734,23 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Requested payment amount of %1 is too small (below discard threshold).</source>
-        <translation type="unfinished"></translation>
+        <translation>La cantidad de pago solicitada de %1 es demasiado pequeña (por debajo del umbral de descarte).</translation>
     </message>
     <message>
         <source>BIP70 payment requests are deprecated and disabled by default. Restart with -enable-bip70 if you absolutely have to use this functionality.
 
 Use this functionality with extreme caution.</source>
-        <translation type="unfinished"></translation>
+        <translation>Las solicitudes de pago BIP70 están obsoletas y deshabilitadas por defecto. Reinicia con -enable-bip70 si absolutamente necesitas usar esta funcionalidad.
+
+Usa esta funcionalidad con extrema precaución.</translation>
     </message>
     <message>
         <source>Payment request file handling is disabled by default. Restart with -enable-bip70 if you absolutely have to use this functionality.
 
 Use this functionality with extreme caution.</source>
-        <translation type="unfinished"></translation>
+        <translation>El manejo de archivos de solicitud de pago está deshabilitado por defecto. Reinicia con -enable-bip70 si absolutamente necesitas usar esta funcionalidad.
+
+Usa esta funcionalidad con extrema precaución.</translation>
     </message>
 </context>
 <context>
@@ -1765,42 +1773,42 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Bytes Sent</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes enviados</translation>
     </message>
     <message>
         <source>Bytes Received</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes recibidos</translation>
     </message>
 </context>
 <context>
     <name>PeerTools</name>
     <message>
         <source>Error: Peer-to-peer functionality missing or disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Error: Funcionalidad peer-to-peer faltante o deshabilitada</translation>
     </message>
     <message>
         <source>Attempted to one try node.</source>
-        <translation type="unfinished"></translation>
+        <translation>Se intentó conectar al nodo una vez.</translation>
     </message>
     <message>
         <source>Node not found in connected nodes</source>
-        <translation type="unfinished"></translation>
+        <translation>Nodo no encontrado en los nodos conectados</translation>
     </message>
     <message>
         <source>Disconnected the node: </source>
-        <translation type="unfinished"></translation>
+        <translation>Nodo desconectado: </translation>
     </message>
     <message>
         <source>Returned OK.</source>
-        <translation type="unfinished"></translation>
+        <translation>Devuelto OK.</translation>
     </message>
     <message>
         <source>Error: Node address is invalid</source>
-        <translation type="unfinished"></translation>
+        <translation>Error: La dirección del nodo es inválida</translation>
     </message>
     <message>
         <source>Error: Unable to add node</source>
-        <translation type="unfinished"></translation>
+        <translation>Error: No se puede agregar el nodo</translation>
     </message>
 </context>
 <context>
@@ -1893,7 +1901,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>%1 B</source>
-        <translation type="unfinished">%1 B</translation>
+        <translation>%1 B</translation>
     </message>
     <message>
         <source>%1 GB</source>
@@ -1901,7 +1909,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>%1 MB</source>
-        <translation type="unfinished">%1 MB</translation>
+        <translation>%1 MB</translation>
     </message>
     <message>
         <source>%1 KB</source>
@@ -1909,7 +1917,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>%1 kB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 kB</translation>
     </message>
 </context>
 <context>
@@ -2250,35 +2258,35 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Connected peers</source>
-        <translation type="unfinished"></translation>
+        <translation>Pares conectados</translation>
     </message>
     <message>
         <source>Add new peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Agregar nuevo par</translation>
     </message>
     <message>
         <source>Remove peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar par</translation>
     </message>
     <message>
         <source>One try peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Intentar par una vez</translation>
     </message>
     <message>
         <source>Error</source>
-        <translation type="unfinished">Error</translation>
+        <translation>Error</translation>
     </message>
     <message>
         <source>Remove Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar par</translation>
     </message>
     <message>
         <source>Are you sure you want to remove the peer: </source>
-        <translation type="unfinished"></translation>
+        <translation>¿Estás seguro de que deseas eliminar el par: </translation>
     </message>
     <message>
         <source>No peer was selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se seleccionó ningún par.</translation>
     </message>
 </context>
 <context>
@@ -2694,31 +2702,31 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Warning: Fee estimation is currently not possible.</source>
-        <translation type="unfinished"></translation>
+        <translation>Advertencia: La estimación de comisiones no es posible actualmente.</translation>
     </message>
     <message>
         <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 satoshis in fee, while &quot;total at least&quot; pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation type="unfinished"></translation>
+        <translation>Si la comisión personalizada se establece en 1000 satoshis y la transacción es de solo 250 bytes, entonces &quot;por kilobyte&quot; solo paga 250 satoshis de comisión, mientras que &quot;total al menos&quot; paga 1000 satoshis. Para transacciones mayores a un kilobyte ambos pagan por kilobyte.</translation>
     </message>
     <message>
         <source>Priority:</source>
-        <translation type="unfinished"></translation>
+        <translation>Prioridad:</translation>
     </message>
     <message>
         <source>low</source>
-        <translation type="unfinished"></translation>
+        <translation>baja</translation>
     </message>
     <message>
         <source>high</source>
-        <translation type="unfinished"></translation>
+        <translation>alta</translation>
     </message>
     <message>
         <source>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar la comisión de respaldo puede resultar en enviar una transacción que tardará varias horas o días (o nunca) en confirmarse. Considera elegir tu comisión manualmente o espera hasta que hayas validado la cadena completa.</translation>
     </message>
     <message>
         <source>If the custom fee is set to 1000 koinu and the transaction is only 250 bytes, then &quot;per kilobyte&quot; only pays 250 koinu in fee, while &quot;total at least&quot; pays 1000 koinu. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation type="unfinished"></translation>
+        <translation>Si la comisión personalizada se establece en 1000 koinu y la transacción es de solo 250 bytes, entonces &quot;por kilobyte&quot; solo paga 250 koinu de comisión, mientras que &quot;total al menos&quot; paga 1000 koinu. Para transacciones mayores a un kilobyte ambos pagan por kilobyte.</translation>
     </message>
 </context>
 <context>
@@ -2972,39 +2980,39 @@ Use this functionality with extreme caution.</source>
     <name>TestPeerDialog</name>
     <message>
         <source>Test Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Probar par</translation>
     </message>
     <message>
         <source>Enter the peer details below.</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce los detalles del par a continuación.</translation>
     </message>
     <message>
         <source>Be careful! Do not blindly trust anyone that tells you to add their node.</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Ten cuidado! No confíes ciegamente en quien te diga que agregues su nodo.</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s address</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce la dirección del par</translation>
     </message>
     <message>
         <source>Enter the peer&apos;s port</source>
-        <translation type="unfinished"></translation>
+        <translation>Introduce el puerto del par</translation>
     </message>
     <message>
         <source>Test!</source>
-        <translation type="unfinished"></translation>
+        <translation>¡Probar!</translation>
     </message>
     <message>
         <source>Please enter an address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, introduce una dirección.</translation>
     </message>
     <message>
         <source>Please enter a valid peer address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, introduce una dirección de par válida.</translation>
     </message>
     <message>
         <source>Try Peer</source>
-        <translation type="unfinished"></translation>
+        <translation>Intentar par</translation>
     </message>
 </context>
 <context>
@@ -4464,83 +4472,83 @@ Establecer la serialización de las transacciones sin procesar o el bloque hex d
     </message>
     <message>
         <source>Bitcoin Core and Dogecoin Core</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitcoin Core y Dogecoin Core</translation>
     </message>
     <message>
         <source>Amount under which a transaction output is considered dust, in %s (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad por debajo de la cual una salida de transacción se considera polvo, en %s (predeterminado: %s)</translation>
     </message>
     <message>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash, %i is replaced by block number)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ejecutar comando cuando el mejor bloque cambia (%s en cmd se reemplaza por el hash del bloque, %i se reemplaza por el número de bloque)</translation>
     </message>
     <message>
         <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard. Paper wallet art provided by Anacoluthia.</source>
-        <translation type="unfinished"></translation>
+        <translation>Este producto incluye software desarrollado por el Proyecto OpenSSL para uso en el OpenSSL Toolkit %s y software criptográfico escrito por Eric Young y software UPnP escrito por Thomas Bernard. Arte del monedero de papel proporcionado por Anacoluthia.</translation>
     </message>
     <message>
         <source>Amaze</source>
-        <translation type="unfinished"></translation>
+        <translation>Asombroso</translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation>Predeterminado</translation>
     </message>
     <message>
         <source>Many generous</source>
-        <translation type="unfinished"></translation>
+        <translation>Muy generoso</translation>
     </message>
     <message>
         <source>Minimum</source>
-        <translation type="unfinished"></translation>
+        <translation>Mínimo</translation>
     </message>
     <message>
         <source>More</source>
-        <translation type="unfinished"></translation>
+        <translation>Más</translation>
     </message>
     <message>
         <source>Such expensive</source>
-        <translation type="unfinished"></translation>
+        <translation>Muy caro</translation>
     </message>
     <message>
         <source>Wow</source>
-        <translation type="unfinished"></translation>
+        <translation>Wow</translation>
     </message>
     <message>
         <source>-discardthreshold is set very high! This is the output amount that the wallet will discard (to fee) if it is smaller than this setting.</source>
-        <translation type="unfinished"></translation>
+        <translation>¡-discardthreshold está configurado muy alto! Esta es la cantidad de salida que el monedero descartará (a comisión) si es menor que esta configuración.</translation>
     </message>
     <message>
         <source>Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad por debajo de la cual una salida de transacción se considera no estándar y no será aceptada ni retransmitida, en %s (predeterminado: %s)</translation>
     </message>
     <message>
         <source>Invalid amount for -discardthreshold=&lt;amount&gt;: &apos;%s&apos; (must be at least the dust limit of %s to prevent stuck transactions)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cantidad inválida para -discardthreshold=&lt;amount&gt;: &apos;%s&apos; (debe ser al menos el límite de polvo de %s para prevenir transacciones atascadas)</translation>
     </message>
     <message>
         <source>The minimum transaction output size (in %s) used to validate wallet transactions and discard change (to fee) (default: %s)</source>
-        <translation type="unfinished"></translation>
+        <translation>El tamaño mínimo de salida de transacción (en %s) usado para validar transacciones del monedero y descartar cambio (a comisión) (predeterminado: %s)</translation>
     </message>
     <message>
         <source>Use Namecoin-compatible AuxPow API structure, (default: %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar estructura de API AuxPow compatible con Namecoin, (predeterminado: %u)</translation>
     </message>
     <message>
         <source>Execute command when we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ejecutar comando cuando vemos una bifurcación realmente larga (%s en cmd se reemplaza por mensaje)</translation>
     </message>
     <message>
         <source>Specify directory where to write backups and data dumps (default datadir/backups)</source>
-        <translation type="unfinished"></translation>
+        <translation>Especificar directorio donde escribir respaldos y volcados de datos (predeterminado datadir/backups)</translation>
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID, %i with block height, with a value of 0 if tx is no longer in chaintip)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ejecutar comando cuando una transacción del monedero cambia (%s en cmd se reemplaza por TxID, %i con altura del bloque, con un valor de 0 si la tx ya no está en la punta de la cadena)</translation>
     </message>
     <message>
         <source>Enable BIP-70 PaymentServer (default: 0)</source>
-        <translation type="unfinished"></translation>
+        <translation>Habilitar servidor de pagos BIP-70 (predeterminado: 0)</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

- Complete all 149 unfinished translations in the Spanish locale file (`bitcoin_es.ts`)
- Provides full Spanish language support for Dogecoin Core Qt wallet

This PR addresses issue #3803 for the Spanish language file.

### Translated sections include:

- **AddPeerDialog**: Peer management UI strings
- **BitcoinGUI**: Paper wallet printing and menu items
- **ImportKeysDialog**: Private key import functionality
- **OverviewPage**: Daily tips and security advice
- **PaperWalletDialog**: Complete paper wallet printing workflow
- **PeerTableModel/PeerTools**: Network peer management
- **SendCoinsDialog**: Fee estimation warnings and priority labels
- **TestPeerDialog**: Peer testing interface
- **dogecoin-core**: Command-line help text and fee settings

## Test plan

- [ ] Verify XML validity (confirmed via Python xml.etree.ElementTree parser)
- [ ] Build with Qt Linguist to verify translation format
- [ ] Run Dogecoin Qt with Spanish locale (LANG=es_ES) to verify translations display correctly
- [ ] Review translations for accuracy and consistency

## Notes

- All translations follow existing terminology conventions in the file
- Maintained consistent use of "monedero" (wallet), "par" (peer), "comisión" (fee)
- Preserved HTML formatting and placeholder variables (%1, %s, etc.)
- Doge-specific meme phrases translated contextually (e.g., "Such expensive" -> "Muy caro")

Closes #3803 (partially - Spanish language file)

---
Generated with [Claude Code](https://claude.com/claude-code)