### PR TITLE
Fix typos, wording and punctuation in Polish (pl) GUI translations

### DIFF
--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -100,7 +100,7 @@
     </message>
     <message>
         <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Tutaj znajdują się adresy Dogecoin na które wysyłasz płatności. Zawsze sprawdzaj ilość i adres odbiorcy przed wysyłką monet.</translation>
+        <translation>Tutaj znajdują się adresy Dogecoin, na które wysyłasz płatności. Zawsze sprawdzaj ilość i adres odbiorcy przed wysyłką monet.</translation>
     </message>
     <message>
         <source>These are your Dogecoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
@@ -154,7 +154,7 @@
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>Okienko Hasła</translation>
+        <translation>Okno hasła</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
@@ -170,7 +170,7 @@
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Wprowadź nowe hasło do portfela.&lt;br/&gt;Proszę używać hasła złożonego z &lt;b&gt;10 lub więcej losowych znaków&lt;/b&gt; albo &lt;b&gt;8 lub więcej słów.&lt;/b&gt;</translation>
+        <translation>Wprowadź nowe hasło do portfela.&lt;br/&gt;Proszę używać hasła złożonego z &lt;b&gt;10 lub więcej losowych znaków&lt;/b&gt; albo &lt;b&gt;8 lub więcej słów.&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
@@ -832,7 +832,7 @@
     </message>
     <message>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
-        <translation>Wprowadzony adres &quot;%1&quot; już istnieje w książce adresowej</translation>
+        <translation>Wprowadzony adres &quot;%1&quot; już istnieje w książce adresowej.</translation>
     </message>
 </context>
 <context>
@@ -1189,11 +1189,11 @@
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation>Włącz funk&amp;cje kontoli monet</translation>
+        <translation>Włącz funk&amp;cje kontroli monet</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation>Jeżeli wyłączysz możliwość wydania niezatwierdzonej wydanej reszty, reszta z transakcji nie będzie mogła zostać wykorzystana, dopóki ta transakcja nie będzie miała przynajmniej jednego potwierdzenia. To także ma wpływ na obliczanie Twojego salda.</translation>
+        <translation>Jeżeli wyłączysz możliwość wydania niepotwierdzonej reszty, reszta z transakcji nie będzie mogła zostać wykorzystana, dopóki ta transakcja nie będzie miała przynajmniej jednego potwierdzenia. To także ma wpływ na obliczanie Twojego salda.</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1201,7 +1201,7 @@
     </message>
     <message>
         <source>Automatically open the Dogecoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Automatycznie otwiera port klienta Dogecoin na routerze. Ta opcja dzieła tylko jeśli twój router wspiera UPnP i jest ono włączone.</translation>
+        <translation>Automatycznie otwiera port klienta Dogecoin na routerze. Ta opcja działa tylko jeśli twój router wspiera UPnP i jest ono włączone.</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
@@ -1233,7 +1233,7 @@
     </message>
     <message>
         <source>Shows, if the supplied default SOCKS5 proxy is used to reach peers via this network type.</source>
-        <translation>Pokazuje, czy wspierane domyślnie proxy SOCKS5 jest używane do łączenia się z peerami w tej sieci</translation>
+        <translation>Pokazuje, czy wspierane domyślnie proxy SOCKS5 jest używane do łączenia się z peerami w tej sieci.</translation>
     </message>
     <message>
         <source>IPv4</source>
@@ -1249,7 +1249,7 @@
     </message>
     <message>
         <source>Connect to the Dogecoin network through a separate SOCKS5 proxy for Tor hidden services.</source>
-        <translation>Połącz się z siecią Dogecoin przy pomocy oddzielnego SOCKS5 proxy dla sieci TOR</translation>
+        <translation>Połącz się z siecią Dogecoin przy pomocy oddzielnego SOCKS5 proxy dla sieci TOR.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
@@ -1337,7 +1337,7 @@
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation>Adres podanego proxy jest nieprawidłowy</translation>
+        <translation>Adres podanego proxy jest nieprawidłowy.</translation>
     </message>
     <message>
         <source>Disables some advanced features but all blocks will still be fully validated. Reverting this setting requires re-downloading the entire blockchain. Actual disk usage may be somewhat higher.</source>
@@ -1682,7 +1682,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Invalid payment request.</source>
-        <translation>Nieprawidłowe żądanie płatności</translation>
+        <translation>Nieprawidłowe żądanie płatności.</translation>
     </message>
     <message>
         <source>Refund from %1</source>
