### PR TITLE
style: add missing space after if/for/while keywords (per developer-notes.md)

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -247,14 +247,14 @@ uint32_t arith_uint256::GetCompact(bool fNegative) const
 uint256 ArithToUint256(const arith_uint256 &a)
 {
     uint256 b;
-    for(int x=0; x<a.WIDTH; ++x)
+    for (int x=0; x<a.WIDTH; ++x)
         WriteLE32(b.begin() + x*4, a.pn[x]);
     return b;
 }
 arith_uint256 UintToArith256(const uint256 &a)
 {
     arith_uint256 b;
-    for(int x=0; x<b.WIDTH; ++x)
+    for (int x=0; x<b.WIDTH; ++x)
         b.pn[x] = ReadLE32(a.begin() + x*4);
     return b;
 }

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -338,7 +338,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
 
     // extract and validate PUBKEYs
     std::vector<CPubKey> pubkeys;
-    for(int pos = 1; pos <= int(numkeys); pos++) {
+    for (int pos = 1; pos <= int(numkeys); pos++) {
         CPubKey pubkey(ParseHex(vStrInputParts[pos + 2]));
         if (!pubkey.IsFullyValid())
             throw std::runtime_error("invalid TX output pubkey");

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -94,7 +94,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     {
         std::vector<std::string>::const_iterator it(comments.begin());
         ss << "(" << *it;
-        for(++it; it != comments.end(); ++it)
+        for (++it; it != comments.end(); ++it)
             ss << "; " << *it;
         ss << ")";
     }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -189,7 +189,7 @@ static bool ClientAllowed(const CNetAddr& netaddr)
 {
     if (!netaddr.IsValid())
         return false;
-    for(const CSubNet& subnet : rpc_allow_subnets)
+    for (const CSubNet& subnet : rpc_allow_subnets)
         if (subnet.Match(netaddr))
             return true;
     return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -692,7 +692,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
  */
 bool InitSanityCheck(void)
 {
-    if(!ECC_InitSanityCheck()) {
+    if (!ECC_InitSanityCheck()) {
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");
         return false;
     }
@@ -1570,7 +1570,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             }
 
             fLoaded = true;
-        } while(false);
+        } while (false);
 
         if (!fLoaded) {
             // first suggest a reindex

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     pblocktemplate.reset(new CBlockTemplate());
 
-    if(!pblocktemplate.get())
+    if (!pblocktemplate.get())
         return nullptr;
     pblock = &pblocktemplate->block; // pointer for convenience
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -300,7 +300,7 @@ void InitializeNode(CNode *pnode, CConnman& connman) {
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName)));
         assert(g_txrequest.Count(nodeid) == 0);
     }
-    if(!pnode->fInbound)
+    if (!pnode->fInbound)
         PushNodeVersion(pnode, connman, GetTime());
 }
 
@@ -1472,7 +1472,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         pfrom->SetSendVersion(nSendVersion);
         pfrom->nVersion = nVersion;
 
