### PR TITLE
docs: update branch strategy to reflect master as active branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,8 @@ or look for work that needs doing, please see:
 
 Dogecoin Core's default branch is intentionally a stable release, so that anyone
 downloading the code and compiling it gets a stable release. Active development
-occurs on branches named after the version they are targeting, for example the
-1.14.4 branch is named `1.14.4-dev`. When raising PRs, please raise against the
-relevant development branch and **not** against the `master` branch.
+occurs on the `master` branch. When raising PRs, please raise them against
+`master`.
 
 ## Contributor Workflow
 


### PR DESCRIPTION
The "Branch Strategy" section of `CONTRIBUTING.md` currently instructs
contributors to raise PRs against versioned `*-dev` branches (e.g.
`1.21-dev`) and explicitly warns against targeting `master`.

In practice, the `*-dev` workflow appears to be no longer active:
- `1.21-dev` received its last commit in February 2024 and has not
  been updated since.
- `master` receives regular commits and is the base branch for all
  currently open PRs.

This small doc update removes the outdated instruction and replaces it
with one line reflecting the actual current practice:

> Active development occurs on the `master` branch. When raising PRs,
> please raise them against `master`.

No code is changed. The intent is purely to avoid confusing new
contributors who follow the written guide and then find that their PR
targets a dead branch.

If the project plans to resume the `*-dev` workflow in the future, this
text can be updated accordingly at that time.