### PR TITLE
Remove duplicate #include lines in three source files

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -16,7 +16,6 @@
 #include "ui_interface.h"
 #include "crypto/hmac_sha256.h"
 #include <stdio.h>
-#include "utilstrencodings.h"
 
 #include <boost/algorithm/string.hpp> // boost::trim
 #include <boost/foreach.hpp> //BOOST_FOREACH

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -16,7 +16,6 @@
 #include "clientmodel.h"
 #include "guiutil.h"
 #include "platformstyle.h"
-#include "bantablemodel.h"
 #include "utilitydialog.h"
 
 #include "chainparams.h"
@@ -41,7 +40,6 @@
 #include <QTime>
 #include <QTimer>
 #include <QStringList>
-#include <QThread>
 #include <functional>
 
 // TODO: add a scrollback limit, as there is currently none

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -28,7 +28,6 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/assign/list_of.hpp>
 #include <boost/foreach.hpp>
 
 #include <univalue.h>


### PR DESCRIPTION
This PR removes duplicate `#include` directives found across three source files. The duplicates are purely mechanical — no header is intentionally included twice, and removing the second occurrence has no behavioral effect.

The change to `src/test/transaction_tests.cpp` was originally part of [#3985](https://github.com/dogecoin/dogecoin/pull/3985) but was moved to a separate PR following reviewer feedback that it fit better on its own.

**Changes:**
- `src/test/transaction_tests.cpp` — remove duplicate `<boost/assign/list_of.hpp>`
- `src/httprpc.cpp` — remove duplicate `"utilstrencodings.h"`
- `src/qt/rpcconsole.cpp` — remove duplicate `"bantablemodel.h"` and `<QThread>`

A duplicate was also found in `src/leveldb/port/port_stdcxx.h`, but that file is part of the vendored LevelDB library and is left unchanged.