-        if((nServices & NODE_WITNESS))
+        if ((nServices & NODE_WITNESS))
         {
             LOCK(cs_main);
             State(pfrom->GetId())->fHaveWitness = true;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -501,7 +501,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if(!g_connman)
+    if (!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -90,7 +90,7 @@ UniValue getinfo(const JSONRPCRequest& request)
 #endif
     obj.pushKV("blocks",        (int)chainActive.Height());
     obj.pushKV("timeoffset",    GetTimeOffset());
-    if(g_connman)
+    if (g_connman)
         obj.pushKV("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
     obj.pushKV("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
     obj.pushKV("difficulty",    (double)GetDifficulty());

--- a/src/streams.h
+++ b/src/streams.h
@@ -86,7 +86,7 @@ class CVectorWriter
 */
     CVectorWriter(int nTypeIn, int nVersionIn, std::vector<unsigned char>& vchDataIn, size_t nPosIn) : nType(nTypeIn), nVersion(nVersionIn), vchData(vchDataIn), nPos(nPosIn)
     {
-        if(nPos > vchData.size())
+        if (nPos > vchData.size())
             vchData.resize(nPos);
     }
 /*
@@ -128,7 +128,7 @@ class CVectorWriter
     void seek(size_t nSize)
     {
         nPos += nSize;
-        if(nPos > vchData.size())
+        if (nPos > vchData.size())
             vchData.resize(nPos);
     }
 private:

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -142,7 +142,7 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
     char *line;
     assert(input);
     //  If there is not a whole line to read, evbuffer_readln returns NULL
-    while((line = evbuffer_readln(input, &n_read_out, EVBUFFER_EOL_CRLF)) != NULL)
+    while ((line = evbuffer_readln(input, &n_read_out, EVBUFFER_EOL_CRLF)) != NULL)
     {
         std::string s(line, n_read_out);
         free(line);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -796,7 +796,7 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 {
     char pszPath[MAX_PATH] = "";
 
-    if(SHGetSpecialFolderPathA(NULL, pszPath, nFolder, fCreate))
+    if (SHGetSpecialFolderPathA(NULL, pszPath, nFolder, fCreate))
     {
         return fs::path(pszPath);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2414,7 +2414,7 @@ static CBlockIndex* FindMostWorkChain() {
         }
         if (!fInvalidAncestor)
             return pindexNew;
-    } while(true);
+    } while (true);
 }
 
 /** Delete all entries in setBlockIndexCandidates that are worse than the current tip. */
@@ -3109,7 +3109,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     // Dogecoin: Version 2 enforcement was never used
-    if((block.GetBaseVersion() < 3 && nHeight >= consensusParams.BIP66Height) ||
+    if ((block.GetBaseVersion() < 3 && nHeight >= consensusParams.BIP66Height) ||
        (block.GetBaseVersion() < 4 && nHeight >= consensusParams.BIP65Height))
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.GetBaseVersion()),
                                  strprintf("rejected nVersion=0x%08x block", block.GetBaseVersion()));

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -374,11 +374,11 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     vHash.push_back(hash);
     vector<uint256> vHashOut;
 
-    if(pwalletMain->ZapSelectTx(vHash, vHashOut) != DB_LOAD_OK) {
+    if (pwalletMain->ZapSelectTx(vHash, vHashOut) != DB_LOAD_OK) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Could not properly delete the transaction.");
     }
 
-    if(vHashOut.empty()) {
+    if (vHashOut.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Transaction does not exist in wallet.");
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -430,7 +430,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssKey >> nID;
             CMasterKey kMasterKey;
             ssValue >> kMasterKey;
-            if(pwallet->mapMasterKeys.count(nID) != 0)
+            if (pwallet->mapMasterKeys.count(nID) != 0)
             {
                 strErr = strprintf("Error reading wallet database: duplicate CMasterKey id %u", nID);
                 return false;
@@ -749,7 +749,7 @@ DBErrors CWalletDB::ZapSelectTx(CWallet* pwallet, vector<uint256>& vTxHashIn, ve
         }
         else if ((*it) == hash) {
             pwallet->mapWallet.erase(hash);
-            if(!EraseTx(hash)) {
+            if (!EraseTx(hash)) {
                 LogPrint("db", "Transaction was found for deletion but returned database error: %s\n", hash.GetHex());
                 delerror = true;
             }

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -175,7 +175,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     {
         LOCK(cs_main);
         CBlock block;
-        if(!ReadBlockFromDisk(block, pindex, consensusParams))
+        if (!ReadBlockFromDisk(block, pindex, consensusParams))
         {
             zmqError("Can't read block from disk");
             return false;


### PR DESCRIPTION
`doc/developer-notes.md` specifies:

> one space after `if`, `for` and `while`

This PR fixes 23 occurrences across 16 files where the space was missing
(e.g. `if(` → `if (`, `for(` → `for (`, `while(` → `while (`).

Files changed:
`src/arith_uint256.cpp`, `src/bitcoin-tx.cpp`, `src/clientversion.cpp`,
`src/httpserver.cpp`, `src/init.cpp`, `src/miner.cpp`,
`src/net_processing.cpp`, `src/rpc/mining.cpp`, `src/rpc/misc.cpp`,
`src/streams.h`, `src/torcontrol.cpp`, `src/util.cpp`,
`src/validation.cpp`, `src/wallet/rpcdump.cpp`, `src/wallet/walletdb.cpp`,
`src/zmq/zmqpublishnotifier.cpp`

This is a formatting-only change: no logic, behaviour or comments are
altered. Qt subsystem files were intentionally excluded to keep the review 
scope small.