### PR TITLE
Add strict minimum difficulty rules to prevent testnet block storms

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -92,6 +92,7 @@ public:
         consensus.nCoinbaseMaturity = 30;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
+        consensus.fEnforceStrictMinDifficulty = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 9576; // 95% of 10,080
         consensus.nMinerConfirmationWindow = 10080; // 60 * 24 * 7 = 10,080 blocks, or one week
@@ -236,6 +237,7 @@ public:
         consensus.nCoinbaseMaturity = 30;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
+        consensus.fEnforceStrictMinDifficulty = false;
         consensus.nSubsidyHalvingInterval = 100000;
         consensus.nMajorityEnforceBlockUpgrade = 501;
         consensus.nMajorityRejectBlockOutdated = 750;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -72,6 +72,7 @@ struct Params {
     bool fDigishieldDifficultyCalculation;
     bool fPowAllowDigishieldMinDifficultyBlocks; // Allow minimum difficulty blocks where a retarget would normally occur
     bool fSimplifiedRewards; // Use block height derived rewards rather than previous block hash derived
+    bool fEnforceStrictMinDifficulty; // Enforce stricter rules on minimum difficulty blocks to prevent block storms and time-warp attacks
 
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -30,12 +30,27 @@ bool AllowDigishieldMinDifficultyForBlock(const CBlockIndex* pindexLast, const C
         return false;
 
     // check if the chain allows minimum difficulty blocks on recalc blocks
-    if (pindexLast->nHeight < 157500)
-    // if (!params.fPowAllowDigishieldMinDifficultyBlocks)
+    if (!params.fPowAllowDigishieldMinDifficultyBlocks)
         return false;
 
-    // Allow for a minimum block time if the elapsed time > 2*nTargetSpacing
-    return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2);
+    // Strict minimum difficulty rules to prevent block storms and time-warp attacks
+    // Similar in spirit to BIP-94 for Bitcoin Testnet4, but adapted for Digishield
+    if (params.fEnforceStrictMinDifficulty) {
+        // Prevent block storm attacks by disallowing consecutive minimum difficulty blocks.
+        // This stops attackers from chaining minimum difficulty blocks indefinitely.
+        if (pindexLast->nBits == UintToArith256(params.powLimit).GetCompact())
+            return false;
+
+        // Prevent time-warps where the block timestamp could be manipulated relative to MTP
+        if (pblock->GetBlockTime() <= pindexLast->GetMedianTimePast() + params.nPowTargetSpacing * 10)
+            return false;
+
+        // Allow for a minimum block time if the elapsed time > 10*nTargetSpacing
+        return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing * 10);
+    }
+
+    // Legacy behavior: Allow for a minimum block time if the elapsed time > 2*nTargetSpacing
+    return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing * 2);
 }
 
 unsigned int CalculateDogecoinNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)


### PR DESCRIPTION
## Summary

This PR introduces stricter minimum difficulty rules for Dogecoin testnet to prevent block storm and time-warp attacks that are currently causing severe issues on the test network.

## Problem

