### PR TITLE
docs: improve Fedora build instructions

### DIFF
--- a/doc/build-fedora.md
+++ b/doc/build-fedora.md
@@ -1,8 +1,8 @@
 Fedora build guide
 ------------------
 
-**Last tested with:** 1.14.7-dev (as of aa53a0d7)
-**Tested on:** Fedora 35-39 (x86 & ARM)
+**Last tested with:** master (as of e1c3c37)
+**Tested on:** Fedora 43 ARM64
 
 ### Build requirements
 

--- a/doc/build-fedora.md
+++ b/doc/build-fedora.md
@@ -33,3 +33,29 @@ To build the GUI with Qt 5 you need the following:
 ```sh
 sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel qrencode-devel
 ``` 
+
+### Build instructions
+
+From the root of the repository, run:
+
+```sh
+./autogen.sh
+./configure --without-gui
+make
+```
+
+This builds `dogecoind` and `dogecoin-cli`.
+
+To also build the Qt GUI (`dogecoin-qt`), install the GUI requirements above and run:
+
+```sh
+./autogen.sh
+./configure --with-gui
+make
+```
+
+Install binaries system-wide (optional):
+
+```sh
+sudo make install
+```


### PR DESCRIPTION
Fedora build instructions did not have information on building, only installing dependencies.

This adds building instructions modeled after the other building guides.