@@ -1796,7 +1796,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Attempted to one try node.</source>
-        <translation>Próba jednorazowego podłaczenia do węzła</translation>
+        <translation>Próba jednorazowego podłaczenia do węzła.</translation>
     </message>
     <message>
         <source>Error: Unable to add node</source>
@@ -2108,7 +2108,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation>Czas trwania nadmiarowego pingu</translation>
+        <translation>Czas trwania nadmiarowego pingu.</translation>
     </message>
     <message>
         <source>Ping Wait</source>
@@ -2767,7 +2767,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>This is a normal payment.</source>
-        <translation>To jest standardowa płatność</translation>
+        <translation>To jest standardowa płatność.</translation>
     </message>
     <message>
         <source>The Dogecoin address to send the payment to</source>
@@ -4137,7 +4137,7 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
     </message>
     <message>
         <source>Unsupported argument -socks found. Setting SOCKS version isn&apos;t possible anymore, only SOCKS5 proxies are supported.</source>
-        <translation>Znaleziono niewspierany argument -socks. Wybieranie wersji SOCKS nie jest już możliwe, wsparcie programu obejmuje tylko proxy SOCKS5</translation>
+        <translation>Znaleziono niewspierany argument -socks. Wybieranie wersji SOCKS nie jest już możliwe, wsparcie programu obejmuje tylko proxy SOCKS5.</translation>
     </message>
     <message>
         <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -100,7 +100,7 @@
     </message>
     <message>
         <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Tutaj znajdują się adresy Dogecoin, na które wysyłasz płatności. Zawsze sprawdzaj ilość i adres odbiorcy przed wysyłką monet.</translation>
+        <translation>Tutaj znajdują się adresy Dogecoin, na które wysyłasz płatności. Zawsze sprawdzaj kwotę i adres odbiorcy przed wysłaniem monet.</translation>
     </message>
     <message>
         <source>These are your Dogecoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
@@ -1249,7 +1249,7 @@
     </message>
     <message>
         <source>Connect to the Dogecoin network through a separate SOCKS5 proxy for Tor hidden services.</source>
-        <translation>Połącz się z siecią Dogecoin przy pomocy oddzielnego SOCKS5 proxy dla sieci TOR.</translation>
+        <translation>Połącz się z siecią Dogecoin przy pomocy oddzielnego SOCKS5 proxy dla sieci Tor.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
@@ -1796,7 +1796,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>Attempted to one try node.</source>
-        <translation>Próba jednorazowego podłaczenia do węzła.</translation>
+        <translation>Próba jednorazowego podłączenia do węzła.</translation>
     </message>
     <message>
         <source>Error: Unable to add node</source>
@@ -2108,7 +2108,7 @@ Use this functionality with extreme caution.</source>
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation>Czas trwania nadmiarowego pingu.</translation>
+        <translation>Czas oczekiwania na odpowiedź ping.</translation>
     </message>
     <message>
         <source>Ping Wait</source>


### PR DESCRIPTION
Improve several Polish string translations in `src/qt/locale/bitcoin_pl.ts`.
These are translation-only changes; no source code or behaviour is affected.

**Typo fixes**
- `kontoli` → `kontroli` (coin control feature label)
- `dzieła tylko` → `działa tylko` (UPnP option description)

**Wording / consistency**
- `Okienko Hasła` → `Okno hasła`: aligns with the term used throughout the
  rest of the Polish translation file; lowercase (adjective) follows normal
  Polish noun-phrase capitalisation.
- `niezatwierdzonej wydanej reszty` → `niepotwierdzonej reszty`: the original
  phrase was unnatural and verbose; the replacement matches the meaning of the
  English "unconfirmed change" more precisely.

**Punctuation**
- Added missing comma: `adresy Dogecoin na które` → `adresy Dogecoin, na które`
  (relative clause requires a comma in Polish).
- Added missing sentence-final periods to 9 translations where the English
  source string ends with a period but the Polish translation did not:
  passphrase dialog, address-book duplicate warning, SOCKS5 proxy descriptions
  (×2), proxy address error, payment-request error, one-try-node message,
  ping-duration tooltip, normal-payment label, unsupported `-socks` argument
  warning.

**Additional fixes (follow-up commit)**

- Fix typo: `podłaczenia` → `podłączenia` (missing ogonek in one-try-node translation)
- Fix mistranslation: `Czas trwania nadmiarowego pingu` → `Czas oczekiwania na odpowiedź ping`
  (`outstanding` means *pending/awaiting response*, not *nadmiarowy*)
- Improve wording: `ilość` → `kwotę`, `wysyłką` → `wysłaniem` for more natural formal UI Polish
- Consistency: `TOR` → `Tor` (not an acronym in modern usage)