Currently the testnet is approaching [30,000,000 blocks](https://doge-testnet.psy.xyz/block/23ba0d9bdf17c87269bb7d0fbd7cfa36826a20c142f49918c677a893130c8f4e), and for some context [block 24,000,000](https://doge-testnet.psy.xyz/block/24000000) was mined just 21 days ago, for an average of **3.3 blocks per second** during this 21 day period — roughly **180x faster** than the intended 1 block per minute rate.

This has caused significant problems:
- **Infrastructure strain**: Block explorers are struggling with the massive increase in data and memory requirements
- **Service outages**: We are now down to two public testnet block explorers (https://chain.so/DOGETEST is no longer functional after the recent spike)
- **Testing impossible**: The erratic block rate makes it very difficult to actually test anything because blocks arrive faster than indexers can process them

### Root Cause

The miner is accomplishing this by exploiting the minimum difficulty exception through a time-warp attack. The current implementation allows minimum difficulty blocks when the elapsed time exceeds `2 * nPowTargetSpacing`, and this can be chained indefinitely by manipulating timestamps.
<a href="https://doge-testnet.psy.xyz/testnet-health-report/index.html">
<img width="1428" height="733" alt="Screenshot 2026-01-22 at 6 08 47 PM" src="https://github.com/user-attachments/assets/44c45aca-c449-41df-9108-fe264c6235e9" />
</a>
For more information/raw data, please see [Dogecoin Testnet Health Report](https://doge-testnet.psy.xyz/testnet-health-report/index.html)


## Solution

[BIP-94](https://github.com/bitcoin/bips/blob/master/bip-0094.mediawiki) addresses similar problems on Bitcoin Testnet4, but unfortunately it is not directly applicable to Dogecoin because:

1. **Digishield retargets every block**: Bitcoin only retargets every 2016 blocks, so BIP-94's difficulty adjustment fix (using the first block of the retarget period) doesn't translate to Digishield where every block is a retarget
2. **Different timing parameters**: Dogecoin's 1-minute block time vs Bitcoin's 10-minute blocks requires different thresholds
3. **Existing Digishield mechanics**: We need to work within the existing `AllowDigishieldMinDifficultyForBlock` framework

### Implementation

This PR introduces a new consensus parameter `fEnforceStrictMinDifficulty` that, when enabled, applies the following rules:

#### 1. Prevent Block Storm Attacks
```cpp
// Prevent block storm attacks by disallowing consecutive minimum difficulty blocks.
// This stops attackers from chaining minimum difficulty blocks indefinitely.
if (pindexLast->nBits == UintToArith256(params.powLimit).GetCompact())
    return false;
```
If the previous block was already at minimum difficulty, we don't allow another minimum difficulty block. This breaks the chain of easy blocks.

#### 2. Prevent Time-Warp Attacks (MTP Check)
```cpp
// Prevent time-warps where the block timestamp could be manipulated relative to MTP
if (pblock->GetBlockTime() <= pindexLast->GetMedianTimePast() + params.nPowTargetSpacing * 10)
    return false;
```
The block timestamp must be significantly ahead of the Median Time Past, preventing timestamp manipulation attacks.

#### 3. Increased Time Threshold
```cpp
// Allow for a minimum block time if the elapsed time > 10*nTargetSpacing
return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing * 10);
```
Changed from `2 * nTargetSpacing` to `10 * nTargetSpacing` (10 minutes instead of 2 minutes), making it much harder to trigger minimum difficulty legitimately while still allowing the network to recover if mining power drops significantly.

### Comparison with BIP-94

| Aspect | BIP-94 (Bitcoin) | This PR (Dogecoin) |
|--------|------------------|-------------------|
| Consecutive min-diff prevention | ✅ | ✅ |
| Time-warp prevention | Via retarget period adjustment | Via MTP + threshold check |
| Difficulty retarget fix | Uses first block of 2016-block period | N/A (Digishield retargets every block) |
| Min-diff time threshold | 20 minutes (2× 10-min target) | 10 minutes (10× 1-min target) |

## Changes

### `src/consensus/params.h`
- Added `bool fEnforceStrictMinDifficulty` parameter to consensus rules

### `src/chainparams.cpp`
- Set `fEnforceStrictMinDifficulty = false` for mainnet (preserves existing behavior)
- Set `fEnforceStrictMinDifficulty = false` for testnet (can be enabled via future activation)

### `src/dogecoin.cpp`
- Modified `AllowDigishieldMinDifficultyForBlock()` to implement strict rules when `fEnforceStrictMinDifficulty` is enabled
- Preserved legacy behavior as fallback

## Activation

This PR sets `fEnforceStrictMinDifficulty = false` for both mainnet and testnet by default. 
I recommend we start a new testnet from scratch as 30 million blocks is **57 years** of blocks, and anyone/everyone should be able to run a testnet node.


## Testing

- [ ] Unit tests for new minimum difficulty logic
- [ ] Regression tests ensuring mainnet behavior unchanged
- [ ] Integration tests on testnet/regtest

## References

- [BIP-94: Testnet 4](https://github.com/bitcoin/bips/blob/master/bip-0094.mediawiki)
- [Bitcoin PR #29775: Testnet4 including BIP-94](https://github.com/bitcoin/bitcoin/pull/29775)
- [Digishield implementation](https://github.com/dogecoin/dogecoin/blob/master/src/dogecoin.cpp)

## Breaking Changes

- None for mainnet (parameter disabled by default)
- Testnet may require coordination if enabled mid-chain