### PR TITLE
Add ISSUE_TEMPLATE/config.yml for issue submission rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue Submission Rules
+    url: https://github.com/dogecoin/dogecoin/issues/2110
+    about: Please read the issue submission rules before posting.
+  - name: Dogeducation (Reddit)
+    url: https://www.reddit.com/r/dogeducation/
+    about: For general questions about Dogecoin or wallet recovery.
+  - name: Dogecoin Discord
+    url: https://discord.com/invite/dogecoin
+    about: Join the community for general support and discussions.


### PR DESCRIPTION
## Summary

- Adds `config.yml` to `.github/ISSUE_TEMPLATE/` to configure the template chooser
- Links to issue submission rules (#2110) so users see them before creating issues
- Adds helpful links to Dogeducation subreddit and Discord for general questions

This implements the suggestion from #2191 to make issue submission rules more visible.

## Preview

When users click "New Issue", they will see:
- Bug Report template
- Feature Request template
- **Issue Submission Rules** link (to #2110)
- **Dogeducation (Reddit)** link
- **Dogecoin Discord** link

## Test plan

- [x] Verify config.yml syntax is valid
- [ ] After merge, verify template chooser displays correctly

Closes #2191

---
Generated with [Claude Code](https://claude.com/claude-code)