### PR TITLE
Mark getauxblock RPC method as deprecated

### DIFF
--- a/doc/rpc-maturity.md
+++ b/doc/rpc-maturity.md
@@ -42,7 +42,7 @@ Core RPC. Maturity is expressed over 3 stages:
 | getaccountaddress      | DEPRECATED | Deprecated since 1.14.0                    |
 | getaddednodeinfo       | STABLE     |                                            |
 | getaddressesbyaccount  | DEPRECATED | Deprecated since 1.14.0                    |
-| getauxblock            | STABLE     |                                            |
+| getauxblock            | DEPRECATED | Use createauxblock/submitauxblock instead  |
 | getbalance             | STABLE     |                                            |
 | getbestblockhash       | STABLE     |                                            |
 | getblock               | STABLE     |                                            |

--- a/src/rpc/auxpow.cpp
+++ b/src/rpc/auxpow.cpp
@@ -232,6 +232,7 @@ UniValue getauxblock(const JSONRPCRequest& request)
         || (request.params.size() != 0 && request.params.size() != 2))
       throw std::runtime_error(
           "getauxblock (hash auxpow)\n"
+          "\nDEPRECATED. Use 'createauxblock' and 'submitauxblock' instead.\n"
           "\nCreate or submit a merge-mined block.\n"
           "\nWithout arguments, create a new block and return information\n"
           "required to merge-mine it.  With arguments, submit a solved\n"


### PR DESCRIPTION
## Summary

- Adds `DEPRECATED` notice to `getauxblock` help text directing miners to use `createauxblock`/`submitauxblock` instead
- Updates `doc/rpc-maturity.md` to mark `getauxblock` as DEPRECATED

## Background

As noted in #2259, retaining the legacy `getauxblock` RPC command requires breaching separation of concerns between the node core and wallet. The newer `createauxblock`/`submitauxblock` commands provide the same functionality without wallet integration.

## Changes

**src/rpc/auxpow.cpp:**
```
getauxblock (hash auxpow)

DEPRECATED. Use 'createauxblock' and 'submitauxblock' instead.
```

**doc/rpc-maturity.md:**
```
| getauxblock | DEPRECATED | Use createauxblock/submitauxblock instead |
```

## Test plan

- [x] Verify help text shows deprecation warning: `dogecoin-cli help getauxblock`
- [x] Verify rpc-maturity.md is properly formatted

Closes #2300

---
Generated with [Claude Code](https://claude.com/claude-code)