### PR TITLE
dogecoin: remove unused bnOld in retarget calculation

### DIFF
--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -74,9 +74,7 @@ unsigned int CalculateDogecoinNextWorkRequired(const CBlockIndex* pindexLast, in
     // Retarget
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
     arith_uint256 bnNew;
-    arith_uint256 bnOld;
     bnNew.SetCompact(pindexLast->nBits);
-    bnOld = bnNew;
     bnNew *= nModulatedTimespan;
     bnNew /= retargetTimespan;
 


### PR DESCRIPTION
bnOld was assigned from nBits but never read; drop the dead store.