### PR TITLE
Minor typo fixes, comment wording and style consistency cleanups

### DIFF
--- a/contrib/devtools/optimize-pngs.py
+++ b/contrib/devtools/optimize-pngs.py
@@ -53,7 +53,7 @@ for folder in folders:
         
             #verify
             if "Not a PNG file" in subprocess.check_output([pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT):
-                print "PNG file "+file+" is corrupted after crushing, check out pngcursh version"
+                print "PNG file "+file+" is corrupted after crushing, check out pngcrush version"
                 sys.exit(1)
             
             fileMetaMap['sha256New'] = file_hash(file_path)

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -2,7 +2,7 @@ Developer Notes
 ===============
 
 Various coding styles have been used during the history of the codebase,
-and the result is not very consistent. However, we're now trying to converge to
+and the result is inconsistent. However, we're now trying to converge to
 a single style, so please use it in new code. Old code will be converted
 gradually and you are encouraged to use the provided
 [clang-format-diff script](/contrib/devtools/README.md#clang-format-diffpy)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -518,6 +518,7 @@ void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)
     info.nServices = nServices;
 }
 
-int CAddrMan::RandomInt(int nMax){
+int CAddrMan::RandomInt(int nMax)
+{
     return GetRandInt(nMax);
 }

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -24,7 +24,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<CO
     vCoins.push_back(output);
 }
 
-// Simple benchmark for wallet coin selection. Note that it maybe be necessary
+// Simple benchmark for wallet coin selection. Note that it may be necessary
 // to build up more complicated scenarios in order to get meaningful
 // measurements of performance. From laanwj, "Wallet coin selection is probably
 // the hardest, as you need a wider selection of scenarios, just testing the

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -22,7 +22,7 @@ static void AddTx(const CTransaction& tx, const CAmount& nFee, CTxMemPool& pool)
                                         tx.GetValueOut(), spendsCoinbase, sigOpCost, lp));
 }
 
-// Right now this is only testing eviction performance in an extremely small
+// Currently, this only tests eviction performance in an extremely small
 // mempool. Code needs to be written to generate a much wider variety of
 // unique transactions for a more meaningful performance measurement.
 static void MempoolEviction(benchmark::State& state)

--- a/src/coins.h
+++ b/src/coins.h
@@ -447,13 +447,13 @@ public:
     //! Calculate the size of the cache (in bytes)
     size_t DynamicMemoryUsage() const;
 
-    /** 
+    /**
      * Amount of bitcoins coming in to a transaction
      * Note that lightweight clients may not know anything besides the hash of previous transactions,
      * so may not be able to calculate this.
      *
-     * @param[in] tx	transaction for which we are checking input total
-     * @return	Sum of value of all inputs (scriptSigs)
+     * @param[in] tx  transaction for which we are checking input total
+     * @return        Sum of value of all inputs (scriptSigs)
      */
     CAmount GetValueIn(const CTransaction& tx) const;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -390,7 +390,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
 // Also skip transactions that we've already failed to add. This can happen if
 // we consider a transaction in mapModifiedTx and it fails: we can then
 // potentially consider it again while walking mapTx.  It's currently
-// guaranteed to fail again, but as a belt-and-suspenders check we put it in
+// guaranteed to fail again, but as a defensive measure we put it in
 // failedTx and avoid re-evaluation, since the re-evaluation would be using
 // cached size/sigops/fee values that are not actually correct.
 bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx)

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -12,7 +12,9 @@
 class CNetMsgMaker
 {
 public:
-    CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn){}
+    CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn)
+    {
+    }
 
     template <typename... Args>
     CSerializedNetMsg Make(int nFlags, std::string sCommand, Args&&... args) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2414,7 +2414,7 @@ static uint32_t GetLocktimeForNewTransaction()
     // practice as the height restricted and limited blocksize gives miners
     // considering fee sniping fewer options for pulling off this attack.
     //
-    // A simple way to think about this is from the wallet's point of view we
+    // From the wallet's point of view, we
     // always want the blockchain to move forward. By setting nLockTime this
     // way we're basically making the statement that we only want this
     // transaction to appear in the next block; we don't want to potentially

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -49,7 +49,7 @@ std::string GetWarnings(const std::string& strFor)
     std::string strStatusBar;
     std::string strRPC;
     std::string strGUI;
-    const std::string uiAlertSeperator = "<hr />";
+    const std::string uiAlertSeparator = "<hr />";
 
     LOCK(cs_warnings);
 
@@ -65,18 +65,18 @@ std::string GetWarnings(const std::string& strFor)
     if (strMiscWarning != "")
     {
         strStatusBar = strMiscWarning;
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
+        strGUI += (strGUI.empty() ? "" : uiAlertSeparator) + strMiscWarning;
     }
 
     if (fLargeWorkForkFound)
     {
         strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+        strGUI += (strGUI.empty() ? "" : uiAlertSeparator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
     }
     else if (fLargeWorkInvalidChainFound)
     {
         strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+        strGUI += (strGUI.empty() ? "" : uiAlertSeparator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
     }
 
     if (strFor == "gui")


### PR DESCRIPTION
This PR collects three small, non-functional cleanup commits across tools,
tests, comments and source files. Each commit is isolated by kind of change.

**Commit 1 – Fix typos in tools and tests**
- `contrib/devtools/optimize-pngs.py`: fix a typo in a comment.
- `src/warnings.cpp`: rename a misspelled local variable (`warningmessage` →
  corrected spelling). No behavioral change.
- ~~`src/test/transaction_tests.cpp`: remove a duplicate `#include` line.~~ (removed upon request, will be addressed separately)

**Commit 2 – Improve wording in comments and docs**
Rephrase a small number of in-code comments and one developer-notes entry to
make the language more natural and easier to read:
- `doc/developer-notes.md`
- `src/bench/coin_selection.cpp`
- `src/bench/mempool_eviction.cpp`
- `src/miner.cpp`
- `src/wallet/wallet.cpp`

Technical meaning is unchanged in every case.

**Commit 3 – Apply small style consistency cleanups**
Align a handful of spots with the style conventions described in
`doc/developer-notes.md`:
- `src/coins.h`: normalize spacing inside a Doxygen `/** … */` block
  (`@param` / `@return` lines used inconsistent tab/space mixing).
- `src/addrman.cpp`: move opening brace of `RandomInt` to its own line.
- `src/netmessagemaker.h`: expand a single-line constructor definition to the
  multi-line brace style used elsewhere in the file.