### PR TITLE
Feature/multi wallet

### DIFF
--- a/qa/rpc-tests/multiwallet.py
+++ b/qa/rpc-tests/multiwallet.py
@@ -4,18 +4,32 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-"""Exercise the multi-wallet RPC surface introduced by the multi-wallet
-backport: -wallet=<file> repetition, listwallets, loadwallet,
-createwallet, unloadwallet, and per-wallet /wallet/<name> routing via
-the cli flag emulated by talking to each wallet through the regular
-RPC interface after switching the default."""
+"""Exercise the multi-wallet surface backported from Bitcoin Core:
+   - -wallet=<file> repetition at boot
+   - listwallets
+   - createwallet (success / duplicate / path traversal)
+   - loadwallet (success / nonexistent / duplicate / path traversal)
+   - unloadwallet (success by arg, success by /wallet URI, errors)
+   - per-wallet /wallet/<name> RPC routing and wallet isolation
+   - default endpoint behaviour with 0, 1, and >1 wallets loaded
+   - -zapwallettxes / -salvagewallet / -upgradewallet rejection with
+     multi -wallet at startup
+"""
 
+from test_framework.authproxy import AuthServiceProxy, JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    start_nodes,
     assert_equal,
     assert_raises_jsonrpc,
+    rpc_url,
+    start_nodes,
+    stop_nodes,
 )
+
+
+def wallet_rpc(node_index, wallet_name):
+    """Construct an AuthServiceProxy targeted at /wallet/<wallet_name>."""
+    return AuthServiceProxy(rpc_url(node_index) + "/wallet/" + wallet_name)
 
 
 class MultiWalletTest(BitcoinTestFramework):
@@ -37,37 +51,93 @@ class MultiWalletTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0]
 
+        # -- startup --
         # -wallet=<file> repeated => both wallets are loaded at boot.
-        loaded = node.listwallets()
-        assert_equal(sorted(loaded), sorted(['wallet.dat', 'second.dat']))
+        assert_equal(sorted(node.listwallets()),
+                     sorted(['wallet.dat', 'second.dat']))
 
-        # createwallet adds a third wallet and registers it.
+        # -- default endpoint behaviour with multiple wallets --
+        # bitcoin 0.17 returns RPC_WALLET_NOT_SPECIFIED (-19) when an
+        # unscoped wallet RPC is invoked but more than one wallet is loaded.
+        assert_raises_jsonrpc(-19, 'Wallet file not specified',
+                              node.getwalletinfo)
+
+        # -- per-wallet routing --
+        w1 = wallet_rpc(0, 'wallet.dat')
+        w2 = wallet_rpc(0, 'second.dat')
+
+        info1 = w1.getwalletinfo()
+        info2 = w2.getwalletinfo()
+        # Each wallet must have its own HD master key, confirming the URI
+        # really routed to two different CWallet instances.
+        assert info1['hdmasterkeyid'] != info2['hdmasterkeyid']
+
+        # Per-wallet getnewaddress: same call on different wallets returns
+        # different addresses because they draw from different keypools.
+        addr1 = w1.getnewaddress()
+        addr2 = w2.getnewaddress()
+        assert addr1 != addr2
+
+        # Routing to a wallet that does not exist is a clean -18.
+        bogus = wallet_rpc(0, 'bogus.dat')
+        assert_raises_jsonrpc(-18, 'Requested wallet does not exist',
+                              bogus.getwalletinfo)
+
+        # -- createwallet --
         result = node.createwallet('third.dat')
         assert_equal(result['name'], 'third.dat')
         assert 'third.dat' in node.listwallets()
 
-        # createwallet on an existing file must be rejected.
-        assert_raises_jsonrpc(-4, 'already exists', node.createwallet, 'third.dat')
+        # createwallet on an existing file is rejected.
+        assert_raises_jsonrpc(-4, 'already exists',
+                              node.createwallet, 'third.dat')
 
-        # Path traversal must be rejected.
+        # Path traversal is rejected.
         assert_raises_jsonrpc(-4, 'outside data directory',
                               node.createwallet, '../escape.dat')
 
-        # unloadwallet detaches the wallet; the file stays on disk.
+        # -- loadwallet error paths --
+        # loadwallet of a nonexistent file must NOT silently create it.
+        # Use createwallet for that. Matches bitcoin 0.17.
+        assert_raises_jsonrpc(-18, 'not found',
+                              node.loadwallet, 'never_existed.dat')
+
+        # Duplicate loadwallet is rejected.
+        assert_raises_jsonrpc(-4, 'already loaded',
+                              node.loadwallet, 'third.dat')
+
+        # Path traversal in loadwallet is rejected.
+        assert_raises_jsonrpc(-4, 'outside data directory',
+                              node.loadwallet, '../escape.dat')
+
+        # -- unloadwallet error paths --
+        # Unknown wallet name.
+        assert_raises_jsonrpc(-18, 'is not loaded',
+                              node.unloadwallet, 'bogus.dat')
+
+        # URI specifies one wallet, arg specifies another => -8 conflict.
+        w_third = wallet_rpc(0, 'third.dat')
+        assert_raises_jsonrpc(-8, 'different wallets',
+                              w_third.unloadwallet, 'wallet.dat')
+
+        # No URI + no arg + multiple wallets loaded => RPC_WALLET_NOT_SPECIFIED.
+        assert_raises_jsonrpc(-19, 'must be provided',
+                              node.unloadwallet)
+
+        # -- unloadwallet by arg, then reload --
         node.unloadwallet('third.dat')
         assert 'third.dat' not in node.listwallets()
 
-        # The on-disk file must remain loadable after unload.
         result = node.loadwallet('third.dat')
         assert_equal(result['name'], 'third.dat')
         assert 'third.dat' in node.listwallets()
 
-        # Duplicate loadwallet must be rejected.
-        assert_raises_jsonrpc(-4, 'already loaded', node.loadwallet, 'third.dat')
-
-        # Unknown wallet unload must report not loaded.
-        assert_raises_jsonrpc(-18, 'is not loaded',
-                              node.unloadwallet, 'bogus.dat')
+        # -- unloadwallet via URI (no arg) --
+        # Now that we're back to 3 wallets, calling unloadwallet on the
+        # /wallet/third.dat endpoint with no arg should detach third.dat.
+        w_third = wallet_rpc(0, 'third.dat')
+        w_third.unloadwallet()
+        assert 'third.dat' not in node.listwallets()
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/multiwallet.py
+++ b/qa/rpc-tests/multiwallet.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 2026 The Dogecoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Exercise the multi-wallet RPC surface introduced by the multi-wallet
+backport: -wallet=<file> repetition, listwallets, loadwallet,
+createwallet, unloadwallet, and per-wallet /wallet/<name> routing via
+the cli flag emulated by talking to each wallet through the regular
+RPC interface after switching the default."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    start_nodes,
+    assert_equal,
+    assert_raises_jsonrpc,
+)
+
+
+class MultiWalletTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        # Boot with two wallets so the startup loop is exercised.
+        self.nodes = start_nodes(
+            self.num_nodes,
+            self.options.tmpdir,
+            [['-wallet=wallet.dat', '-wallet=second.dat']],
+        )
+        self.is_network_split = False
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # -wallet=<file> repeated => both wallets are loaded at boot.
+        loaded = node.listwallets()
+        assert_equal(sorted(loaded), sorted(['wallet.dat', 'second.dat']))
+
+        # createwallet adds a third wallet and registers it.
+        result = node.createwallet('third.dat')
+        assert_equal(result['name'], 'third.dat')
+        assert 'third.dat' in node.listwallets()
+
+        # createwallet on an existing file must be rejected.
+        assert_raises_jsonrpc(-4, 'already exists', node.createwallet, 'third.dat')
+
+        # Path traversal must be rejected.
+        assert_raises_jsonrpc(-4, 'outside data directory',
+                              node.createwallet, '../escape.dat')
+
+        # unloadwallet detaches the wallet; the file stays on disk.
+        node.unloadwallet('third.dat')
+        assert 'third.dat' not in node.listwallets()
+
+        # The on-disk file must remain loadable after unload.
+        result = node.loadwallet('third.dat')
+        assert_equal(result['name'], 'third.dat')
+        assert 'third.dat' in node.listwallets()
+
+        # Duplicate loadwallet must be rejected.
+        assert_raises_jsonrpc(-4, 'already loaded', node.loadwallet, 'third.dat')
+
+        # Unknown wallet unload must report not loaded.
+        assert_raises_jsonrpc(-18, 'is not loaded',
+                              node.unloadwallet, 'bogus.dat')
+
+
+if __name__ == '__main__':
+    MultiWalletTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ BITCOIN_CORE_H = \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  wallet/walletutil.h \
   warnings.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
@@ -253,6 +254,7 @@ libdogecoin_wallet_a_SOURCES = \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \
   wallet/walletdb.cpp \
+  wallet/walletutil.cpp \
   policy/rbf.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -46,6 +46,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcclienttimeout=<n>", strprintf(_("Timeout during HTTP requests (default: %d)"), DEFAULT_HTTP_CLIENT_TIMEOUT));
+    strUsage += HelpMessageOpt("-rpcwallet=<walletname>", _("Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to dogecoind)"));
     strUsage += HelpMessageOpt("-stdin", _("Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases)"));
 
     return strUsage;
@@ -236,7 +237,25 @@ UniValue CallRPC(const std::string& strMethod, const UniValue& params)
     assert(output_buffer);
     evbuffer_add(output_buffer, strRequest.data(), strRequest.size());
 
-    int r = evhttp_make_request(evcon.get(), req.get(), EVHTTP_REQ_POST, "/");
+    // Per-wallet endpoint when -rpcwallet=<name> is set. The server
+    // routes /wallet/<name>/ requests via the prefix handler added in
+    // 'httprpc: register /wallet/ prefix handler for per-wallet RPC
+    // routing' so this is the same dispatch the BEAM-side multi-wallet
+    // clients use. With -rpcwallet unset we keep posting to "/" — the
+    // legacy single-wallet entry point — so non-wallet RPCs (and
+    // single-wallet setups) behave identically to before.
+    std::string endpoint = "/";
+    if (!GetArg("-rpcwallet", "").empty()) {
+        std::string walletName = GetArg("-rpcwallet", "");
+        char *encodedURI = evhttp_uriencode(walletName.c_str(), walletName.size(), false);
+        if (encodedURI) {
+            endpoint = "/wallet/" + std::string(encodedURI);
+            free(encodedURI);
+        } else {
+            throw CConnectionFailed("uri-encode failed");
+        }
+    }
+    int r = evhttp_make_request(evcon.get(), req.get(), EVHTTP_REQ_POST, endpoint.c_str());
     req.release(); // ownership moved to evcon in above call
     if (r != 0) {
         throw CConnectionFailed("send http request failed");

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -238,6 +238,7 @@ bool StartHTTPRPC()
         return false;
 
     RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
+    RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC);
 
     assert(EventBase());
     httpRPCTimerInterface = new HTTPRPCTimerInterface(EventBase());
@@ -254,6 +255,7 @@ void StopHTTPRPC()
 {
     LogPrint("rpc", "Stopping HTTP RPC server\n");
     UnregisterHTTPHandler("/", true);
+    UnregisterHTTPHandler("/wallet/", false);
     if (httpRPCTimerInterface) {
         RPCUnsetTimerInterface(httpRPCTimerInterface);
         delete httpRPCTimerInterface;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -245,8 +245,10 @@ void Shutdown()
         pblocktree = NULL;
     }
 #ifdef ENABLE_WALLET
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(true);
+    // CWallet::Flush delegates to the shared CDBEnv, so a single shutdown
+    // call drains every loaded wallet's BDB file at once.
+    if (!vpwallets.empty()) {
+        vpwallets.front()->Flush(true);
     }
 #endif
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -205,8 +205,9 @@ void Shutdown()
     StopHTTPServer();
 #ifdef ENABLE_WALLET
     // Dogecoin 1.14 TODO: ShutdownRPCMining();
-    if (pwalletMain)
-        pwalletMain->Flush(false);
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(false);
+    }
 #endif
     MapPort(false);
     UnregisterValidationInterface(peerLogic.get());
@@ -244,8 +245,9 @@ void Shutdown()
         pblocktree = NULL;
     }
 #ifdef ENABLE_WALLET
-    if (pwalletMain)
-        pwalletMain->Flush(true);
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(true);
+    }
 #endif
 
 #if ENABLE_ZMQ
@@ -265,7 +267,10 @@ void Shutdown()
 #endif
     UnregisterAllValidationInterfaces();
 #ifdef ENABLE_WALLET
-    delete pwalletMain;
+    for (CWalletRef pwallet : vpwallets) {
+        delete pwallet;
+    }
+    vpwallets.clear();
     pwalletMain = NULL;
 #endif
     globalVerifyHandle.reset();
@@ -1717,8 +1722,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
-    if (pwalletMain)
-        pwalletMain->postInitProcess(threadGroup);
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->postInitProcess(threadGroup);
+    }
 #endif
 
     return !fRequestShutdown;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #ifdef ENABLE_WALLET
+#include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #endif
@@ -178,7 +179,15 @@ UniValue validateaddress(const JSONRPCRequest& request)
         );
 
 #ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : NULL);
+    // Pick the wallet from the /wallet/<name>/ request URI if present;
+    // otherwise fall back to pwalletMain (legacy single-wallet) so
+    // non-multi-wallet setups behave identically. Returning a per-request
+    // wallet here matches what the wallet-only RPCs in rpcwallet.cpp do
+    // via GetWalletForJSONRPCRequest, so /wallet/<name>/validateaddress
+    // reports ismine/account/timestamp/hdkeypath/hdmasterkeyid against
+    // the wallet the URL names — not the first-loaded wallet.
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : NULL);
 #else
     LOCK(cs_main);
 #endif
@@ -198,16 +207,16 @@ UniValue validateaddress(const JSONRPCRequest& request)
         ret.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
 #ifdef ENABLE_WALLET
-        isminetype mine = pwalletMain ? IsMine(*pwalletMain, dest) : ISMINE_NO;
+        isminetype mine = pwallet ? IsMine(*pwallet, dest) : ISMINE_NO;
         ret.pushKV("ismine", (mine & ISMINE_SPENDABLE) ? true : false);
         ret.pushKV("iswatchonly", (mine & ISMINE_WATCH_ONLY) ? true: false);
         UniValue detail = boost::apply_visitor(DescribeAddressVisitor(), dest);
         ret.pushKVs(detail);
-        if (pwalletMain && pwalletMain->mapAddressBook.count(dest))
-            ret.pushKV("account", pwalletMain->mapAddressBook[dest].name);
+        if (pwallet && pwallet->mapAddressBook.count(dest))
+            ret.pushKV("account", pwallet->mapAddressBook[dest].name);
         CKeyID keyID;
-        if (pwalletMain) {
-            const auto& meta = pwalletMain->mapKeyMetadata;
+        if (pwallet) {
+            const auto& meta = pwallet->mapKeyMetadata;
             auto it = address.GetKeyID(keyID) ? meta.find(keyID) : meta.end();
             if (it == meta.end()) {
                 it = meta.find(CScriptID(scriptPubKey));

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -78,6 +78,8 @@ enum RPCErrorCode
     RPC_WALLET_WRONG_ENC_STATE      = -15, //!< Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
     RPC_WALLET_ENCRYPTION_FAILED    = -16, //!< Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED     = -17, //!< Wallet is already unlocked
+    RPC_WALLET_NOT_FOUND            = -18, //!< Invalid wallet specified
+    RPC_WALLET_NOT_SPECIFIED        = -19, //!< No wallet specified (error when there are multiple wallets loaded)
 };
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -348,8 +348,15 @@ CDB::CDB(const fs::path& wallet_path, const char* pszMode, bool fFlushOnCloseIn)
 // "single env at GetWalletDir()" semantics they're used to. Existing
 // (pre-multi-env) call sites keep working unchanged; new code should
 // hand the full path to the fs::path overload above.
+//
+// Important: an empty strFilename must NOT be resolved via
+// GetWalletDir() / "" — that returns GetWalletDir() itself and would
+// make GetWalletEnv pick up the wallet-dir's last path component
+// ("regtest" in tests) as the BDB filename, opening the wrong file.
+// Hand an empty fs::path down so the path-based ctor's empty-check
+// fires and produces a no-op CDB the way callers expect.
 CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnCloseIn)
-    : CDB(GetWalletDir() / strFilename, pszMode, fFlushOnCloseIn)
+    : CDB(strFilename.empty() ? fs::path() : GetWalletDir() / strFilename, pszMode, fFlushOnCloseIn)
 {
 }
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -11,6 +11,7 @@
 #include "protocol.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "wallet/walletutil.h"
 
 #include <stdint.h>
 
@@ -23,22 +24,73 @@
 
 using namespace std;
 
+//
+// Multi-env machinery
+//
+// Process-wide lock guarding g_dbenvs (the env registry) and every
+// touch of per-env mutable state (mapDb, mapFileUseCount, the BDB
+// open/close lifecycle). Lives at namespace level — replaces the
+// per-CDBEnv `cs_db` member from the singleton era.
+CCriticalSection cs_db;
+
+namespace {
+// Map from env-directory string → open environment for that directory.
+// One env per unique env_directory.string(); directory-layout wallets
+// (<walletdir>/<name>/wallet.dat) each get their own env at
+// <walletdir>/<name>/. Flat wallets (<walletdir>/<name>.dat) share
+// one env at <walletdir>/.
+std::map<std::string, CDBEnv> g_dbenvs;
+} // namespace
+
+CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
+{
+    fs::path env_directory = wallet_path.parent_path();
+    if (env_directory.empty()) {
+        // Bare filename — assume legacy "single env at walletdir" semantics.
+        env_directory = GetWalletDir();
+    }
+    database_filename = wallet_path.filename().string();
+    LOCK(cs_db);
+    return &g_dbenvs.emplace(std::piecewise_construct,
+                              std::forward_as_tuple(env_directory.string()),
+                              std::forward_as_tuple(env_directory)).first->second;
+}
+
+void FlushAllDbEnvs(bool fShutdown)
+{
+    LOCK(cs_db);
+    for (auto& kv : g_dbenvs) {
+        kv.second.Flush(fShutdown);
+    }
+}
 
 //
 // CDB
 //
 
-CDBEnv bitdb;
-
-void CDBEnv::EnvShutdown()
+void CDBEnv::Close()
 {
     if (!fDbEnvInit)
         return;
 
     fDbEnvInit = false;
+
+    // Close any Db handles still alive in this env. The assert catches
+    // refcount bugs in unloadwallet / shutdown — leaving an open handle
+    // when we tear down the env risks on-disk corruption.
+    for (auto& db : mapDb) {
+        auto count = mapFileUseCount.find(db.first);
+        assert(count == mapFileUseCount.end() || count->second == 0);
+        if (db.second) {
+            db.second->close(0);
+            delete db.second;
+            db.second = nullptr;
+        }
+    }
+
     int ret = dbenv->close(0);
     if (ret != 0)
-        LogPrintf("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
+        LogPrintf("CDBEnv::Close: Error %d shutting down env at %s: %s\n", ret, strPath, DbEnv::strerror(ret));
     if (!fMockDb)
         DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
@@ -51,31 +103,26 @@ void CDBEnv::Reset()
     fMockDb = false;
 }
 
-CDBEnv::CDBEnv() : dbenv(NULL)
+CDBEnv::CDBEnv(const fs::path& dir_path) : strPath(dir_path.string()), dbenv(NULL)
 {
     Reset();
 }
 
 CDBEnv::~CDBEnv()
 {
-    EnvShutdown();
+    Close();
     delete dbenv;
     dbenv = NULL;
 }
 
-void CDBEnv::Close()
-{
-    EnvShutdown();
-}
-
-bool CDBEnv::Open(const fs::path& pathIn)
+bool CDBEnv::Open(bool retry)
 {
     if (fDbEnvInit)
         return true;
 
     boost::this_thread::interruption_point();
 
-    strPath = pathIn.string();
+    fs::path pathIn = strPath;
     fs::path pathLogDir = pathIn / "database";
     TryCreateDirectory(pathLogDir);
     fs::path pathErrorFile = pathIn / "db.log";
@@ -237,12 +284,12 @@ void CDBEnv::CheckpointLSN(const std::string& strFile)
 }
 
 
-CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnCloseIn) : pdb(NULL), activeTxn(NULL)
+CDB::CDB(const fs::path& wallet_path, const char* pszMode, bool fFlushOnCloseIn) : pdb(NULL), env(NULL), activeTxn(NULL)
 {
     int ret;
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
-    if (strFilename.empty())
+    if (wallet_path.empty())
         return;
 
     bool fCreate = strchr(pszMode, 'c') != NULL;
@@ -250,18 +297,19 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
     if (fCreate)
         nFlags |= DB_CREATE;
 
+    env = GetWalletEnv(wallet_path, strFile);
+
     {
-        LOCK(bitdb.cs_db);
-        if (!bitdb.Open(GetDataDir()))
+        LOCK(cs_db);
+        if (!env->Open(false /* retry */))
             throw runtime_error("CDB: Failed to open database environment.");
 
-        strFile = strFilename;
-        ++bitdb.mapFileUseCount[strFile];
-        pdb = bitdb.mapDb[strFile];
+        ++env->mapFileUseCount[strFile];
+        pdb = env->mapDb[strFile];
         if (pdb == NULL) {
-            pdb = new Db(bitdb.dbenv, 0);
+            pdb = new Db(env->dbenv, 0);
 
-            bool fMockDb = bitdb.IsMock();
+            bool fMockDb = env->IsMock();
             if (fMockDb) {
                 DbMpoolFile* mpf = pdb->get_mpf();
                 ret = mpf->set_flags(DB_MPOOL_NOFILE, 1);
@@ -279,9 +327,9 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
             if (ret != 0) {
                 delete pdb;
                 pdb = NULL;
-                --bitdb.mapFileUseCount[strFile];
+                --env->mapFileUseCount[strFile];
                 strFile = "";
-                throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFilename));
+                throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, wallet_path.string()));
             }
 
             if (fCreate && !Exists(string("version"))) {
@@ -291,14 +339,23 @@ CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnClose
                 fReadOnly = fTmp;
             }
 
-            bitdb.mapDb[strFile] = pdb;
+            env->mapDb[strFile] = pdb;
         }
     }
 }
 
+// Legacy entry: callers who only know a relative filename get the
+// "single env at GetWalletDir()" semantics they're used to. Existing
+// (pre-multi-env) call sites keep working unchanged; new code should
+// hand the full path to the fs::path overload above.
+CDB::CDB(const std::string& strFilename, const char* pszMode, bool fFlushOnCloseIn)
+    : CDB(GetWalletDir() / strFilename, pszMode, fFlushOnCloseIn)
+{
+}
+
 void CDB::Flush()
 {
-    if (activeTxn)
+    if (activeTxn || !env)
         return;
 
     // Flush database activity from memory pool to disk log
@@ -306,7 +363,7 @@ void CDB::Flush()
     if (fReadOnly)
         nMinutes = 1;
 
-    bitdb.dbenv->txn_checkpoint(nMinutes ? GetArg("-dblogsize", DEFAULT_WALLET_DBLOGSIZE) * 1024 : 0, nMinutes, 0);
+    env->dbenv->txn_checkpoint(nMinutes ? GetArg("-dblogsize", DEFAULT_WALLET_DBLOGSIZE) * 1024 : 0, nMinutes, 0);
 }
 
 void CDB::Close()
@@ -321,9 +378,9 @@ void CDB::Close()
     if (fFlushOnClose)
         Flush();
 
-    {
-        LOCK(bitdb.cs_db);
-        --bitdb.mapFileUseCount[strFile];
+    if (env) {
+        LOCK(cs_db);
+        --env->mapFileUseCount[strFile];
     }
 }
 
@@ -352,21 +409,26 @@ bool CDBEnv::RemoveDb(const string& strFile)
 
 bool CDB::Rewrite(const string& strFile, const char* pszSkip)
 {
+    // strFile is a wallet path relative to GetWalletDir() (matches the
+    // legacy CDB constructor's interpretation). Resolve the env from it
+    // so we operate on the right BDB environment for multi-env hosts.
+    std::string dbFilename;
+    CDBEnv* env = GetWalletEnv(GetWalletDir() / strFile, dbFilename);
     while (true) {
         {
-            LOCK(bitdb.cs_db);
-            if (!bitdb.mapFileUseCount.count(strFile) || bitdb.mapFileUseCount[strFile] == 0) {
+            LOCK(cs_db);
+            if (!env->mapFileUseCount.count(dbFilename) || env->mapFileUseCount[dbFilename] == 0) {
                 // Flush log data to the dat file
-                bitdb.CloseDb(strFile);
-                bitdb.CheckpointLSN(strFile);
-                bitdb.mapFileUseCount.erase(strFile);
+                env->CloseDb(dbFilename);
+                env->CheckpointLSN(dbFilename);
+                env->mapFileUseCount.erase(dbFilename);
 
                 bool fSuccess = true;
                 LogPrintf("CDB::Rewrite: Rewriting %s...\n", strFile);
-                string strFileRes = strFile + ".rewrite";
+                string strFileRes = dbFilename + ".rewrite";
                 { // surround usage of db with extra {}
-                    CDB db(strFile.c_str(), "r");
-                    Db* pdbCopy = new Db(bitdb.dbenv, 0);
+                    CDB db(strFile, "r");
+                    Db* pdbCopy = new Db(env->dbenv, 0);
 
                     int ret = pdbCopy->open(NULL,               // Txn pointer
                                             strFileRes.c_str(), // Filename
@@ -409,18 +471,18 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         }
                     if (fSuccess) {
                         db.Close();
-                        bitdb.CloseDb(strFile);
+                        env->CloseDb(dbFilename);
                         if (pdbCopy->close(0))
                             fSuccess = false;
                         delete pdbCopy;
                     }
                 }
                 if (fSuccess) {
-                    Db dbA(bitdb.dbenv, 0);
-                    if (dbA.remove(strFile.c_str(), NULL, 0))
+                    Db dbA(env->dbenv, 0);
+                    if (dbA.remove(dbFilename.c_str(), NULL, 0))
                         fSuccess = false;
-                    Db dbB(bitdb.dbenv, 0);
-                    if (dbB.rename(strFileRes.c_str(), NULL, strFile.c_str(), 0))
+                    Db dbB(env->dbenv, 0);
+                    if (dbB.rename(strFileRes.c_str(), NULL, dbFilename.c_str(), 0))
                         fSuccess = false;
                 }
                 if (!fSuccess)

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -31,20 +31,24 @@ private:
     // shutdown problems/crashes caused by a static initialized internal pointer.
     std::string strPath;
 
-    void EnvShutdown();
-
 public:
-    mutable CCriticalSection cs_db;
+    // cs_db lives at the namespace level now (db.cpp) so a single lock
+    // covers the g_dbenvs map plus every BDB call site. Each CDBEnv
+    // still has its own mapDb / mapFileUseCount but operations against
+    // them serialise through the global cs_db.
+
     DbEnv *dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
 
-    CDBEnv();
+    explicit CDBEnv(const fs::path& env_directory);
     ~CDBEnv();
     void Reset();
 
     void MakeMock();
-    bool IsMock() { return fMockDb; }
+    bool IsMock() const { return fMockDb; }
+    bool IsInitialized() const { return fDbEnvInit; }
+    fs::path Directory() const { return strPath; }
 
     /**
      * Verify that database file strFile is OK. If it is not,
@@ -66,7 +70,7 @@ public:
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(const std::string& strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 
-    bool Open(const fs::path& path);
+    bool Open(bool retry = false);
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(const std::string& strFile);
@@ -84,7 +88,19 @@ public:
     }
 };
 
-extern CDBEnv bitdb;
+/** Get the CDBEnv covering wallet_path. Lazily constructs one if absent
+ * from g_dbenvs. The BDB-relative filename of the wallet (what Db::open
+ * takes) is returned via `database_filename`. Wallets in the same
+ * directory share an env; directory-layout wallets each get their own
+ * at <walletdir>/<name>/. */
+CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
+
+/** Process-wide lock guarding g_dbenvs + per-env mutable state. */
+extern CCriticalSection cs_db;
+
+/** Flush every open BDB env. Called at shutdown after every wallet
+ * has been detached from its env. */
+void FlushAllDbEnvs(bool fShutdown);
 
 
 /** RAII class that provides access to a Berkeley database */
@@ -92,11 +108,16 @@ class CDB
 {
 protected:
     Db* pdb;
-    std::string strFile;
+    std::string strFile;        //!< BDB-relative filename inside env (e.g. "wallet.dat")
+    CDBEnv* env;                //!< Env this database lives in (per-directory; nullptr only for the empty-filename mock path)
     DbTxn* activeTxn;
     bool fReadOnly;
     bool fFlushOnClose;
 
+    /** Open a database identified by its full path on disk. Used by all
+     * new (post-multi-env) callers. */
+    explicit CDB(const fs::path& wallet_path, const char* pszMode = "r+", bool fFlushOnCloseIn=true);
+    /** Legacy entry: treat strFilename as a path relative to GetWalletDir(). */
     explicit CDB(const std::string& strFilename, const char* pszMode = "r+", bool fFlushOnCloseIn=true);
     ~CDB() { Close(); }
 
@@ -264,9 +285,9 @@ protected:
 public:
     bool TxnBegin()
     {
-        if (!pdb || activeTxn)
+        if (!pdb || activeTxn || !env)
             return false;
-        DbTxn* ptxn = bitdb.TxnBegin();
+        DbTxn* ptxn = env->TxnBegin();
         if (!ptxn)
             return false;
         activeTxn = ptxn;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "utiltime.h"
 #include "wallet.h"
+#include "wallet/rpcwallet.h"
 #include "wallet/rpcutil.h"
 #include "merkleblock.h"
 #include "core_io.h"
@@ -32,10 +33,8 @@
 
 using namespace std;
 
-void EnsureWalletIsUnlocked();
-bool EnsureWalletIsAvailable(bool avoidException);
 uint32_t getHeightParamFromRequest(const JSONRPCRequest& request, size_t pos);
-void attemptRescanFromHeight(uint32_t nHeight);
+void attemptRescanFromHeight(CWallet * const pwallet, uint32_t nHeight);
 
 std::string static EncodeDumpTime(int64_t nTime) {
     return DateTimeStrFormat("%Y-%m-%dT%H:%M:%SZ", nTime);
@@ -82,7 +81,8 @@ std::string DecodeDumpString(const std::string &str) {
 
 UniValue importprivkey(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
@@ -111,9 +111,9 @@ UniValue importprivkey(const JSONRPCRequest& request)
         );
 
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     string strSecret = request.params[0].get_str();
     string strLabel = "";
@@ -140,21 +140,21 @@ UniValue importprivkey(const JSONRPCRequest& request)
     assert(key.VerifyPubKey(pubkey));
     CKeyID vchAddress = pubkey.GetID();
     {
-        pwalletMain->MarkDirty();
-        pwalletMain->SetAddressBook(vchAddress, strLabel, "receive");
+        pwallet->MarkDirty();
+        pwallet->SetAddressBook(vchAddress, strLabel, "receive");
 
         // Don't throw error in case a key is already there
-        if (pwalletMain->HaveKey(vchAddress))
+        if (pwallet->HaveKey(vchAddress))
             return NullUniValue;
 
-        pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = 1;
+        pwallet->mapKeyMetadata[vchAddress].nCreateTime = 1;
 
-        if (!pwalletMain->AddKeyPubKey(key, pubkey))
+        if (!pwallet->AddKeyPubKey(key, pubkey))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 
         if (fRescan) {
             const uint32_t nHeight = getHeightParamFromRequest(request, 3);
-            attemptRescanFromHeight(nHeight);
+            attemptRescanFromHeight(pwallet, nHeight);
         }
     }
 
@@ -174,55 +174,56 @@ uint32_t getHeightParamFromRequest(const JSONRPCRequest& request, const size_t p
     return nHeight;
 }
 
-void attemptRescanFromHeight(const uint32_t nHeight)
+void attemptRescanFromHeight(CWallet * const pwallet, const uint32_t nHeight)
 {
     CBlockIndex* pblockindex = chainActive.Genesis();
 
     // we have no implicit first height for a key, so we need to scan the whole chain
     if (nHeight <= 1)
-        pwalletMain->UpdateTimeFirstKey(1);
+        pwallet->UpdateTimeFirstKey(1);
     else
         pblockindex = chainActive[nHeight];
 
-    pwalletMain->ScanForWalletTransactions(pblockindex, true);
-    pwalletMain->ReacceptWalletTransactions();
+    pwallet->ScanForWalletTransactions(pblockindex, true);
+    pwallet->ReacceptWalletTransactions();
 }
 
-void ImportAddress(const CBitcoinAddress& address, const string& strLabel);
-void ImportScript(const CScript& script, const string& strLabel, bool isRedeemScript)
+void ImportAddress(CWallet * const pwallet, const CBitcoinAddress& address, const string& strLabel);
+void ImportScript(CWallet * const pwallet, const CScript& script, const string& strLabel, bool isRedeemScript)
 {
-    if (!isRedeemScript && ::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE)
+    if (!isRedeemScript && ::IsMine(*pwallet, script) == ISMINE_SPENDABLE)
         throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
 
-    pwalletMain->MarkDirty();
+    pwallet->MarkDirty();
 
-    if (!pwalletMain->HaveWatchOnly(script) && !pwalletMain->AddWatchOnly(script, 0 /* nCreateTime */))
+    if (!pwallet->HaveWatchOnly(script) && !pwallet->AddWatchOnly(script, 0 /* nCreateTime */))
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
 
     if (isRedeemScript) {
-        if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
+        if (!pwallet->HaveCScript(script) && !pwallet->AddCScript(script))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
-        ImportAddress(CBitcoinAddress(CScriptID(script)), strLabel);
+        ImportAddress(pwallet, CBitcoinAddress(CScriptID(script)), strLabel);
     } else {
         CTxDestination destination;
         if (ExtractDestination(script, destination)) {
-            pwalletMain->SetAddressBook(destination, strLabel, "receive");
+            pwallet->SetAddressBook(destination, strLabel, "receive");
         }
     }
 }
 
-void ImportAddress(const CBitcoinAddress& address, const string& strLabel)
+void ImportAddress(CWallet * const pwallet, const CBitcoinAddress& address, const string& strLabel)
 {
     CScript script = GetScriptForDestination(address.Get());
-    ImportScript(script, strLabel, false);
+    ImportScript(pwallet, script, strLabel, false);
     // add to address book or update label
     if (address.IsValid())
-        pwalletMain->SetAddressBook(address.Get(), strLabel, "receive");
+        pwallet->SetAddressBook(address.Get(), strLabel, "receive");
 }
 
 UniValue importaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 5)
@@ -268,23 +269,23 @@ UniValue importaddress(const JSONRPCRequest& request)
     if (request.params.size() > 3)
         fP2SH = request.params[3].get_bool();
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     CBitcoinAddress address(request.params[0].get_str());
     if (address.IsValid()) {
         if (fP2SH)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Cannot use the p2sh flag with an address - use a script instead");
-        ImportAddress(address, strLabel);
+        ImportAddress(pwallet, address, strLabel);
     } else if (IsHex(request.params[0].get_str())) {
         std::vector<unsigned char> data(ParseHex(request.params[0].get_str()));
-        ImportScript(CScript(data.begin(), data.end()), strLabel, fP2SH);
+        ImportScript(pwallet, CScript(data.begin(), data.end()), strLabel, fP2SH);
     } else {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Dogecoin address or script");
     }
 
     if (fRescan) {
         const uint32_t nHeight = getHeightParamFromRequest(request, 4);
-        attemptRescanFromHeight(nHeight);
+        attemptRescanFromHeight(pwallet, nHeight);
     }
 
     return NullUniValue;
@@ -292,7 +293,8 @@ UniValue importaddress(const JSONRPCRequest& request)
 
 UniValue importprunedfunds(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 2)
@@ -308,7 +310,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     if (!DecodeHexTx(tx, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     uint256 hashTx = tx.GetHash();
-    CWalletTx wtx(pwalletMain, MakeTransactionRef(std::move(tx)));
+    CWalletTx wtx(pwallet, MakeTransactionRef(std::move(tx)));
 
     CDataStream ssMB(ParseHexV(request.params[1], "proof"), SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock merkleBlock;
@@ -339,10 +341,10 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     wtx.nIndex = txnIndex;
     wtx.hashBlock = merkleBlock.header.GetHash();
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    if (pwalletMain->IsMine(wtx)) {
-        pwalletMain->AddToWallet(wtx, false);
+    if (pwallet->IsMine(wtx)) {
+        pwallet->AddToWallet(wtx, false);
         return NullUniValue;
     }
 
@@ -351,7 +353,8 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
 
 UniValue removeprunedfunds(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -366,7 +369,7 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
             + HelpExampleRpc("removprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
@@ -374,7 +377,7 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     vHash.push_back(hash);
     vector<uint256> vHashOut;
 
-    if (pwalletMain->ZapSelectTx(vHash, vHashOut) != DB_LOAD_OK) {
+    if (pwallet->ZapSelectTx(vHash, vHashOut) != DB_LOAD_OK) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Could not properly delete the transaction.");
     }
 
@@ -387,7 +390,8 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
 
 UniValue importpubkey(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
@@ -431,14 +435,14 @@ UniValue importpubkey(const JSONRPCRequest& request)
     if (!pubKey.IsFullyValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Pubkey is not a valid public key");
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    ImportAddress(CBitcoinAddress(pubKey.GetID()), strLabel);
-    ImportScript(GetScriptForRawPubKey(pubKey), strLabel, false);
+    ImportAddress(pwallet, CBitcoinAddress(pubKey.GetID()), strLabel);
+    ImportScript(pwallet, GetScriptForRawPubKey(pubKey), strLabel, false);
 
     if (fRescan) {
         const uint32_t nHeight = getHeightParamFromRequest(request, 3);
-        attemptRescanFromHeight(nHeight);
+        attemptRescanFromHeight(pwallet, nHeight);
     }
 
     return NullUniValue;
@@ -447,7 +451,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
 
 UniValue importwallet(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -468,9 +473,9 @@ UniValue importwallet(const JSONRPCRequest& request)
     if (fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Importing wallets is disabled in pruned mode");
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     ifstream file;
     file.open(request.params[0].get_str().c_str(), std::ios::in | std::ios::ate);
@@ -484,9 +489,9 @@ UniValue importwallet(const JSONRPCRequest& request)
     int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
     file.seekg(0, file.beg);
 
-    pwalletMain->ShowProgress(_("Importing..."), 0); // show progress dialog in GUI
+    pwallet->ShowProgress(_("Importing..."), 0); // show progress dialog in GUI
     while (file.good()) {
-        pwalletMain->ShowProgress("", std::max(1, std::min(99, (int)(((double)file.tellg() / (double)nFilesize) * 100))));
+        pwallet->ShowProgress("", std::max(1, std::min(99, (int)(((double)file.tellg() / (double)nFilesize) * 100))));
         std::string line;
         std::getline(file, line);
         if (line.empty() || line[0] == '#')
@@ -503,7 +508,7 @@ UniValue importwallet(const JSONRPCRequest& request)
         CPubKey pubkey = key.GetPubKey();
         assert(key.VerifyPubKey(pubkey));
         CKeyID keyid = pubkey.GetID();
-        if (pwalletMain->HaveKey(keyid)) {
+        if (pwallet->HaveKey(keyid)) {
             LogPrintf("Skipping import of %s (key already present)\n", CBitcoinAddress(keyid).ToString());
             continue;
         }
@@ -523,24 +528,24 @@ UniValue importwallet(const JSONRPCRequest& request)
             }
         }
         LogPrintf("Importing %s...\n", CBitcoinAddress(keyid).ToString());
-        if (!pwalletMain->AddKeyPubKey(key, pubkey)) {
+        if (!pwallet->AddKeyPubKey(key, pubkey)) {
             fGood = false;
             continue;
         }
-        pwalletMain->mapKeyMetadata[keyid].nCreateTime = nTime;
+        pwallet->mapKeyMetadata[keyid].nCreateTime = nTime;
         if (fLabel)
-            pwalletMain->SetAddressBook(keyid, strLabel, "receive");
+            pwallet->SetAddressBook(keyid, strLabel, "receive");
         nTimeBegin = std::min(nTimeBegin, nTime);
     }
     file.close();
-    pwalletMain->ShowProgress("", 100); // hide progress dialog in GUI
-    pwalletMain->UpdateTimeFirstKey(nTimeBegin);
+    pwallet->ShowProgress("", 100); // hide progress dialog in GUI
+    pwallet->UpdateTimeFirstKey(nTimeBegin);
 
     CBlockIndex *pindex = chainActive.FindEarliestAtLeast(nTimeBegin - 7200);
 
     LogPrintf("Rescanning last %i blocks\n", pindex ? chainActive.Height() - pindex->nHeight + 1 : 0);
-    pwalletMain->ScanForWalletTransactions(pindex);
-    pwalletMain->MarkDirty();
+    pwallet->ScanForWalletTransactions(pindex);
+    pwallet->MarkDirty();
 
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
@@ -550,7 +555,8 @@ UniValue importwallet(const JSONRPCRequest& request)
 
 UniValue dumpprivkey(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -568,9 +574,9 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
             + HelpExampleRpc("dumpprivkey", "\"myaddress\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     string strAddress = request.params[0].get_str();
     CBitcoinAddress address;
@@ -580,7 +586,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!address.GetKeyID(keyID))
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     CKey vchSecret;
-    if (!pwalletMain->GetKey(keyID, vchSecret))
+    if (!pwallet->GetKey(keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
     return CBitcoinSecret(vchSecret).ToString();
 }
@@ -588,7 +594,8 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
 UniValue dumpwallet(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -602,9 +609,9 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("dumpwallet", "\"test\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     ofstream file;
 
@@ -622,8 +629,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     std::map<CTxDestination, int64_t> mapKeyBirth;
     std::set<CKeyID> setKeyPool;
-    pwalletMain->GetKeyBirthTimes(mapKeyBirth);
-    pwalletMain->GetAllReserveKeys(setKeyPool);
+    pwallet->GetKeyBirthTimes(mapKeyBirth);
+    pwallet->GetAllReserveKeys(setKeyPool);
 
     // sort time/key pairs
     std::vector<std::pair<int64_t, CKeyID> > vKeyBirth;
@@ -643,11 +650,11 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file << "\n";
 
     // add the base58check encoded extended master if the wallet uses HD
-    CKeyID masterKeyID = pwalletMain->GetHDChain().masterKeyID;
+    CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
     if (!masterKeyID.IsNull())
     {
         CKey key;
-        if (pwalletMain->GetKey(masterKeyID, key))
+        if (pwallet->GetKey(masterKeyID, key))
         {
             CExtKey masterKey;
             masterKey.SetMaster(key.begin(), key.size());
@@ -663,20 +670,20 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         std::string strTime = EncodeDumpTime(it->first);
         std::string strAddr = CBitcoinAddress(keyid).ToString();
         CKey key;
-        if (pwalletMain->GetKey(keyid, key)) {
+        if (pwallet->GetKey(keyid, key)) {
             file << strprintf("%s %s ", CBitcoinSecret(key).ToString(), strTime);
-            if (pwalletMain->mapAddressBook.count(keyid)) {
-                file << strprintf("label=%s", EncodeDumpString(pwalletMain->mapAddressBook[keyid].name));
+            if (pwallet->mapAddressBook.count(keyid)) {
+                file << strprintf("label=%s", EncodeDumpString(pwallet->mapAddressBook[keyid].name));
             } else if (keyid == masterKeyID) {
                 file << "hdmaster=1";
             } else if (setKeyPool.count(keyid)) {
                 file << "reserve=1";
-            } else if (pwalletMain->mapKeyMetadata[keyid].hdKeypath == "m") {
+            } else if (pwallet->mapKeyMetadata[keyid].hdKeypath == "m") {
                 file << "inactivehdmaster=1";
             } else {
                 file << "change=1";
             }
-            file << strprintf(" # addr=%s%s\n", strAddr, (pwalletMain->mapKeyMetadata[keyid].hdKeypath.size() > 0 ? " hdkeypath="+pwalletMain->mapKeyMetadata[keyid].hdKeypath : ""));
+            file << strprintf(" # addr=%s%s\n", strAddr, (pwallet->mapKeyMetadata[keyid].hdKeypath.size() > 0 ? " hdkeypath="+pwallet->mapKeyMetadata[keyid].hdKeypath : ""));
         }
     }
     file << "\n";
@@ -686,7 +693,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 }
 
 
-UniValue ProcessImport(const UniValue& data, const int64_t timestamp)
+UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp)
 {
     try {
         bool success = false;
@@ -768,32 +775,32 @@ UniValue ProcessImport(const UniValue& data, const int64_t timestamp)
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid P2SH address / script");
             }
 
-            pwalletMain->MarkDirty();
+            pwallet->MarkDirty();
 
-            if (!pwalletMain->HaveWatchOnly(redeemScript) && !pwalletMain->AddWatchOnly(redeemScript, timestamp)) {
+            if (!pwallet->HaveWatchOnly(redeemScript) && !pwallet->AddWatchOnly(redeemScript, timestamp)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
             }
 
-            if (!pwalletMain->HaveCScript(redeemScript) && !pwalletMain->AddCScript(redeemScript)) {
+            if (!pwallet->HaveCScript(redeemScript) && !pwallet->AddCScript(redeemScript)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
             }
 
             CBitcoinAddress redeemAddress = CBitcoinAddress(CScriptID(redeemScript));
             CScript redeemDestination = GetScriptForDestination(redeemAddress.Get());
 
-            if (::IsMine(*pwalletMain, redeemDestination) == ISMINE_SPENDABLE) {
+            if (::IsMine(*pwallet, redeemDestination) == ISMINE_SPENDABLE) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
             }
 
-            pwalletMain->MarkDirty();
+            pwallet->MarkDirty();
 
-            if (!pwalletMain->HaveWatchOnly(redeemDestination) && !pwalletMain->AddWatchOnly(redeemDestination, timestamp)) {
+            if (!pwallet->HaveWatchOnly(redeemDestination) && !pwallet->AddWatchOnly(redeemDestination, timestamp)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
             }
 
             // add to address book or update label
             if (address.IsValid()) {
-                pwalletMain->SetAddressBook(address.Get(), label, "receive");
+                pwallet->SetAddressBook(address.Get(), label, "receive");
             }
 
             // Import private keys.
@@ -818,20 +825,20 @@ UniValue ProcessImport(const UniValue& data, const int64_t timestamp)
                     assert(key.VerifyPubKey(pubkey));
 
                     CKeyID vchAddress = pubkey.GetID();
-                    pwalletMain->MarkDirty();
-                    pwalletMain->SetAddressBook(vchAddress, label, "receive");
+                    pwallet->MarkDirty();
+                    pwallet->SetAddressBook(vchAddress, label, "receive");
 
-                    if (pwalletMain->HaveKey(vchAddress)) {
+                    if (pwallet->HaveKey(vchAddress)) {
                         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Already have this key");
                     }
 
-                    pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
+                    pwallet->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
 
-                    if (!pwalletMain->AddKeyPubKey(key, pubkey)) {
+                    if (!pwallet->AddKeyPubKey(key, pubkey)) {
                         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
                     }
 
-                    pwalletMain->UpdateTimeFirstKey(timestamp);
+                    pwallet->UpdateTimeFirstKey(timestamp);
                 }
             }
 
@@ -874,31 +881,31 @@ UniValue ProcessImport(const UniValue& data, const int64_t timestamp)
 
                 CScript pubKeyScript = GetScriptForDestination(pubKeyAddress.Get());
 
-                if (::IsMine(*pwalletMain, pubKeyScript) == ISMINE_SPENDABLE) {
+                if (::IsMine(*pwallet, pubKeyScript) == ISMINE_SPENDABLE) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
                 }
 
-                pwalletMain->MarkDirty();
+                pwallet->MarkDirty();
 
-                if (!pwalletMain->HaveWatchOnly(pubKeyScript) && !pwalletMain->AddWatchOnly(pubKeyScript, timestamp)) {
+                if (!pwallet->HaveWatchOnly(pubKeyScript) && !pwallet->AddWatchOnly(pubKeyScript, timestamp)) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
                 }
 
                 // add to address book or update label
                 if (pubKeyAddress.IsValid()) {
-                    pwalletMain->SetAddressBook(pubKeyAddress.Get(), label, "receive");
+                    pwallet->SetAddressBook(pubKeyAddress.Get(), label, "receive");
                 }
 
                 // TODO Is this necessary?
                 CScript scriptRawPubKey = GetScriptForRawPubKey(pubKey);
 
-                if (::IsMine(*pwalletMain, scriptRawPubKey) == ISMINE_SPENDABLE) {
+                if (::IsMine(*pwallet, scriptRawPubKey) == ISMINE_SPENDABLE) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
                 }
 
-                pwalletMain->MarkDirty();
+                pwallet->MarkDirty();
 
-                if (!pwalletMain->HaveWatchOnly(scriptRawPubKey) && !pwalletMain->AddWatchOnly(scriptRawPubKey, timestamp)) {
+                if (!pwallet->HaveWatchOnly(scriptRawPubKey) && !pwallet->AddWatchOnly(scriptRawPubKey, timestamp)) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
                 }
 
@@ -946,40 +953,40 @@ UniValue ProcessImport(const UniValue& data, const int64_t timestamp)
                 }
 
                 CKeyID vchAddress = pubKey.GetID();
-                pwalletMain->MarkDirty();
-                pwalletMain->SetAddressBook(vchAddress, label, "receive");
+                pwallet->MarkDirty();
+                pwallet->SetAddressBook(vchAddress, label, "receive");
 
-                if (pwalletMain->HaveKey(vchAddress)) {
+                if (pwallet->HaveKey(vchAddress)) {
                     return false;
                 }
 
-                pwalletMain->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
+                pwallet->mapKeyMetadata[vchAddress].nCreateTime = timestamp;
 
-                if (!pwalletMain->AddKeyPubKey(key, pubKey)) {
+                if (!pwallet->AddKeyPubKey(key, pubKey)) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
                 }
 
-                pwalletMain->UpdateTimeFirstKey(timestamp);
+                pwallet->UpdateTimeFirstKey(timestamp);
 
                 success = true;
             }
 
             // Import scriptPubKey only.
             if (pubKeys.size() == 0 && keys.size() == 0) {
-                if (::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE) {
+                if (::IsMine(*pwallet, script) == ISMINE_SPENDABLE) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
                 }
 
-                pwalletMain->MarkDirty();
+                pwallet->MarkDirty();
 
-                if (!pwalletMain->HaveWatchOnly(script) && !pwalletMain->AddWatchOnly(script, timestamp)) {
+                if (!pwallet->HaveWatchOnly(script) && !pwallet->AddWatchOnly(script, timestamp)) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
                 }
 
                 if (scriptPubKey.getType() == UniValue::VOBJ) {
                     // add to address book or update label
                     if (address.IsValid()) {
-                        pwalletMain->SetAddressBook(address.Get(), label, "receive");
+                        pwallet->SetAddressBook(address.Get(), label, "receive");
                     }
                 }
 
@@ -1057,7 +1064,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
             "  [{ \"success\": true } , { \"success\": false, \"error\": { \"code\": -1, \"message\": \"Internal Server Error\"} }, ... ]\n");
 
     // clang-format on
-    if (!EnsureWalletIsAvailable(mainRequest.fHelp)) {
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(mainRequest);
+    if (!EnsureWalletIsAvailable(pwallet, mainRequest.fHelp)) {
         return NullUniValue;
     }
 
@@ -1076,8 +1084,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         }
     }
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    EnsureWalletIsUnlocked();
+    LOCK2(cs_main, pwallet->cs_wallet);
+    EnsureWalletIsUnlocked(pwallet);
 
     // Verify all timestamps are present before importing any keys.
     const int64_t now = chainActive.Tip() ? chainActive.Tip()->GetMedianTimePast() : 0;
@@ -1099,7 +1107,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     BOOST_FOREACH (const UniValue& data, requests.getValues()) {
         const int64_t timestamp = std::max(GetImportTimestamp(data, now), minimumTimestamp);
-        const UniValue result = ProcessImport(data, timestamp);
+        const UniValue result = ProcessImport(pwallet, data, timestamp);
         response.push_back(result);
 
         if (!fRescan) {
@@ -1121,8 +1129,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         CBlockIndex* pindex = nLowestTimestamp > minimumTimestamp ? chainActive.FindEarliestAtLeast(std::max<int64_t>(nLowestTimestamp - 7200, 0)) : chainActive.Genesis();
         CBlockIndex* scannedRange = nullptr;
         if (pindex) {
-            scannedRange = pwalletMain->ScanForWalletTransactions(pindex, true);
-            pwalletMain->ReacceptWalletTransactions();
+            scannedRange = pwallet->ScanForWalletTransactions(pindex, true);
+            pwallet->ReacceptWalletTransactions();
         }
 
         if (!scannedRange || scannedRange->nHeight > pindex->nHeight) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -139,7 +139,8 @@ string AccountFromValue(const UniValue& value)
 
 UniValue getnewaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 1)
@@ -157,32 +158,32 @@ UniValue getnewaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("getnewaddress", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // Parse the account first so we don't generate a key if there's an error
     string strAccount;
     if (request.params.size() > 0)
         strAccount = AccountFromValue(request.params[0]);
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    if (!pwallet->IsLocked())
+        pwallet->TopUpKeyPool();
 
     // Generate a new key that is added to wallet
     CPubKey newKey;
-    if (!pwalletMain->GetKeyFromPool(newKey))
+    if (!pwallet->GetKeyFromPool(newKey))
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
     CKeyID keyID = newKey.GetID();
 
-    pwalletMain->SetAddressBook(keyID, strAccount, "receive");
+    pwallet->SetAddressBook(keyID, strAccount, "receive");
 
     return CBitcoinAddress(keyID).ToString();
 }
 
 
-CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
+CBitcoinAddress GetAccountAddress(CWallet * const pwallet, string strAccount, bool bForceNew=false)
 {
     CPubKey pubKey;
-    if (!pwalletMain->GetAccountPubkey(pubKey, strAccount, bForceNew)) {
+    if (!pwallet->GetAccountPubkey(pubKey, strAccount, bForceNew)) {
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
     }
 
@@ -191,7 +192,8 @@ CBitcoinAddress GetAccountAddress(string strAccount, bool bForceNew=false)
 
 UniValue getaccountaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -209,21 +211,22 @@ UniValue getaccountaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("getaccountaddress", "\"myaccount\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // Parse the account first so we don't generate a key if there's an error
     string strAccount = AccountFromValue(request.params[0]);
 
     UniValue ret(UniValue::VSTR);
 
-    ret = GetAccountAddress(strAccount).ToString();
+    ret = GetAccountAddress(pwallet, strAccount).ToString();
     return ret;
 }
 
 
 UniValue getrawchangeaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 1)
@@ -238,12 +241,12 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("getrawchangeaddress", "")
        );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    if (!pwallet->IsLocked())
+        pwallet->TopUpKeyPool();
 
-    CReserveKey reservekey(pwalletMain);
+    CReserveKey reservekey(pwallet);
     CPubKey vchPubKey;
     if (!reservekey.GetReservedKey(vchPubKey))
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
@@ -258,7 +261,8 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
 
 UniValue setaccount(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -273,7 +277,7 @@ UniValue setaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("setaccount", "\"DH9fPpKHLiP5eaAD3pXxxUZmPktGNGTFp6\", \"tabby\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     CBitcoinAddress address(request.params[0].get_str());
     if (!address.IsValid())
@@ -284,16 +288,16 @@ UniValue setaccount(const JSONRPCRequest& request)
         strAccount = AccountFromValue(request.params[1]);
 
     // Only add the account if the address is yours.
-    if (IsMine(*pwalletMain, address.Get()))
+    if (IsMine(*pwallet, address.Get()))
     {
         // Detect when changing the account of an address that is the 'unused current key' of another account:
-        if (pwalletMain->mapAddressBook.count(address.Get()))
+        if (pwallet->mapAddressBook.count(address.Get()))
         {
-            string strOldAccount = pwalletMain->mapAddressBook[address.Get()].name;
-            if (address == GetAccountAddress(strOldAccount))
-                GetAccountAddress(strOldAccount, true);
+            string strOldAccount = pwallet->mapAddressBook[address.Get()].name;
+            if (address == GetAccountAddress(pwallet, strOldAccount))
+                GetAccountAddress(pwallet, strOldAccount, true);
         }
-        pwalletMain->SetAddressBook(address.Get(), strAccount, "receive");
+        pwallet->SetAddressBook(address.Get(), strAccount, "receive");
     }
     else
         throw JSONRPCError(RPC_MISC_ERROR, "setaccount can only be used with own address");
@@ -304,7 +308,8 @@ UniValue setaccount(const JSONRPCRequest& request)
 
 UniValue getaccount(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -320,15 +325,15 @@ UniValue getaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("getaccount", "\"DH9fPpKHLiP5eaAD3pXxxUZmPktGNGTFp6\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     CBitcoinAddress address(request.params[0].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Dogecoin address");
 
     string strAccount;
-    map<CTxDestination, CAddressBookData>::iterator mi = pwalletMain->mapAddressBook.find(address.Get());
-    if (mi != pwalletMain->mapAddressBook.end() && !(*mi).second.name.empty())
+    map<CTxDestination, CAddressBookData>::iterator mi = pwallet->mapAddressBook.find(address.Get());
+    if (mi != pwallet->mapAddressBook.end() && !(*mi).second.name.empty())
         strAccount = (*mi).second.name;
     return strAccount;
 }
@@ -336,7 +341,8 @@ UniValue getaccount(const JSONRPCRequest& request)
 
 UniValue getaddressesbyaccount(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -355,13 +361,13 @@ UniValue getaddressesbyaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("getaddressesbyaccount", "\"tabby\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string strAccount = AccountFromValue(request.params[0]);
 
     // Find all addresses that have the given account
     UniValue ret(UniValue::VARR);
-    BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, CAddressBookData)& item, pwalletMain->mapAddressBook)
+    BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, CAddressBookData)& item, pwallet->mapAddressBook)
     {
         const CBitcoinAddress& address = item.first;
         const string& strName = item.second.name;
@@ -371,9 +377,9 @@ UniValue getaddressesbyaccount(const JSONRPCRequest& request)
     return ret;
 }
 
-static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew)
+static void SendMoney(CWallet * const pwallet, const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew)
 {
-    CAmount curBalance = pwalletMain->GetBalance();
+    CAmount curBalance = pwallet->GetBalance();
 
     // Check amount
     if (nValue <= 0)
@@ -382,27 +388,27 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
     if (nValue > curBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
 
-    if (pwalletMain->GetBroadcastTransactions() && !g_connman)
+    if (pwallet->GetBroadcastTransactions() && !g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     // Parse Bitcoin address
     CScript scriptPubKey = GetScriptForDestination(address);
 
     // Create and send the transaction
-    CReserveKey reservekey(pwalletMain);
+    CReserveKey reservekey(pwallet);
     CAmount nFeeRequired;
     std::string strError;
     vector<CRecipient> vecSend;
     int nChangePosRet = -1;
     CRecipient recipient = {scriptPubKey, nValue, fSubtractFeeFromAmount};
     vecSend.push_back(recipient);
-    if (!pwalletMain->CreateTransaction(vecSend, wtxNew, reservekey, nFeeRequired, nChangePosRet, strError)) {
+    if (!pwallet->CreateTransaction(vecSend, wtxNew, reservekey, nFeeRequired, nChangePosRet, strError)) {
         if (!fSubtractFeeFromAmount && nValue + nFeeRequired > curBalance)
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s", FormatMoney(nFeeRequired));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
     CValidationState state;
-    if (!pwalletMain->CommitTransaction(wtxNew, reservekey, g_connman.get(), state)) {
+    if (!pwallet->CommitTransaction(wtxNew, reservekey, g_connman.get(), state)) {
         strError = strprintf("Error: The transaction was rejected! Reason given: %s", state.GetRejectReason());
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
@@ -410,14 +416,15 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
 
 UniValue sendtoaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
         throw runtime_error(
             "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount )\n"
             "\nSend an amount to a given address.\n"
-            + HelpRequiringPassphrase() +
+            + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
             "1. \"address\"            (string, required) The dogecoin address to send to.\n"
             "2. \"amount\"             (numeric or string, required) The amount in " + CURRENCY_UNIT + " to send. eg 0.1\n"
@@ -437,7 +444,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("sendtoaddress", "\"DRF7yvmFHR5gMXRtijkbkPzmLYnMfTYMGZ\", 0.1, \"donation\", \"seans outpost\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     CBitcoinAddress address(request.params[0].get_str());
     if (!address.IsValid())
@@ -459,16 +466,17 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     if (request.params.size() > 4)
         fSubtractFeeFromAmount = request.params[4].get_bool();
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
-    SendMoney(address.Get(), nAmount, fSubtractFeeFromAmount, wtx);
+    SendMoney(pwallet, address.Get(), nAmount, fSubtractFeeFromAmount, wtx);
 
     return wtx.GetHash().GetHex();
 }
 
 UniValue listaddressgroupings(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp)
@@ -494,11 +502,11 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
             + HelpExampleRpc("listaddressgroupings", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     UniValue jsonGroupings(UniValue::VARR);
-    map<CTxDestination, CAmount> balances = pwalletMain->GetAddressBalances();
-    BOOST_FOREACH(set<CTxDestination> grouping, pwalletMain->GetAddressGroupings())
+    map<CTxDestination, CAmount> balances = pwallet->GetAddressBalances();
+    BOOST_FOREACH(set<CTxDestination> grouping, pwallet->GetAddressGroupings())
     {
         UniValue jsonGrouping(UniValue::VARR);
         BOOST_FOREACH(CTxDestination address, grouping)
@@ -507,8 +515,8 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
             addressInfo.push_back(CBitcoinAddress(address).ToString());
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
-                if (pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get()) != pwalletMain->mapAddressBook.end())
-                    addressInfo.push_back(pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get())->second.name);
+                if (pwallet->mapAddressBook.find(CBitcoinAddress(address).Get()) != pwallet->mapAddressBook.end())
+                    addressInfo.push_back(pwallet->mapAddressBook.find(CBitcoinAddress(address).Get())->second.name);
             }
             jsonGrouping.push_back(addressInfo);
         }
@@ -519,14 +527,15 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
 
 UniValue signmessage(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 2)
         throw runtime_error(
             "signmessage \"address\" \"message\"\n"
             "\nSign a message with the private key of an address"
-            + HelpRequiringPassphrase() + "\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
             "\nArguments:\n"
             "1. \"address\"         (string, required) The dogecoin address to use for the private key.\n"
             "2. \"message\"         (string, required) The message to create a signature of.\n"
@@ -543,9 +552,9 @@ UniValue signmessage(const JSONRPCRequest& request)
             + HelpExampleRpc("signmessage", "\"DH9fPpKHLiP5eaAD3pXxxUZmPktGNGTFp6\", \"my message\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     string strAddress = request.params[0].get_str();
     string strMessage = request.params[1].get_str();
@@ -559,7 +568,7 @@ UniValue signmessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
 
     CKey key;
-    if (!pwalletMain->GetKey(keyID, key))
+    if (!pwallet->GetKey(keyID, key))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key not available");
 
     CHashWriter ss(SER_GETHASH, 0);
@@ -575,7 +584,8 @@ UniValue signmessage(const JSONRPCRequest& request)
 
 UniValue getreceivedbyaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -598,14 +608,14 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("getreceivedbyaddress", "\"DH9fPpKHLiP5eaAD3pXxxUZmPktGNGTFp6\", 6")
        );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // Bitcoin address
     CBitcoinAddress address = CBitcoinAddress(request.params[0].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Dogecoin address");
     CScript scriptPubKey = GetScriptForDestination(address.Get());
-    if (!IsMine(*pwalletMain, scriptPubKey))
+    if (!IsMine(*pwallet, scriptPubKey))
         return ValueFromAmount(0);
 
     // Minimum confirmations
@@ -615,7 +625,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
 
     // Tally
     CAmount nAmount = 0;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         if (wtx.IsCoinBase() || !CheckFinalTx(*wtx.tx))
@@ -633,7 +643,8 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
 
 UniValue getreceivedbyaccount(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -656,7 +667,7 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("getreceivedbyaccount", "\"tabby\", 6")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // Minimum confirmations
     int nMinDepth = 1;
@@ -665,11 +676,11 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
 
     // Get the set of pub keys assigned to account
     string strAccount = AccountFromValue(request.params[0]);
-    set<CTxDestination> setAddress = pwalletMain->GetAccountAddresses(strAccount);
+    set<CTxDestination> setAddress = pwallet->GetAccountAddresses(strAccount);
 
     // Tally
     CAmount nAmount = 0;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         if (wtx.IsCoinBase() || !CheckFinalTx(*wtx.tx))
@@ -678,7 +689,7 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
         BOOST_FOREACH(const CTxOut& txout, wtx.tx->vout)
         {
             CTxDestination address;
-            if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwalletMain, address) && setAddress.count(address))
+            if (ExtractDestination(txout.scriptPubKey, address) && IsMine(*pwallet, address) && setAddress.count(address))
                 if (wtx.GetDepthInMainChain() >= nMinDepth)
                     nAmount += txout.nValue;
         }
@@ -690,7 +701,8 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
 
 UniValue getbalance(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 3)
@@ -726,10 +738,10 @@ UniValue getbalance(const JSONRPCRequest& request)
             + HelpExampleRpc("getbalance", "\"*\", 6")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.params.size() == 0)
-        return  ValueFromAmount(pwalletMain->GetBalance());
+        return  ValueFromAmount(pwallet->GetBalance());
 
     int nMinDepth = 1;
     if (request.params.size() > 1)
@@ -747,7 +759,7 @@ UniValue getbalance(const JSONRPCRequest& request)
         // TxIns spending from the wallet. This also has fewer restrictions on
         // which unconfirmed transactions are considered trusted.
         CAmount nBalance = 0;
-        for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+        for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
         {
             const CWalletTx& wtx = (*it).second;
             if (!CheckFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetDepthInMainChain() < 0)
@@ -772,14 +784,15 @@ UniValue getbalance(const JSONRPCRequest& request)
 
     string strAccount = AccountFromValue(request.params[0]);
 
-    CAmount nBalance = pwalletMain->GetAccountBalance(strAccount, nMinDepth, filter);
+    CAmount nBalance = pwallet->GetAccountBalance(strAccount, nMinDepth, filter);
 
     return ValueFromAmount(nBalance);
 }
 
 UniValue getunconfirmedbalance(const JSONRPCRequest &request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 0)
@@ -787,15 +800,16 @@ UniValue getunconfirmedbalance(const JSONRPCRequest &request)
                 "getunconfirmedbalance\n"
                 "Returns the server's total unconfirmed balance\n");
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    return ValueFromAmount(pwalletMain->GetUnconfirmedBalance());
+    return ValueFromAmount(pwallet->GetUnconfirmedBalance());
 }
 
 
 UniValue movecmd(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 3 || request.params.size() > 5)
@@ -819,7 +833,7 @@ UniValue movecmd(const JSONRPCRequest& request)
             + HelpExampleRpc("move", "\"timotei\", \"akiko\", 0.01, 6, \"happy birthday!\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string strFrom = AccountFromValue(request.params[0]);
     string strTo = AccountFromValue(request.params[1]);
@@ -833,7 +847,7 @@ UniValue movecmd(const JSONRPCRequest& request)
     if (request.params.size() > 4)
         strComment = request.params[4].get_str();
 
-    if (!pwalletMain->AccountMove(strFrom, strTo, nAmount, strComment))
+    if (!pwallet->AccountMove(strFrom, strTo, nAmount, strComment))
         throw JSONRPCError(RPC_DATABASE_ERROR, "database error");
 
     return true;
@@ -841,7 +855,8 @@ UniValue movecmd(const JSONRPCRequest& request)
 
 UniValue rescan(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     const int nParams = request.params.size();
@@ -895,16 +910,16 @@ UniValue rescan(const JSONRPCRequest& request)
     }
 
     UniValue beforeObj(UniValue::VOBJ);
-    beforeObj.pushKV("balance", ValueFromAmount(pwalletMain->GetBalance()));
-    beforeObj.pushKV("txcount", (int)pwalletMain->mapWallet.size());
+    beforeObj.pushKV("balance", ValueFromAmount(pwallet->GetBalance()));
+    beforeObj.pushKV("txcount", (int)pwallet->mapWallet.size());
 
     int64_t beforeTime = GetTime();
 
-    pwalletMain->ScanForWalletTransactions(pblockindex, true);
+    pwallet->ScanForWalletTransactions(pblockindex, true);
 
     UniValue afterObj(UniValue::VOBJ);
-    afterObj.pushKV("balance", ValueFromAmount(pwalletMain->GetBalance()));
-    afterObj.pushKV("txcount", (int)pwalletMain->mapWallet.size());
+    afterObj.pushKV("balance", ValueFromAmount(pwallet->GetBalance()));
+    afterObj.pushKV("txcount", (int)pwallet->mapWallet.size());
 
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("before", beforeObj);
@@ -919,14 +934,15 @@ UniValue rescan(const JSONRPCRequest& request)
 
 UniValue sendfrom(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 3 || request.params.size() > 6)
         throw runtime_error(
             "sendfrom \"fromaccount\" \"toaddress\" amount ( minconf \"comment\" \"comment_to\" )\n"
             "\nDEPRECATED (use sendtoaddress). Sent an amount from an account to a dogecoin address."
-            + HelpRequiringPassphrase() + "\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
             "\nArguments:\n"
             "1. \"fromaccount\"       (string, required) The name of the account to send funds from. May be the default account using \"\".\n"
             "                       Specifying an account does not influence coin selection, but it does associate the newly created\n"
@@ -951,7 +967,7 @@ UniValue sendfrom(const JSONRPCRequest& request)
             + HelpExampleRpc("sendfrom", "\"tabby\", \"DRF7yvmFHR5gMXRtijkbkPzmLYnMfTYMGZ\", 0.01, 6, \"donation\", \"seans outpost\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string strAccount = AccountFromValue(request.params[0]);
     CBitcoinAddress address(request.params[1].get_str());
@@ -971,14 +987,14 @@ UniValue sendfrom(const JSONRPCRequest& request)
     if (request.params.size() > 5 && !request.params[5].isNull() && !request.params[5].get_str().empty())
         wtx.mapValue["to"]      = request.params[5].get_str();
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     // Check funds
-    CAmount nBalance = pwalletMain->GetAccountBalance(strAccount, nMinDepth, ISMINE_SPENDABLE);
+    CAmount nBalance = pwallet->GetAccountBalance(strAccount, nMinDepth, ISMINE_SPENDABLE);
     if (nAmount > nBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
 
-    SendMoney(address.Get(), nAmount, false, wtx);
+    SendMoney(pwallet, address.Get(), nAmount, false, wtx);
 
     return wtx.GetHash().GetHex();
 }
@@ -986,14 +1002,15 @@ UniValue sendfrom(const JSONRPCRequest& request)
 
 UniValue sendmany(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
         throw runtime_error(
             "sendmany \"fromaccount\" {\"address\":amount,...} ( minconf \"comment\" [\"address\",...] )\n"
             "\nSend multiple times. Amounts are double-precision floating point numbers."
-            + HelpRequiringPassphrase() + "\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
             "\nArguments:\n"
             "1. \"fromaccount\"         (string, required) DEPRECATED. The account to send the funds from. Should be \"\" for the default account\n"
             "2. \"amounts\"             (string, required) A json object with addresses and amounts\n"
@@ -1025,9 +1042,9 @@ UniValue sendmany(const JSONRPCRequest& request)
             + HelpExampleRpc("sendmany", "\"\", \"{\\\"DH9fPpKHLiP5eaAD3pXxxUZmPktGNGTFp6\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\", 6, \"testing\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    if (pwalletMain->GetBroadcastTransactions() && !g_connman)
+    if (pwallet->GetBroadcastTransactions() && !g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     string strAccount = AccountFromValue(request.params[0]);
@@ -1077,23 +1094,23 @@ UniValue sendmany(const JSONRPCRequest& request)
         vecSend.push_back(recipient);
     }
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwallet);
 
     // Check funds
-    CAmount nBalance = pwalletMain->GetAccountBalance(strAccount, nMinDepth, ISMINE_SPENDABLE);
+    CAmount nBalance = pwallet->GetAccountBalance(strAccount, nMinDepth, ISMINE_SPENDABLE);
     if (totalAmount > nBalance)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Account has insufficient funds");
 
     // Send
-    CReserveKey keyChange(pwalletMain);
+    CReserveKey keyChange(pwallet);
     CAmount nFeeRequired = 0;
     int nChangePosRet = -1;
     string strFailReason;
-    bool fCreated = pwalletMain->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, nChangePosRet, strFailReason);
+    bool fCreated = pwallet->CreateTransaction(vecSend, wtx, keyChange, nFeeRequired, nChangePosRet, strFailReason);
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
     CValidationState state;
-    if (!pwalletMain->CommitTransaction(wtx, keyChange, g_connman.get(), state)) {
+    if (!pwallet->CommitTransaction(wtx, keyChange, g_connman.get(), state)) {
         strFailReason = strprintf("Transaction commit failed:: %s", state.GetRejectReason());
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }
@@ -1106,7 +1123,8 @@ extern CScript _createmultisig_redeemScript(const UniValue& params);
 
 UniValue addmultisigaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
@@ -1137,7 +1155,7 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
         throw runtime_error(msg);
     }
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string strAccount;
     if (request.params.size() > 2)
@@ -1146,29 +1164,32 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     // Construct using pay-to-script-hash:
     CScript inner = _createmultisig_redeemScript(request.params);
     CScriptID innerID(inner);
-    pwalletMain->AddCScript(inner);
+    pwallet->AddCScript(inner);
 
-    pwalletMain->SetAddressBook(innerID, strAccount, "send");
+    pwallet->SetAddressBook(innerID, strAccount, "send");
     return CBitcoinAddress(innerID).ToString();
 }
 
 class Witnessifier : public boost::static_visitor<bool>
 {
 public:
+    CWallet * const pwallet;
     CScriptID result;
+
+    Witnessifier(CWallet *_pwallet) : pwallet(_pwallet) {}
 
     bool operator()(const CNoDestination &dest) const { return false; }
 
     bool operator()(const CKeyID &keyID) {
         CPubKey pubkey;
-        if (pwalletMain) {
+        if (pwallet) {
             CScript basescript = GetScriptForDestination(keyID);
             isminetype typ;
-            typ = IsMine(*pwalletMain, basescript, SIGVERSION_WITNESS_V0);
+            typ = IsMine(*pwallet, basescript, SIGVERSION_WITNESS_V0);
             if (typ != ISMINE_SPENDABLE && typ != ISMINE_WATCH_SOLVABLE)
                 return false;
             CScript witscript = GetScriptForWitness(basescript);
-            pwalletMain->AddCScript(witscript);
+            pwallet->AddCScript(witscript);
             result = CScriptID(witscript);
             return true;
         }
@@ -1177,7 +1198,7 @@ public:
 
     bool operator()(const CScriptID &scriptID) {
         CScript subscript;
-        if (pwalletMain && pwalletMain->GetCScript(scriptID, subscript)) {
+        if (pwallet && pwallet->GetCScript(scriptID, subscript)) {
             int witnessversion;
             std::vector<unsigned char> witprog;
             if (subscript.IsWitnessProgram(witnessversion, witprog)) {
@@ -1185,11 +1206,11 @@ public:
                 return true;
             }
             isminetype typ;
-            typ = IsMine(*pwalletMain, subscript, SIGVERSION_WITNESS_V0);
+            typ = IsMine(*pwallet, subscript, SIGVERSION_WITNESS_V0);
             if (typ != ISMINE_SPENDABLE && typ != ISMINE_WATCH_SOLVABLE)
                 return false;
             CScript witscript = GetScriptForWitness(subscript);
-            pwalletMain->AddCScript(witscript);
+            pwallet->AddCScript(witscript);
             result = CScriptID(witscript);
             return true;
         }
@@ -1199,7 +1220,8 @@ public:
 
 UniValue addwitnessaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
@@ -1229,14 +1251,14 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
 
-    Witnessifier w;
+    Witnessifier w(pwallet);
     CTxDestination dest = address.Get();
     bool ret = boost::apply_visitor(w, dest);
     if (!ret) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
     }
 
-    pwalletMain->SetAddressBook(w.result, "", "receive");
+    pwallet->SetAddressBook(w.result, "", "receive");
 
     return CBitcoinAddress(w.result).ToString();
 }
@@ -1255,7 +1277,7 @@ struct tallyitem
     }
 };
 
-UniValue ListReceived(const UniValue& params, bool fByAccounts)
+UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByAccounts)
 {
     // Minimum confirmations
     int nMinDepth = 1;
@@ -1274,7 +1296,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
 
     // Tally
     map<CBitcoinAddress, tallyitem> mapTally;
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
 
@@ -1291,7 +1313,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
             if (!ExtractDestination(txout.scriptPubKey, address))
                 continue;
 
-            isminefilter mine = IsMine(*pwalletMain, address);
+            isminefilter mine = IsMine(*pwallet, address);
             if(!(mine & filter))
                 continue;
 
@@ -1307,7 +1329,7 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
     // Reply
     UniValue ret(UniValue::VARR);
     map<string, tallyitem> mapAccountTally;
-    BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, CAddressBookData)& item, pwalletMain->mapAddressBook)
+    BOOST_FOREACH(const PAIRTYPE(CBitcoinAddress, CAddressBookData)& item, pwallet->mapAddressBook)
     {
         const CBitcoinAddress& address = item.first;
         const string& strAccount = item.second.name;
@@ -1377,7 +1399,8 @@ UniValue ListReceived(const UniValue& params, bool fByAccounts)
 
 UniValue listreceivedbyaddress(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 3)
@@ -1412,14 +1435,15 @@ UniValue listreceivedbyaddress(const JSONRPCRequest& request)
             + HelpExampleRpc("listreceivedbyaddress", "6, true, true")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    return ListReceived(request.params, false);
+    return ListReceived(pwallet, request.params, false);
 }
 
 UniValue listreceivedbyaccount(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 3)
@@ -1449,9 +1473,9 @@ UniValue listreceivedbyaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("listreceivedbyaccount", "6, true, true")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    return ListReceived(request.params, true);
+    return ListReceived(pwallet, request.params, true);
 }
 
 static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
@@ -1461,7 +1485,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
         entry.pushKV("address", addr.ToString());
 }
 
-void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+void ListTransactions(CWallet * const pwallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
 {
     CAmount nFee;
     string strSentAccount;
@@ -1479,14 +1503,14 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
         BOOST_FOREACH(const COutputEntry& s, listSent)
         {
             UniValue entry(UniValue::VOBJ);
-            if(involvesWatchonly || (::IsMine(*pwalletMain, s.destination) & ISMINE_WATCH_ONLY))
+            if(involvesWatchonly || (::IsMine(*pwallet, s.destination) & ISMINE_WATCH_ONLY))
                 entry.pushKV("involvesWatchonly", true);
             entry.pushKV("account", strSentAccount);
             MaybePushAddress(entry, s.destination);
             entry.pushKV("category", "send");
             entry.pushKV("amount", ValueFromAmount(-s.amount));
-            if (pwalletMain->mapAddressBook.count(s.destination))
-                entry.pushKV("label", pwalletMain->mapAddressBook[s.destination].name);
+            if (pwallet->mapAddressBook.count(s.destination))
+                entry.pushKV("label", pwallet->mapAddressBook[s.destination].name);
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong)
@@ -1502,12 +1526,12 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
         BOOST_FOREACH(const COutputEntry& r, listReceived)
         {
             string account;
-            if (pwalletMain->mapAddressBook.count(r.destination))
-                account = pwalletMain->mapAddressBook[r.destination].name;
+            if (pwallet->mapAddressBook.count(r.destination))
+                account = pwallet->mapAddressBook[r.destination].name;
             if (fAllAccounts || (account == strAccount))
             {
                 UniValue entry(UniValue::VOBJ);
-                if(involvesWatchonly || (::IsMine(*pwalletMain, r.destination) & ISMINE_WATCH_ONLY))
+                if(involvesWatchonly || (::IsMine(*pwallet, r.destination) & ISMINE_WATCH_ONLY))
                     entry.pushKV("involvesWatchonly", true);
                 entry.pushKV("account", account);
                 MaybePushAddress(entry, r.destination);
@@ -1525,7 +1549,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                     entry.pushKV("category", "receive");
                 }
                 entry.pushKV("amount", ValueFromAmount(r.amount));
-                if (pwalletMain->mapAddressBook.count(r.destination))
+                if (pwallet->mapAddressBook.count(r.destination))
                     entry.pushKV("label", account);
                 entry.pushKV("vout", r.vout);
                 if (fLong)
@@ -1555,7 +1579,8 @@ void AcentryToJSON(const CAccountingEntry& acentry, const string& strAccount, Un
 
 UniValue listtransactions(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 4)
@@ -1618,7 +1643,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
             + HelpExampleRpc("listtransactions", "\"*\", 20, 100")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string strAccount = "*";
     if (request.params.size() > 0)
@@ -1641,14 +1666,14 @@ UniValue listtransactions(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VARR);
 
-    const CWallet::TxItems & txOrdered = pwalletMain->wtxOrdered;
+    const CWallet::TxItems & txOrdered = pwallet->wtxOrdered;
 
     // iterate backwards until we have nCount items to return:
     for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
     {
         CWalletTx *const pwtx = (*it).second.first;
         if (pwtx != 0)
-            ListTransactions(*pwtx, strAccount, 0, true, ret, filter);
+            ListTransactions(pwallet, *pwtx, strAccount, 0, true, ret, filter);
         CAccountingEntry *const pacentry = (*it).second.second;
         if (pacentry != 0)
             AcentryToJSON(*pacentry, strAccount, ret);
@@ -1683,7 +1708,8 @@ UniValue listtransactions(const JSONRPCRequest& request)
 
 UniValue liststucktransactions(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 2)
@@ -1741,7 +1767,7 @@ UniValue liststucktransactions(const JSONRPCRequest& request)
             + HelpExampleRpc("liststucktransactions", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     bool verbose = false;
     if (request.params.size() > 0)
@@ -1754,7 +1780,7 @@ UniValue liststucktransactions(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VARR);
 
-    const CWallet::TxItems& txOrdered = pwalletMain->wtxOrdered;
+    const CWallet::TxItems& txOrdered = pwallet->wtxOrdered;
 
     for (CWallet::TxItems::const_iterator it = txOrdered.begin(); it != txOrdered.end(); ++it)
     {
@@ -1777,7 +1803,7 @@ UniValue liststucktransactions(const JSONRPCRequest& request)
                 WalletTxToJSON(*wtx, entry);
 
                 UniValue details(UniValue::VARR);
-                ListTransactions(*wtx, "*", 0, false, details, filter);
+                ListTransactions(pwallet, *wtx, "*", 0, false, details, filter);
                 entry.pushKV("details", details);
 
                 string strHex = EncodeHexTx(static_cast<CTransaction>(*wtx), RPCSerializationFlags());
@@ -1792,7 +1818,8 @@ UniValue liststucktransactions(const JSONRPCRequest& request)
 
 UniValue listaccounts(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 2)
@@ -1818,7 +1845,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
             + HelpExampleRpc("listaccounts", "6")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     int nMinDepth = 1;
     if (request.params.size() > 0)
@@ -1829,12 +1856,12 @@ UniValue listaccounts(const JSONRPCRequest& request)
             includeWatchonly = includeWatchonly | ISMINE_WATCH_ONLY;
 
     map<string, CAmount> mapAccountBalances;
-    BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& entry, pwalletMain->mapAddressBook) {
-        if (IsMine(*pwalletMain, entry.first) & includeWatchonly) // This address belongs to me
+    BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& entry, pwallet->mapAddressBook) {
+        if (IsMine(*pwallet, entry.first) & includeWatchonly) // This address belongs to me
             mapAccountBalances[entry.second.name] = 0;
     }
 
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
+    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         const CWalletTx& wtx = (*it).second;
         CAmount nFee;
@@ -1851,14 +1878,14 @@ UniValue listaccounts(const JSONRPCRequest& request)
         if (nDepth >= nMinDepth)
         {
             BOOST_FOREACH(const COutputEntry& r, listReceived)
-                if (pwalletMain->mapAddressBook.count(r.destination))
-                    mapAccountBalances[pwalletMain->mapAddressBook[r.destination].name] += r.amount;
+                if (pwallet->mapAddressBook.count(r.destination))
+                    mapAccountBalances[pwallet->mapAddressBook[r.destination].name] += r.amount;
                 else
                     mapAccountBalances[""] += r.amount;
         }
     }
 
-    const list<CAccountingEntry> & acentries = pwalletMain->laccentries;
+    const list<CAccountingEntry> & acentries = pwallet->laccentries;
     BOOST_FOREACH(const CAccountingEntry& entry, acentries)
         mapAccountBalances[entry.strAccount] += entry.nCreditDebit;
 
@@ -1871,7 +1898,8 @@ UniValue listaccounts(const JSONRPCRequest& request)
 
 UniValue listsinceblock(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp)
@@ -1915,7 +1943,7 @@ UniValue listsinceblock(const JSONRPCRequest& request)
             + HelpExampleRpc("listsinceblock", "\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\", 6")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     const CBlockIndex *pindex = NULL;
     int target_confirms = 1;
@@ -1957,12 +1985,12 @@ UniValue listsinceblock(const JSONRPCRequest& request)
 
     UniValue transactions(UniValue::VARR);
 
-    for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); it++)
+    for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); it++)
     {
         CWalletTx tx = (*it).second;
 
         if (depth == -1 || tx.GetDepthInMainChain() < depth)
-            ListTransactions(tx, "*", 0, true, transactions, filter);
+            ListTransactions(pwallet, tx, "*", 0, true, transactions, filter);
     }
 
     CBlockIndex *pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
@@ -1977,7 +2005,8 @@ UniValue listsinceblock(const JSONRPCRequest& request)
 
 UniValue gettransaction(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -2025,7 +2054,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
             + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
@@ -2036,9 +2065,9 @@ UniValue gettransaction(const JSONRPCRequest& request)
             filter = filter | ISMINE_WATCH_ONLY;
 
     UniValue entry(UniValue::VOBJ);
-    if (!pwalletMain->mapWallet.count(hash))
+    if (!pwallet->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+    const CWalletTx& wtx = pwallet->mapWallet[hash];
 
     CAmount nCredit = wtx.GetCredit(filter);
     CAmount nDebit = wtx.GetDebit(filter);
@@ -2052,7 +2081,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     WalletTxToJSON(wtx, entry);
 
     UniValue details(UniValue::VARR);
-    ListTransactions(wtx, "*", 0, false, details, filter);
+    ListTransactions(pwallet, wtx, "*", 0, false, details, filter);
     entry.pushKV("details", details);
 
     string strHex = EncodeHexTx(static_cast<CTransaction>(wtx), RPCSerializationFlags());
@@ -2063,7 +2092,8 @@ UniValue gettransaction(const JSONRPCRequest& request)
 
 UniValue abandontransaction(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -2082,14 +2112,14 @@ UniValue abandontransaction(const JSONRPCRequest& request)
             + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
 
-    if (!pwalletMain->mapWallet.count(hash))
+    if (!pwallet->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    if (!pwalletMain->AbandonTransaction(hash))
+    if (!pwallet->AbandonTransaction(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not eligible for abandonment");
 
     return NullUniValue;
@@ -2098,7 +2128,8 @@ UniValue abandontransaction(const JSONRPCRequest& request)
 
 UniValue backupwallet(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 1)
@@ -2112,7 +2143,7 @@ UniValue backupwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("backupwallet", "\"backup.dat\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     string userFilename = request.params[0].get_str();
     fs::path path = GetBackupDirFromInput(userFilename);
@@ -2120,7 +2151,7 @@ UniValue backupwallet(const JSONRPCRequest& request)
     if (fs::exists(path))
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Wallet dump file already exists; not overwriting");
 
-    if (!pwalletMain->BackupWallet(path.string()))
+    if (!pwallet->BackupWallet(path.string()))
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: Wallet backup failed!");
 
     return NullUniValue;
@@ -2129,14 +2160,15 @@ UniValue backupwallet(const JSONRPCRequest& request)
 
 UniValue keypoolrefill(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 1)
         throw runtime_error(
             "keypoolrefill ( newsize )\n"
             "\nFills the keypool."
-            + HelpRequiringPassphrase() + "\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
             "\nArguments\n"
             "1. newsize     (numeric, optional, default=100) The new keypool size\n"
             "\nExamples:\n"
@@ -2144,7 +2176,7 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
             + HelpExampleRpc("keypoolrefill", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // 0 is interpreted by TopUpKeyPool() as the default keypool size given by -keypool
     unsigned int kpSize = 0;
@@ -2154,10 +2186,10 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
         kpSize = (unsigned int)request.params[0].get_int();
     }
 
-    EnsureWalletIsUnlocked();
-    pwalletMain->TopUpKeyPool(kpSize);
+    EnsureWalletIsUnlocked(pwallet);
+    pwallet->TopUpKeyPool(kpSize);
 
-    if (pwalletMain->GetKeyPoolSize() < kpSize)
+    if (pwallet->GetKeyPoolSize() < kpSize)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error refreshing keypool.");
 
     return NullUniValue;
@@ -2173,10 +2205,11 @@ static void LockWallet(CWallet* pWallet)
 
 UniValue walletpassphrase(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
-    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() != 2))
+    if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 2))
         throw runtime_error(
             "walletpassphrase \"passphrase\" timeout\n"
             "\nStores the wallet decryption key in memory for 'timeout' seconds.\n"
@@ -2196,11 +2229,11 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
             + HelpExampleRpc("walletpassphrase", "\"my pass phrase\", 60")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.fHelp)
         return true;
-    if (!pwalletMain->IsCrypted())
+    if (!pwallet->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrase was called.");
 
     // Note that the walletpassphrase is stored in request.params[0] which is not mlock()ed
@@ -2212,7 +2245,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
     if (strWalletPass.length() > 0)
     {
-        if (!pwalletMain->Unlock(strWalletPass))
+        if (!pwallet->Unlock(strWalletPass))
             throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
     }
     else
@@ -2220,12 +2253,12 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
             "walletpassphrase <passphrase> <timeout>\n"
             "Stores the wallet decryption key in memory for <timeout> seconds.");
 
-    pwalletMain->TopUpKeyPool();
+    pwallet->TopUpKeyPool();
 
     int64_t nSleepTime = request.params[1].get_int64();
     LOCK(cs_nWalletUnlockTime);
     nWalletUnlockTime = GetTime() + nSleepTime;
-    RPCRunLater("lockwallet", boost::bind(LockWallet, pwalletMain), nSleepTime);
+    RPCRunLater("lockwallet", boost::bind(LockWallet, pwallet), nSleepTime);
 
     return NullUniValue;
 }
@@ -2233,10 +2266,11 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
 UniValue walletpassphrasechange(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
-    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() != 2))
+    if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 2))
         throw runtime_error(
             "walletpassphrasechange \"oldpassphrase\" \"newpassphrase\"\n"
             "\nChanges the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.\n"
@@ -2248,11 +2282,11 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
             + HelpExampleRpc("walletpassphrasechange", "\"old one\", \"new one\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.fHelp)
         return true;
-    if (!pwalletMain->IsCrypted())
+    if (!pwallet->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletpassphrasechange was called.");
 
     // TODO: get rid of these .c_str() calls by implementing SecureString::operator=(std::string)
@@ -2270,7 +2304,7 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
             "walletpassphrasechange <oldpassphrase> <newpassphrase>\n"
             "Changes the wallet passphrase from <oldpassphrase> to <newpassphrase>.");
 
-    if (!pwalletMain->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass))
+    if (!pwallet->ChangeWalletPassphrase(strOldWalletPass, strNewWalletPass))
         throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: The wallet passphrase entered was incorrect.");
 
     return NullUniValue;
@@ -2279,10 +2313,11 @@ UniValue walletpassphrasechange(const JSONRPCRequest& request)
 
 UniValue walletlock(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
-    if (pwalletMain->IsCrypted() && (request.fHelp || request.params.size() != 0))
+    if (pwallet->IsCrypted() && (request.fHelp || request.params.size() != 0))
         throw runtime_error(
             "walletlock\n"
             "\nRemoves the wallet encryption key from memory, locking the wallet.\n"
@@ -2299,16 +2334,16 @@ UniValue walletlock(const JSONRPCRequest& request)
             + HelpExampleRpc("walletlock", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.fHelp)
         return true;
-    if (!pwalletMain->IsCrypted())
+    if (!pwallet->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an unencrypted wallet, but walletlock was called.");
 
     {
         LOCK(cs_nWalletUnlockTime);
-        pwalletMain->Lock();
+        pwallet->Lock();
         nWalletUnlockTime = 0;
     }
 
@@ -2318,10 +2353,11 @@ UniValue walletlock(const JSONRPCRequest& request)
 
 UniValue encryptwallet(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
-    if (!pwalletMain->IsCrypted() && (request.fHelp || request.params.size() != 1))
+    if (!pwallet->IsCrypted() && (request.fHelp || request.params.size() != 1))
         throw runtime_error(
             "encryptwallet \"passphrase\"\n"
             "\nEncrypts the wallet with 'passphrase'. This is for first time encryption.\n"
@@ -2345,11 +2381,11 @@ UniValue encryptwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("encryptwallet", "\"my pass phrase\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.fHelp)
         return true;
-    if (pwalletMain->IsCrypted())
+    if (pwallet->IsCrypted())
         throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: running with an encrypted wallet, but encryptwallet was called.");
 
     // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
@@ -2363,7 +2399,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
             "encryptwallet <passphrase>\n"
             "Encrypts the wallet with <passphrase>.");
 
-    if (!pwalletMain->EncryptWallet(strWalletPass))
+    if (!pwallet->EncryptWallet(strWalletPass))
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
 
     // BDB seems to have a bad habit of writing old data into
@@ -2375,7 +2411,8 @@ UniValue encryptwallet(const JSONRPCRequest& request)
 
 UniValue lockunspent(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -2415,7 +2452,7 @@ UniValue lockunspent(const JSONRPCRequest& request)
             + HelpExampleRpc("lockunspent", "false, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     if (request.params.size() == 1)
         RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VBOOL));
@@ -2426,7 +2463,7 @@ UniValue lockunspent(const JSONRPCRequest& request)
 
     if (request.params.size() == 1) {
         if (fUnlock)
-            pwalletMain->UnlockAllCoins();
+            pwallet->UnlockAllCoins();
         return true;
     }
 
@@ -2454,9 +2491,9 @@ UniValue lockunspent(const JSONRPCRequest& request)
         COutPoint outpt(uint256S(txid), nOutput);
 
         if (fUnlock)
-            pwalletMain->UnlockCoin(outpt);
+            pwallet->UnlockCoin(outpt);
         else
-            pwalletMain->LockCoin(outpt);
+            pwallet->LockCoin(outpt);
     }
 
     return true;
@@ -2464,7 +2501,8 @@ UniValue lockunspent(const JSONRPCRequest& request)
 
 UniValue listlockunspent(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 0)
@@ -2493,10 +2531,10 @@ UniValue listlockunspent(const JSONRPCRequest& request)
             + HelpExampleRpc("listlockunspent", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     vector<COutPoint> vOutpts;
-    pwalletMain->ListLockedCoins(vOutpts);
+    pwallet->ListLockedCoins(vOutpts);
 
     UniValue ret(UniValue::VARR);
 
@@ -2513,7 +2551,8 @@ UniValue listlockunspent(const JSONRPCRequest& request)
 
 UniValue settxfee(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
@@ -2529,7 +2568,7 @@ UniValue settxfee(const JSONRPCRequest& request)
             + HelpExampleRpc("settxfee", "0.00001")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     // Amount
     CAmount nAmount = AmountFromValue(request.params[0]);
@@ -2540,7 +2579,8 @@ UniValue settxfee(const JSONRPCRequest& request)
 
 UniValue getwalletinfo(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 0)
@@ -2565,20 +2605,20 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             + HelpExampleRpc("getwalletinfo", "")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
     UniValue obj(UniValue::VOBJ);
-    obj.pushKV("walletversion", pwalletMain->GetVersion());
-    obj.pushKV("balance",       ValueFromAmount(pwalletMain->GetBalance()));
-    obj.pushKV("unconfirmed_balance", ValueFromAmount(pwalletMain->GetUnconfirmedBalance()));
-    obj.pushKV("immature_balance",    ValueFromAmount(pwalletMain->GetImmatureBalance()));
-    obj.pushKV("txcount",       (int)pwalletMain->mapWallet.size());
-    obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
-    obj.pushKV("keypoolsize",   (int)pwalletMain->GetKeyPoolSize());
-    if (pwalletMain->IsCrypted())
+    obj.pushKV("walletversion", pwallet->GetVersion());
+    obj.pushKV("balance",       ValueFromAmount(pwallet->GetBalance()));
+    obj.pushKV("unconfirmed_balance", ValueFromAmount(pwallet->GetUnconfirmedBalance()));
+    obj.pushKV("immature_balance",    ValueFromAmount(pwallet->GetImmatureBalance()));
+    obj.pushKV("txcount",       (int)pwallet->mapWallet.size());
+    obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
+    obj.pushKV("keypoolsize",   (int)pwallet->GetKeyPoolSize());
+    if (pwallet->IsCrypted())
         obj.pushKV("unlocked_until", nWalletUnlockTime);
     obj.pushKV("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK()));
-    CKeyID masterKeyID = pwalletMain->GetHDChain().masterKeyID;
+    CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
     if (!masterKeyID.IsNull())
          obj.pushKV("hdmasterkeyid", masterKeyID.GetHex());
     return obj;
@@ -2586,7 +2626,8 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
 
 UniValue resendwallettransactions(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 0)
@@ -2601,9 +2642,9 @@ UniValue resendwallettransactions(const JSONRPCRequest& request)
     if (!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    std::vector<uint256> txids = pwalletMain->ResendWalletTransactionsBefore(GetTime(), g_connman.get());
+    std::vector<uint256> txids = pwallet->ResendWalletTransactionsBefore(GetTime(), g_connman.get());
     UniValue result(UniValue::VARR);
     BOOST_FOREACH(const uint256& txid, txids)
     {
@@ -2614,7 +2655,8 @@ UniValue resendwallettransactions(const JSONRPCRequest& request)
 
 UniValue listunspent(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() > 5)
@@ -2723,10 +2765,10 @@ UniValue listunspent(const JSONRPCRequest& request)
 
     UniValue results(UniValue::VARR);
     vector<COutput> vecOutputs;
-    assert(pwalletMain != NULL);
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    assert(pwallet != NULL);
+    LOCK2(cs_main, pwallet->cs_wallet);
 
-    pwalletMain->AvailableCoins(vecOutputs, !include_unsafe, NULL, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
+    pwallet->AvailableCoins(vecOutputs, !include_unsafe, NULL, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
     BOOST_FOREACH(const COutput& out, vecOutputs) {
         CTxDestination address;
         const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
@@ -2742,13 +2784,13 @@ UniValue listunspent(const JSONRPCRequest& request)
         if (fValidAddress) {
             entry.pushKV("address", CBitcoinAddress(address).ToString());
 
-            if (pwalletMain->mapAddressBook.count(address))
-                entry.pushKV("account", pwalletMain->mapAddressBook[address].name);
+            if (pwallet->mapAddressBook.count(address))
+                entry.pushKV("account", pwallet->mapAddressBook[address].name);
 
             if (scriptPubKey.IsPayToScriptHash()) {
                 const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
-                if (pwalletMain->GetCScript(hash, redeemScript))
+                if (pwallet->GetCScript(hash, redeemScript))
                     entry.pushKV("redeemScript", HexStr(redeemScript.begin(), redeemScript.end()));
             }
         }
@@ -2766,7 +2808,8 @@ UniValue listunspent(const JSONRPCRequest& request)
 
 UniValue fundrawtransaction(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp))
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -2908,7 +2951,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     CAmount nFeeOut;
     string strFailReason;
 
-    if(!pwalletMain->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey, changeAddress))
+    if(!pwallet->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, setSubtractFeeFromOutputs, reserveChangeKey, changeAddress))
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
 
     UniValue result(UniValue::VOBJ);
@@ -2926,7 +2969,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
 // calculation, but we should be able to refactor after priority is removed).
 // NOTE: this requires that all inputs must be in mapWallet (eg the tx should
 // be IsAllFromMe).
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx)
+int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, CWallet * const pwallet)
 {
     CMutableTransaction txNew(tx);
     std::vector<pair<CWalletTx *, unsigned int>> vCoins;
@@ -2934,11 +2977,11 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx)
     // IsAllFromMe(ISMINE_SPENDABLE), so every input should already be in our
     // wallet, with a valid index into the vout array.
     for (auto& input : tx.vin) {
-        const auto mi = pwalletMain->mapWallet.find(input.prevout.hash);
-        assert(mi != pwalletMain->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
+        const auto mi = pwallet->mapWallet.find(input.prevout.hash);
+        assert(mi != pwallet->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
         vCoins.emplace_back(make_pair(&(mi->second), input.prevout.n));
     }
-    if (!pwalletMain->DummySignTx(txNew, vCoins)) {
+    if (!pwallet->DummySignTx(txNew, vCoins)) {
         // This should never happen, because IsAllFromMe(ISMINE_SPENDABLE)
         // implies that we can sign for every input.
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction contains inputs that cannot be signed");
@@ -2948,7 +2991,8 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx)
 
 UniValue bumpfee(const JSONRPCRequest& request)
 {
-    if (!EnsureWalletIsAvailable(request.fHelp)) {
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
         return NullUniValue;
     }
 
@@ -3000,14 +3044,14 @@ UniValue bumpfee(const JSONRPCRequest& request)
     hash.SetHex(request.params[0].get_str());
 
     // retrieve the original tx from the wallet
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    EnsureWalletIsUnlocked();
-    if (!pwalletMain->mapWallet.count(hash)) {
+    LOCK2(cs_main, pwallet->cs_wallet);
+    EnsureWalletIsUnlocked(pwallet);
+    if (!pwallet->mapWallet.count(hash)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     }
-    CWalletTx& wtx = pwalletMain->mapWallet[hash];
+    CWalletTx& wtx = pwallet->mapWallet[hash];
 
-    if (pwalletMain->HasWalletSpend(hash)) {
+    if (pwallet->HasWalletSpend(hash)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Transaction has descendants in the wallet");
     }
 
@@ -3033,7 +3077,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
 
     // check that original tx consists entirely of our inputs
     // if not, we can't bump the fee, because the wallet has no way of knowing the value of the other inputs (thus the fee)
-    if (!pwalletMain->IsAllFromMe(wtx, ISMINE_SPENDABLE)) {
+    if (!pwallet->IsAllFromMe(wtx, ISMINE_SPENDABLE)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Transaction contains inputs that don't belong to this wallet");
     }
 
@@ -3041,7 +3085,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     // if there was no change output or multiple change outputs, fail
     int nOutput = -1;
     for (size_t i = 0; i < wtx.tx->vout.size(); ++i) {
-        if (pwalletMain->IsChange(wtx.tx->vout[i])) {
+        if (pwallet->IsChange(wtx.tx->vout[i])) {
             if (nOutput != -1) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Transaction has multiple change outputs");
             }
@@ -3058,7 +3102,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     if (txSize % 1024 != 0) {
         txSize = txSize + 1024 - (txSize % 1024);
     }
-    const int64_t maxNewTxSize = CalculateMaximumSignedTxSize(*wtx.tx);
+    const int64_t maxNewTxSize = CalculateMaximumSignedTxSize(*wtx.tx, pwallet);
 
     // optional parameters
     bool specifiedConfirmTarget = false;
@@ -3188,12 +3232,12 @@ UniValue bumpfee(const JSONRPCRequest& request)
     CTransaction txNewConst(tx);
     int nIn = 0;
     for (auto& input : tx.vin) {
-        std::map<uint256, CWalletTx>::const_iterator mi = pwalletMain->mapWallet.find(input.prevout.hash);
-        assert(mi != pwalletMain->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
+        std::map<uint256, CWalletTx>::const_iterator mi = pwallet->mapWallet.find(input.prevout.hash);
+        assert(mi != pwallet->mapWallet.end() && input.prevout.n < mi->second.tx->vout.size());
         const CScript& scriptPubKey = mi->second.tx->vout[input.prevout.n].scriptPubKey;
         const CAmount& amount = mi->second.tx->vout[input.prevout.n].nValue;
         SignatureData sigdata;
-        if (!ProduceSignature(TransactionSignatureCreator(pwalletMain, &txNewConst, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata)) {
+        if (!ProduceSignature(TransactionSignatureCreator(pwallet, &txNewConst, nIn, amount, SIGHASH_ALL), scriptPubKey, sigdata)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Can't sign transaction.");
         }
         UpdateTransaction(tx, nIn, sigdata);
@@ -3201,8 +3245,8 @@ UniValue bumpfee(const JSONRPCRequest& request)
     }
 
     // commit/broadcast the tx
-    CReserveKey reservekey(pwalletMain);
-    CWalletTx wtxBumped(pwalletMain, MakeTransactionRef(std::move(tx)));
+    CReserveKey reservekey(pwallet);
+    CWalletTx wtxBumped(pwallet, MakeTransactionRef(std::move(tx)));
     wtxBumped.mapValue = wtx.mapValue;
     wtxBumped.mapValue["replaces_txid"] = hash.ToString();
     wtxBumped.vOrderForm = wtx.vOrderForm;
@@ -3210,7 +3254,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     wtxBumped.fTimeReceivedIsTxTime = true;
     wtxBumped.fFromMe = true;
     CValidationState state;
-    if (!pwalletMain->CommitTransaction(wtxBumped, reservekey, g_connman.get(), state)) {
+    if (!pwallet->CommitTransaction(wtxBumped, reservekey, g_connman.get(), state)) {
         // NOTE: CommitTransaction never returns false, so this should never happen.
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Error: The transaction was rejected! Reason given: %s", state.GetRejectReason()));
     }
@@ -3223,7 +3267,7 @@ UniValue bumpfee(const JSONRPCRequest& request)
     }
 
     // mark the original tx as bumped
-    if (!pwalletMain->MarkReplaced(wtx.GetHash(), wtxBumped.GetHash())) {
+    if (!pwallet->MarkReplaced(wtx.GetHash(), wtxBumped.GetHash())) {
         // TODO: see if JSON-RPC has a standard way of returning a response
         // along with an exception. It would be good to return information about
         // wtxBumped to the caller even if marking the original transaction

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2718,6 +2718,66 @@ UniValue loadwallet(const JSONRPCRequest& request)
     return obj;
 }
 
+UniValue unloadwallet(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 1)
+        throw runtime_error(
+            "unloadwallet ( \"wallet_name\" )\n"
+            "\nDetaches a wallet from the running node. The wallet file remains\n"
+            "on disk and can be reattached later with loadwallet.\n"
+            "\nWhen no wallet_name is supplied the wallet is taken from the\n"
+            "/wallet/<name> request URI.\n"
+            "\nArguments:\n"
+            "1. \"wallet_name\"    (string, optional) The wallet name to unload.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("unloadwallet", "\"trading.dat\"")
+            + HelpExampleRpc("unloadwallet", "\"trading.dat\"")
+        );
+
+    std::string wallet_name;
+    if (request.params.size() == 1) {
+        wallet_name = request.params[0].get_str();
+    } else {
+        CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+        if (!pwallet) {
+            throw JSONRPCError(RPC_WALLET_NOT_SPECIFIED, "Wallet name must be provided either as an argument or through the /wallet/<name> URI.");
+        }
+        wallet_name = pwallet->GetName();
+    }
+
+    std::vector<CWalletRef>::iterator it = vpwallets.end();
+    for (auto i = vpwallets.begin(); i != vpwallets.end(); ++i) {
+        if ((*i)->GetName() == wallet_name) {
+            it = i;
+            break;
+        }
+    }
+    if (it == vpwallets.end()) {
+        throw JSONRPCError(RPC_WALLET_NOT_FOUND, strprintf("Wallet %s is not loaded.", wallet_name));
+    }
+
+    CWallet * const pwallet = *it;
+
+    // Serialise against concurrent wallet activity before tearing things down.
+    // This is not bulletproof — dogecoin's wallet handles are raw pointers
+    // and an in-flight wallet RPC on this wallet could still race the delete
+    // below. Production callers should quiesce traffic to the wallet first.
+    {
+        LOCK2(cs_main, pwallet->cs_wallet);
+        pwallet->Flush(true);
+    }
+    UnregisterValidationInterface(pwallet);
+    bitdb.CloseDb(pwallet->strWalletFile);
+
+    vpwallets.erase(it);
+    if (pwalletMain == pwallet) {
+        pwalletMain = vpwallets.empty() ? nullptr : vpwallets.front();
+    }
+    delete pwallet;
+
+    return NullUniValue;
+}
+
 UniValue createwallet(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
@@ -3474,6 +3534,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listwallets",              &listwallets,              true,   {} },
     { "wallet",             "loadwallet",               &loadwallet,               true,   {"filename"} },
     { "wallet",             "createwallet",             &createwallet,             true,   {"filename"} },
+    { "wallet",             "unloadwallet",             &unloadwallet,             true,   {"wallet_name"} },
     { "wallet",             "listlockunspent",          &listlockunspent,          false,  {} },
     { "wallet",             "listreceivedbyaccount",    &listreceivedbyaccount,    false,  {"minconf","include_empty","include_watchonly"} },
     { "wallet",             "listreceivedbyaddress",    &listreceivedbyaddress,    false,  {"minconf","include_empty","include_watchonly"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -42,6 +42,11 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
         std::string requestedWallet = request.URI.substr(WALLET_ENDPOINT_BASE.size());
+        // Tolerate /wallet/<name>/ as well as /wallet/<name>: callers often
+        // accidentally append a trailing slash.
+        while (!requestedWallet.empty() && requestedWallet.back() == '/') {
+            requestedWallet.pop_back();
+        }
         for (CWalletRef pwallet : ::vpwallets) {
             if (pwallet->GetName() == requestedWallet) {
                 return pwallet;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2714,8 +2714,15 @@ UniValue loadwallet(const JSONRPCRequest& request)
     // form based on what already exists on disk.
     const std::string dbFile = WalletDataFileName(walletFile);
 
-    // Verify the wallet file under the already-open BDB environment.
-    CDBEnv::VerifyResult r = bitdb.Verify(dbFile, CWalletDB::Recover);
+    // Resolve THIS wallet's env (per-wallet in the multi-env world)
+    // and Verify against it. Each directory-layout wallet lives in
+    // its own env under <walletdir>/<name>/.
+    std::string dbFilename;
+    CDBEnv* env = GetWalletEnv(GetWalletDir() / dbFile, dbFilename);
+    if (!env->Open(false /* retry */)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Failed to open wallet env for %s", walletFile));
+    }
+    CDBEnv::VerifyResult r = env->Verify(dbFilename, CWalletDB::Recover);
     if (r == CDBEnv::RECOVER_FAIL) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("%s corrupt, salvage failed", walletFile));
     }
@@ -2792,20 +2799,29 @@ UniValue unloadwallet(const JSONRPCRequest& request)
     // and an in-flight wallet RPC on this wallet could still race the delete
     // below. Production callers should quiesce traffic to the wallet first.
     //
-    // Note: do NOT call pwallet->Flush(true) here. CWallet::Flush delegates to
-    // CDBEnv::Flush which is env-wide; passing true would shut down the
-    // shared BerkeleyDB environment for every loaded wallet. CloseDb closes
-    // just this wallet's file handle, and BDB's DB_AUTO_COMMIT guarantees
+    // Note: do NOT call pwallet->Flush(true) here. CWallet::Flush
+    // delegates to CDBEnv::Flush which is env-wide; passing true would
+    // shut down THIS wallet's BerkeleyDB environment (in the multi-env
+    // world that may host other wallets in the same directory — e.g.
+    // legacy flat wallets all share the walletdir env). CloseDb closes
+    // just this wallet's Db handle, and BDB's DB_AUTO_COMMIT guarantees
     // the data is on disk by then.
     {
         LOCK2(cs_main, pwallet->cs_wallet);
     }
     UnregisterValidationInterface(pwallet);
-    bitdb.CloseDb(pwallet->strWalletFile);
+
+    // Resolve THIS wallet's env from its strWalletFile (BDB-relative
+    // path) and close+flush this file within it. Other wallets sharing
+    // the same env (or wallets in entirely different envs) are
+    // unaffected.
+    std::string dbFilename;
+    CDBEnv* env = GetWalletEnv(GetWalletDir() / pwallet->strWalletFile, dbFilename);
+    env->CloseDb(dbFilename);
     // CDBEnv::Verify asserts that the file is not in mapFileUseCount, so we
     // have to evict the (now refcount-0) entry before a future loadwallet
-    // can verify this same file. Flush(false) does that across the env.
-    bitdb.Flush(false);
+    // can verify this same file. Flush(false) on the env does that.
+    env->Flush(false);
 
     vpwallets.erase(it);
     if (pwalletMain == pwallet) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "wallet.h"
+#include "wallet/rpcwallet.h"
 #include "wallet/rpcutil.h"
 #include "walletdb.h"
 
@@ -34,29 +35,59 @@ using namespace std;
 int64_t nWalletUnlockTime;
 static CCriticalSection cs_nWalletUnlockTime;
 
-std::string HelpRequiringPassphrase()
+const std::string WALLET_ENDPOINT_BASE = "/wallet/";
+
+CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
-    return pwalletMain && pwalletMain->IsCrypted()
+    if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
+        // wallet endpoint was used
+        std::string requestedWallet = request.URI.substr(WALLET_ENDPOINT_BASE.size());
+        for (CWalletRef pwallet : ::vpwallets) {
+            if (pwallet->GetName() == requestedWallet) {
+                return pwallet;
+            }
+        }
+        throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
+    }
+    return ::vpwallets.size() == 1 || (request.fHelp && ::vpwallets.size() > 0) ? ::vpwallets[0] : nullptr;
+}
+
+std::string HelpRequiringPassphrase(CWallet * const pwallet)
+{
+    return pwallet && pwallet->IsCrypted()
         ? "\nRequires wallet passphrase to be set with walletpassphrase call."
         : "";
 }
 
-bool EnsureWalletIsAvailable(bool avoidException)
+std::string HelpRequiringPassphrase()
 {
-    if (!pwalletMain)
-    {
+    return HelpRequiringPassphrase(pwalletMain);
+}
+
+bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
+{
+    if (!pwallet) {
         if (!avoidException)
-            throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
-        else
-            return false;
+            throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (wallet method is disabled because no wallet is loaded)");
+        return false;
     }
     return true;
 }
 
+bool EnsureWalletIsAvailable(bool avoidException)
+{
+    return EnsureWalletIsAvailable(pwalletMain, avoidException);
+}
+
+void EnsureWalletIsUnlocked(CWallet * const pwallet)
+{
+    if (pwallet->IsLocked())
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+}
+
 void EnsureWalletIsUnlocked()
 {
-    if (pwalletMain->IsLocked())
-        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+    EnsureWalletIsUnlocked(pwalletMain);
 }
 
 void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2680,14 +2680,20 @@ UniValue loadwallet(const JSONRPCRequest& request)
 
     std::string walletFile = request.params[0].get_str();
 
-    // Validate the wallet file name. Plain filenames only, no directory
-    // components — matches CWallet::Verify's startup rule.
+    // Validate the wallet name. Plain single-segment names only — we
+    // build any directory layout ourselves via WalletDataFileName,
+    // user input never carries path separators. Matches Verify().
     fs::path walletPath(walletFile);
-    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetDataDir().string()));
+    if (walletPath.has_parent_path() ||
+        walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetWalletDir().string()));
     }
 
-    // Reject if already loaded.
+    // Reject if already loaded. GetName() returns the user-facing
+    // name (m_name), which for directory wallets is the directory
+    // (e.g. "unsandbox" given on-disk "unsandbox/wallet.dat") — so
+    // comparing directly to the user input here works for both
+    // layouts.
     for (CWalletRef pwallet : vpwallets) {
         if (pwallet->GetName() == walletFile) {
             throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s is already loaded.", walletFile));
@@ -2696,18 +2702,25 @@ UniValue loadwallet(const JSONRPCRequest& request)
 
     // Refuse to silently create a brand new wallet when the caller asked us
     // to load one. Use createwallet for that — matches upstream bitcoin 0.17
-    // loadwallet semantics.
-    if (!fs::exists(GetDataDir() / walletFile)) {
+    // loadwallet semantics. WalletDataFilePath is migration-aware so a
+    // wallet present on disk in EITHER layout (flat <name> or directory
+    // <name>/wallet.dat) satisfies this check.
+    if (!fs::exists(WalletDataFilePath(walletFile))) {
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, strprintf("Wallet %s not found.", walletFile));
     }
 
+    // Resolve the BDB-relative path once and reuse for Verify + the
+    // CWallet construction. WalletDataFileName picks flat or directory
+    // form based on what already exists on disk.
+    const std::string dbFile = WalletDataFileName(walletFile);
+
     // Verify the wallet file under the already-open BDB environment.
-    CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
+    CDBEnv::VerifyResult r = bitdb.Verify(dbFile, CWalletDB::Recover);
     if (r == CDBEnv::RECOVER_FAIL) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("%s corrupt, salvage failed", walletFile));
     }
 
-    CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
+    CWallet * const pwallet = CWallet::CreateWalletFromFile(dbFile);
     if (!pwallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet loading failed for %s.", walletFile));
     }
@@ -2827,11 +2840,18 @@ UniValue createwallet(const JSONRPCRequest& request)
     std::string walletFile = request.params[0].get_str();
 
     fs::path walletPath(walletFile);
-    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetDataDir().string()));
+    if (walletPath.has_parent_path() ||
+        walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetWalletDir().string()));
     }
 
-    if (fs::exists(GetDataDir() / walletFile)) {
+    // WalletDataFilePath resolves to <walletdir>/<name>/wallet.dat for
+    // directory-layout names (no-extension) when the directory either
+    // doesn't exist yet or already exists as a dir; it resolves to a
+    // flat <walletdir>/<name> when a regular file is already squatting
+    // (migration-friendly). So fs::exists here catches BOTH layouts
+    // and refuses to clobber an existing wallet of either shape.
+    if (fs::exists(WalletDataFilePath(walletFile))) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s already exists.", walletFile));
     }
 
@@ -2841,7 +2861,15 @@ UniValue createwallet(const JSONRPCRequest& request)
         }
     }
 
-    CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
+    // mkdir <walletdir>/<name>/ for directory-layout names before BDB
+    // tries to open <name>/wallet.dat. No-op for flat names.
+    if (!EnsureWalletDirectoryExists(walletFile)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Failed to create wallet directory for %s.", walletFile));
+    }
+
+    const std::string dbFile = WalletDataFileName(walletFile);
+
+    CWallet * const pwallet = CWallet::CreateWalletFromFile(dbFile);
     if (!pwallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet creation failed for %s.", walletFile));
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2654,6 +2654,70 @@ UniValue listwallets(const JSONRPCRequest& request)
     return obj;
 }
 
+UniValue loadwallet(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw runtime_error(
+            "loadwallet \"filename\"\n"
+            "\nLoads a wallet file into the running node and registers it for\n"
+            "RPC use at /wallet/<filename>.\n"
+            "\nArguments:\n"
+            "1. \"filename\"    (string, required) The wallet file name (within the data directory).\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"name\" :    <wallet_name>,  (string) The wallet name.\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("loadwallet", "\"second.dat\"")
+            + HelpExampleRpc("loadwallet", "\"second.dat\"")
+        );
+
+    if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet support is disabled (-disablewallet)");
+    }
+
+    std::string walletFile = request.params[0].get_str();
+
+    // Validate the wallet file name. Plain filenames only, no directory
+    // components — matches CWallet::Verify's startup rule.
+    fs::path walletPath(walletFile);
+    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetDataDir().string()));
+    }
+
+    // Reject if already loaded.
+    for (CWalletRef pwallet : vpwallets) {
+        if (pwallet->GetName() == walletFile) {
+            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s is already loaded.", walletFile));
+        }
+    }
+
+    // Verify the wallet file under the already-open BDB environment.
+    if (fs::exists(GetDataDir() / walletFile)) {
+        CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
+        if (r == CDBEnv::RECOVER_FAIL) {
+            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("%s corrupt, salvage failed", walletFile));
+        }
+    }
+
+    CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
+    if (!pwallet) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet loading failed for %s.", walletFile));
+    }
+    vpwallets.push_back(pwallet);
+
+    // Replay any wallet transactions that aren't already in the mempool.
+    // We deliberately do not call postInitProcess(threadGroup) here: the
+    // periodic flush thread is already running and covers every entry in
+    // vpwallets (see ThreadFlushWalletDB), and there is no thread group
+    // accessible from RPC context.
+    pwallet->ReacceptWalletTransactions();
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("name", pwallet->GetName());
+    return obj;
+}
+
 UniValue resendwallettransactions(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -3358,6 +3422,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listaccounts",             &listaccounts,             false,  {"minconf","include_watchonly"} },
     { "wallet",             "listaddressgroupings",     &listaddressgroupings,     false,  {} },
     { "wallet",             "listwallets",              &listwallets,              true,   {} },
+    { "wallet",             "loadwallet",               &loadwallet,               true,   {"filename"} },
     { "wallet",             "listlockunspent",          &listlockunspent,          false,  {} },
     { "wallet",             "listreceivedbyaccount",    &listreceivedbyaccount,    false,  {"minconf","include_empty","include_watchonly"} },
     { "wallet",             "listreceivedbyaddress",    &listreceivedbyaddress,    false,  {"minconf","include_empty","include_watchonly"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2718,6 +2718,56 @@ UniValue loadwallet(const JSONRPCRequest& request)
     return obj;
 }
 
+UniValue createwallet(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw runtime_error(
+            "createwallet \"filename\"\n"
+            "\nCreates a new wallet file inside the data directory and loads it.\n"
+            "\nArguments:\n"
+            "1. \"filename\"    (string, required) The wallet file name (within the data directory).\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"name\" :    <wallet_name>,  (string) The wallet name.\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("createwallet", "\"trading.dat\"")
+            + HelpExampleRpc("createwallet", "\"trading.dat\"")
+        );
+
+    if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet support is disabled (-disablewallet)");
+    }
+
+    std::string walletFile = request.params[0].get_str();
+
+    fs::path walletPath(walletFile);
+    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s resides outside data directory %s", walletFile, GetDataDir().string()));
+    }
+
+    if (fs::exists(GetDataDir() / walletFile)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s already exists.", walletFile));
+    }
+
+    for (CWalletRef pwallet : vpwallets) {
+        if (pwallet->GetName() == walletFile) {
+            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet %s is already loaded.", walletFile));
+        }
+    }
+
+    CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
+    if (!pwallet) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Wallet creation failed for %s.", walletFile));
+    }
+    vpwallets.push_back(pwallet);
+    pwallet->ReacceptWalletTransactions();
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("name", pwallet->GetName());
+    return obj;
+}
+
 UniValue resendwallettransactions(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -3423,6 +3473,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listaddressgroupings",     &listaddressgroupings,     false,  {} },
     { "wallet",             "listwallets",              &listwallets,              true,   {} },
     { "wallet",             "loadwallet",               &loadwallet,               true,   {"filename"} },
+    { "wallet",             "createwallet",             &createwallet,             true,   {"filename"} },
     { "wallet",             "listlockunspent",          &listlockunspent,          false,  {} },
     { "wallet",             "listreceivedbyaccount",    &listreceivedbyaccount,    false,  {"minconf","include_empty","include_watchonly"} },
     { "wallet",             "listreceivedbyaddress",    &listreceivedbyaddress,    false,  {"minconf","include_empty","include_watchonly"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -71,12 +71,14 @@ std::string HelpRequiringPassphrase()
 
 bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
-    if (!pwallet) {
-        if (!avoidException)
-            throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (wallet method is disabled because no wallet is loaded)");
-        return false;
+    if (pwallet) return true;
+    if (avoidException) return false;
+    if (vpwallets.empty()) {
+        // no wallets loaded at all (e.g. -disablewallet)
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (wallet method is disabled because no wallet is loaded)");
     }
-    return true;
+    // more than one wallet is loaded and the caller didn't pick one
+    throw JSONRPCError(RPC_WALLET_NOT_SPECIFIED, "Wallet file not specified (must request wallet RPC through /wallet/<filename> uri-path).");
 }
 
 bool EnsureWalletIsAvailable(bool avoidException)
@@ -2692,12 +2694,17 @@ UniValue loadwallet(const JSONRPCRequest& request)
         }
     }
 
+    // Refuse to silently create a brand new wallet when the caller asked us
+    // to load one. Use createwallet for that — matches upstream bitcoin 0.17
+    // loadwallet semantics.
+    if (!fs::exists(GetDataDir() / walletFile)) {
+        throw JSONRPCError(RPC_WALLET_NOT_FOUND, strprintf("Wallet %s not found.", walletFile));
+    }
+
     // Verify the wallet file under the already-open BDB environment.
-    if (fs::exists(GetDataDir() / walletFile)) {
-        CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
-        if (r == CDBEnv::RECOVER_FAIL) {
-            throw JSONRPCError(RPC_WALLET_ERROR, strprintf("%s corrupt, salvage failed", walletFile));
-        }
+    CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
+    if (r == CDBEnv::RECOVER_FAIL) {
+        throw JSONRPCError(RPC_WALLET_ERROR, strprintf("%s corrupt, salvage failed", walletFile));
     }
 
     CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
@@ -2734,9 +2741,18 @@ UniValue unloadwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("unloadwallet", "\"trading.dat\"")
         );
 
+    // Resolve the wallet name from either the explicit arg or the
+    // /wallet/<name> URI. If both are present they must match.
     std::string wallet_name;
+    bool uri_used = request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE;
     if (request.params.size() == 1) {
         wallet_name = request.params[0].get_str();
+        if (uri_used) {
+            CWallet * const uri_wallet = GetWalletForJSONRPCRequest(request);
+            if (uri_wallet && uri_wallet->GetName() != wallet_name) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot unload the requested wallet: the /wallet/<name> endpoint and the wallet_name argument refer to different wallets.");
+            }
+        }
     } else {
         CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
         if (!pwallet) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2624,6 +2624,31 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     return obj;
 }
 
+UniValue listwallets(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw runtime_error(
+            "listwallets\n"
+            "Returns a list of currently loaded wallets.\n"
+            "For full information on the wallet, use \"getwalletinfo\"\n"
+            "\nResult:\n"
+            "[                         (json array of strings)\n"
+            "  \"walletname\"            (string) the wallet name\n"
+            "   ...\n"
+            "]\n"
+            "\nExamples:\n"
+            + HelpExampleCli("listwallets", "")
+            + HelpExampleRpc("listwallets", "")
+        );
+
+    UniValue obj(UniValue::VARR);
+    for (CWalletRef pwallet : vpwallets) {
+        LOCK(pwallet->cs_wallet);
+        obj.push_back(pwallet->GetName());
+    }
+    return obj;
+}
+
 UniValue resendwallettransactions(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -3327,6 +3352,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "keypoolrefill",            &keypoolrefill,            true,   {"newsize"} },
     { "wallet",             "listaccounts",             &listaccounts,             false,  {"minconf","include_watchonly"} },
     { "wallet",             "listaddressgroupings",     &listaddressgroupings,     false,  {} },
+    { "wallet",             "listwallets",              &listwallets,              true,   {} },
     { "wallet",             "listlockunspent",          &listlockunspent,          false,  {} },
     { "wallet",             "listreceivedbyaccount",    &listreceivedbyaccount,    false,  {"minconf","include_empty","include_watchonly"} },
     { "wallet",             "listreceivedbyaddress",    &listreceivedbyaddress,    false,  {"minconf","include_empty","include_watchonly"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2762,12 +2762,21 @@ UniValue unloadwallet(const JSONRPCRequest& request)
     // This is not bulletproof — dogecoin's wallet handles are raw pointers
     // and an in-flight wallet RPC on this wallet could still race the delete
     // below. Production callers should quiesce traffic to the wallet first.
+    //
+    // Note: do NOT call pwallet->Flush(true) here. CWallet::Flush delegates to
+    // CDBEnv::Flush which is env-wide; passing true would shut down the
+    // shared BerkeleyDB environment for every loaded wallet. CloseDb closes
+    // just this wallet's file handle, and BDB's DB_AUTO_COMMIT guarantees
+    // the data is on disk by then.
     {
         LOCK2(cs_main, pwallet->cs_wallet);
-        pwallet->Flush(true);
     }
     UnregisterValidationInterface(pwallet);
     bitdb.CloseDb(pwallet->strWalletFile);
+    // CDBEnv::Verify asserts that the file is not in mapFileUseCount, so we
+    // have to evict the (now refcount-0) entry before a future loadwallet
+    // can verify this same file. Flush(false) does that across the env.
+    bitdb.Flush(false);
 
     vpwallets.erase(it);
     if (pwalletMain == pwallet) {

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -5,8 +5,36 @@
 #ifndef BITCOIN_WALLET_RPCWALLET_H
 #define BITCOIN_WALLET_RPCWALLET_H
 
+#include <string>
+
 class CRPCTable;
+class CWallet;
+class JSONRPCRequest;
 
 void RegisterWalletRPCCommands(CRPCTable &t);
+
+/** URL prefix used to route an RPC call to a specific wallet, e.g.
+ *  POST /wallet/<name>/ */
+extern const std::string WALLET_ENDPOINT_BASE;
+
+/** Resolve the wallet that an RPC call should operate on. If the request
+ *  URI begins with /wallet/<name>/ the named wallet is returned; otherwise
+ *  the only loaded wallet is returned (or NULL when multiple are loaded
+ *  and none was specified). Returns NULL when no wallets are loaded. */
+CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+
+/** Throw JSONRPCError when the wallet is unavailable. Returns false when
+ *  avoidException is true and no wallet is present (so callers may return
+ *  NullUniValue from the help branch). */
+bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException);
+void EnsureWalletIsUnlocked(CWallet * const pwallet);
+
+/** Help text suffix used by RPCs that require an unlocked wallet. */
+std::string HelpRequiringPassphrase(CWallet * const pwallet);
+
+/** Legacy single-wallet helpers, retained while call sites are migrated to
+ *  the per-request wallet handle. Remove when the migration is complete. */
+bool EnsureWalletIsAvailable(bool avoidException);
+void EnsureWalletIsUnlocked();
 
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -11,7 +11,13 @@
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     TestingSetup(chainName)
 {
-    bitdb.MakeMock();
+    // Resolve the env for the test wallet's BDB-relative filename and
+    // put THAT env into mock mode. In the multi-env world there is no
+    // single global env to mock; the test wallet lives in an env at
+    // GetWalletDir() so that's the one we mock.
+    std::string dbFilename;
+    CDBEnv* testEnv = GetWalletEnv(GetWalletDir() / "wallet_test.dat", dbFilename);
+    testEnv->MakeMock();
 
     bool fFirstRun;
     pwalletMain = new CWallet("wallet_test.dat");
@@ -29,6 +35,8 @@ WalletTestingSetup::~WalletTestingSetup()
     delete pwalletMain;
     pwalletMain = NULL;
 
-    bitdb.Flush(true);
-    bitdb.Reset();
+    std::string dbFilename;
+    CDBEnv* testEnv = GetWalletEnv(GetWalletDir() / "wallet_test.dat", dbFilename);
+    testEnv->Flush(true);
+    testEnv->Reset();
 }

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -17,6 +17,7 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     pwalletMain = new CWallet("wallet_test.dat");
     pwalletMain->LoadWallet(fFirstRun);
     RegisterValidationInterface(pwalletMain);
+    vpwallets.push_back(pwalletMain);
 
     RegisterWalletRPCCommands(tableRPC);
 }
@@ -24,6 +25,7 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
 WalletTestingSetup::~WalletTestingSetup()
 {
     UnregisterValidationInterface(pwalletMain);
+    vpwallets.erase(std::remove(vpwallets.begin(), vpwallets.end(), pwalletMain), vpwallets.end());
     delete pwalletMain;
     pwalletMain = NULL;
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -14,7 +14,9 @@
 #include "rpc/server.h"
 #include "test/test_bitcoin.h"
 #include "validation.h"
+#include "wallet/db.h"
 #include "wallet/test/wallet_test_fixture.h"
+#include "wallet/walletutil.h"
 
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
@@ -597,6 +599,132 @@ BOOST_FIXTURE_TEST_CASE(derive_new_child_key_test, WalletTestingSetup)
     // Verify the child public key matches the expected value
     std::string derivedPubKeyHex = HexStr(childPubKey.begin(), childPubKey.end());
     BOOST_CHECK_EQUAL(derivedPubKeyHex, expectedPubKeyHex);
+}
+
+// ─── Directory-layout wallet path resolution ───────────────────────
+//
+// Covers walletutil.{cpp,h}:
+//   - IsDirectoryWalletName  (dot-suffix heuristic)
+//   - WalletDataFileName     (migration-aware: flat file already at name
+//                             stays flat; otherwise resolves to
+//                             <name>/wallet.dat)
+//   - WalletNameFromDataFilePath (inverse — derives user-facing name
+//                                  from the internal BDB path)
+//
+// Plus the per-wallet env path-split done by GetWalletEnv: env directory
+// is wallet_path.parent_path(), so two wallets in different subdirectories
+// resolve to different envs (the core property the bitdb→g_dbenvs refactor
+// gives us).
+
+BOOST_AUTO_TEST_CASE(walletutil_is_directory_wallet_name)
+{
+    // Dotted names → flat layout (legacy wallet.dat, *.dat, *.bak)
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName(""), false);
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName("wallet.dat"), false);
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName("unsandbox.dat"), false);
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName("legacy.bak"), false);
+    // Dotless names → directory layout (the new default)
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName("unsandbox"), true);
+    BOOST_CHECK_EQUAL(IsDirectoryWalletName("makepostsell"), true);
+}
+
+BOOST_AUTO_TEST_CASE(walletutil_data_file_name_resolution)
+{
+    // Flat (dotted) names round-trip unchanged.
+    BOOST_CHECK_EQUAL(WalletDataFileName("wallet.dat"), "wallet.dat");
+    BOOST_CHECK_EQUAL(WalletDataFileName("unsandbox.dat"), "unsandbox.dat");
+
+    // Dotless name, nothing on disk: directory layout.
+    // We use a fresh subdir under GetWalletDir() to keep test isolated
+    // from any prior runs (WalletTestingSetup gives us a temp datadir).
+    const std::string fresh_name = "wallet_unit_test_fresh";
+    BOOST_CHECK(!fs::exists(GetWalletDir() / fresh_name));
+    BOOST_CHECK_EQUAL(WalletDataFileName(fresh_name), fresh_name + "/wallet.dat");
+
+    // Dotless name, flat file already squats at <walletdir>/<name>:
+    // migration-aware path returns the bare name (flat) so the existing
+    // file keeps loading without a mkdir+mv.
+    const std::string flat_name = "wallet_unit_test_flat";
+    fs::path flat_path = GetWalletDir() / flat_name;
+    std::ofstream(flat_path.string()) << "stub"; // create a regular file
+    BOOST_CHECK(fs::is_regular_file(flat_path));
+    BOOST_CHECK_EQUAL(WalletDataFileName(flat_name), flat_name);
+    fs::remove(flat_path); // clean up
+}
+
+BOOST_AUTO_TEST_CASE(walletutil_name_from_data_file_path_roundtrip)
+{
+    // Inverse of WalletDataFileName for the directory case
+    BOOST_CHECK_EQUAL(WalletNameFromDataFilePath("unsandbox/wallet.dat"), "unsandbox");
+    BOOST_CHECK_EQUAL(WalletNameFromDataFilePath("makepostsell/wallet.dat"), "makepostsell");
+    // Flat names pass through unchanged
+    BOOST_CHECK_EQUAL(WalletNameFromDataFilePath("wallet.dat"), "wallet.dat");
+    BOOST_CHECK_EQUAL(WalletNameFromDataFilePath("legacy.dat"), "legacy.dat");
+    // Empty stays empty (no crash)
+    BOOST_CHECK_EQUAL(WalletNameFromDataFilePath(""), "");
+}
+
+BOOST_AUTO_TEST_CASE(walletutil_ensure_directory)
+{
+    const std::string name = "wallet_unit_test_mkdir";
+    fs::path wallet_path = GetWalletDir() / name;
+    // Clean slate
+    if (fs::exists(wallet_path)) fs::remove_all(wallet_path);
+
+    BOOST_CHECK(EnsureWalletDirectoryExists(name));
+    BOOST_CHECK(fs::is_directory(wallet_path));
+
+    // Idempotent (second call no-op)
+    BOOST_CHECK(EnsureWalletDirectoryExists(name));
+    BOOST_CHECK(fs::is_directory(wallet_path));
+
+    // Cleanup
+    fs::remove_all(wallet_path);
+
+    // Migration-friendly: a flat file at the no-extension name doesn't
+    // trigger a mkdir attempt (which would race with the file existing).
+    std::ofstream(wallet_path.string()) << "stub";
+    BOOST_CHECK(EnsureWalletDirectoryExists(name));
+    BOOST_CHECK(fs::is_regular_file(wallet_path));
+    fs::remove(wallet_path);
+
+    // Flat (dotted) names always succeed without touching disk.
+    BOOST_CHECK(EnsureWalletDirectoryExists("any.dat"));
+}
+
+BOOST_AUTO_TEST_CASE(getwalletenv_per_directory_isolation)
+{
+    // The bitdb→g_dbenvs core property: wallets in different
+    // directories resolve to different CDBEnv pointers; wallets in
+    // the same directory share one.
+    std::string fn_alpha, fn_beta, fn_alpha_two;
+    CDBEnv* env_alpha     = GetWalletEnv(GetWalletDir() / "alpha"     / "wallet.dat", fn_alpha);
+    CDBEnv* env_beta      = GetWalletEnv(GetWalletDir() / "beta"      / "wallet.dat", fn_beta);
+    CDBEnv* env_alpha_two = GetWalletEnv(GetWalletDir() / "alpha"     / "wallet.dat", fn_alpha_two);
+
+    BOOST_CHECK(env_alpha != nullptr);
+    BOOST_CHECK(env_beta  != nullptr);
+    BOOST_CHECK(env_alpha != env_beta);          // different dirs → different envs
+    BOOST_CHECK(env_alpha == env_alpha_two);     // same dir → same env
+
+    // database_filename always strips the directory.
+    BOOST_CHECK_EQUAL(fn_alpha,     "wallet.dat");
+    BOOST_CHECK_EQUAL(fn_beta,      "wallet.dat");
+    BOOST_CHECK_EQUAL(fn_alpha_two, "wallet.dat");
+
+    // Each env knows its own directory.
+    BOOST_CHECK_EQUAL(env_alpha->Directory().filename().string(), "alpha");
+    BOOST_CHECK_EQUAL(env_beta->Directory().filename().string(),  "beta");
+
+    // Flat-layout wallets at <walletdir>/<name>.dat share the
+    // walletdir env (parent_path of "<walletdir>/foo.dat" is
+    // <walletdir>), matching pre-refactor semantics.
+    std::string fn_flat_a, fn_flat_b;
+    CDBEnv* env_flat_a = GetWalletEnv(GetWalletDir() / "legacy_a.dat", fn_flat_a);
+    CDBEnv* env_flat_b = GetWalletEnv(GetWalletDir() / "legacy_b.dat", fn_flat_b);
+    BOOST_CHECK(env_flat_a == env_flat_b);
+    BOOST_CHECK_EQUAL(fn_flat_a, "legacy_a.dat");
+    BOOST_CHECK_EQUAL(fn_flat_b, "legacy_b.dat");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -408,6 +408,8 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain240Setup)
         CWallet wallet;
         CWallet *backup = ::pwalletMain;
         ::pwalletMain = &wallet;
+        std::vector<CWalletRef> vpwallets_backup = ::vpwallets;
+        ::vpwallets = {&wallet};
         UniValue keys;
         keys.setArray();
         UniValue key;
@@ -431,6 +433,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain240Setup)
         UniValue response = importmulti(request);
         BOOST_CHECK_EQUAL(response.write(), strprintf("[{\"success\":false,\"error\":{\"code\":-1,\"message\":\"Failed to rescan before time %d, transactions may be missing.\"}},{\"success\":true}]", newTip->GetBlockTimeMax()));
         ::pwalletMain = backup;
+        ::vpwallets = vpwallets_backup;
     }
 }
 
@@ -441,6 +444,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain240Setup)
 BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain240Setup)
 {
     CWallet *pwalletMainBackup = ::pwalletMain;
+    std::vector<CWalletRef> vpwallets_backup = ::vpwallets;
     LOCK(cs_main);
 
     // Create two blocks with same timestamp to verify that importwallet rescan
@@ -467,6 +471,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain240Setup)
         request.params.setArray();
         request.params.push_back("wallet.backup");
         ::pwalletMain = &wallet;
+        ::vpwallets = {&wallet};
         ::dumpwallet(request);
     }
 
@@ -479,6 +484,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain240Setup)
         request.params.setArray();
         request.params.push_back(TestChain240Setup::pathTemp.string() + "/regtest/backups/wallet.backup");
         ::pwalletMain = &wallet;
+        ::vpwallets = {&wallet};
         ::importwallet(request);
 
         BOOST_CHECK_EQUAL(wallet.mapWallet.size(), 3);
@@ -492,6 +498,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain240Setup)
 
     SetMockTime(0);
     ::pwalletMain = pwalletMainBackup;
+    ::vpwallets = vpwallets_backup;
 }
 
 BOOST_AUTO_TEST_CASE(GetMinimumFee_test)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3932,6 +3932,23 @@ bool CWallet::ParameterInteraction()
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
         return true;
 
+    // Single-wallet-only operations must not be combined with the multi
+    // -wallet=<file> startup form. With more than one wallet loaded these
+    // flags would either operate on the wrong file or silently corrupt the
+    // others. Matches bitcoin 0.17 behaviour.
+    const bool multi_wallet = mapMultiArgs.count("-wallet") && mapMultiArgs.at("-wallet").size() > 1;
+    if (multi_wallet) {
+        if (IsArgSet("-zapwallettxes")) {
+            return InitError(_("-zapwallettxes is only allowed with a single wallet file"));
+        }
+        if (GetBoolArg("-salvagewallet", false)) {
+            return InitError(_("-salvagewallet is only allowed with a single wallet file"));
+        }
+        if (IsArgSet("-upgradewallet")) {
+            return InitError(_("-upgradewallet is only allowed with a single wallet file"));
+        }
+    }
+
     if (GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) && SoftSetBoolArg("-walletbroadcast", false)) {
         LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -walletbroadcast=0\n", __func__);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -38,6 +38,7 @@
 
 using namespace std;
 
+std::vector<CWalletRef> vpwallets;
 CWallet* pwalletMain = NULL;
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
@@ -3868,6 +3869,7 @@ bool CWallet::InitLoadWallet()
 {
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         pwalletMain = NULL;
+        vpwallets.clear();
         LogPrintf("Wallet disabled!\n");
         return true;
     }
@@ -3878,6 +3880,7 @@ bool CWallet::InitLoadWallet()
     if (!pwallet) {
         return false;
     }
+    vpwallets.push_back(pwallet);
     pwalletMain = pwallet;
 
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -455,15 +455,28 @@ bool CWallet::Verify()
         return true;
 
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
-    std::string walletFile = GetArg("-wallet", DEFAULT_WALLET_DAT);
+    uiInterface.InitMessage(_("Verifying wallet(s)..."));
 
-    LogPrintf("Using wallet %s\n", walletFile);
-    uiInterface.InitMessage(_("Verifying wallet..."));
+    // Collect the wallet files requested on the command line. When no -wallet
+    // argument is supplied at all we fall back to the legacy single default.
+    std::vector<std::string> wallet_files;
+    if (mapMultiArgs.count("-wallet")) {
+        wallet_files = mapMultiArgs.at("-wallet");
+    } else {
+        wallet_files.push_back(DEFAULT_WALLET_DAT);
+    }
 
-    // Wallet file must be a plain filename without a directory
-    fs::path walletPath(walletFile);
-    if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
-        return InitError(strprintf(_("Wallet %s resides outside data directory %s"), walletFile, GetDataDir().string()));
+    // Reject duplicates and paths that escape the data directory before we
+    // touch the database environment.
+    std::set<std::string> wallet_file_names;
+    for (const std::string& walletFile : wallet_files) {
+        fs::path walletPath(walletFile);
+        if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+            return InitError(strprintf(_("Wallet %s resides outside data directory %s"), walletFile, GetDataDir().string()));
+        }
+        if (!wallet_file_names.insert(walletFile).second) {
+            return InitError(strprintf(_("Error loading wallet %s. Duplicate -wallet filename specified."), walletFile));
+        }
     }
 
     if (!bitdb.Open(GetDataDir()))
@@ -485,26 +498,30 @@ bool CWallet::Verify()
         }
     }
 
-    if (GetBoolArg("-salvagewallet", false))
-    {
-        // Recover readable keypairs:
-        if (!CWalletDB::Recover(bitdb, walletFile, true))
-            return false;
-    }
+    for (const std::string& walletFile : wallet_files) {
+        LogPrintf("Using wallet %s\n", walletFile);
 
-    if (fs::exists(GetDataDir() / walletFile))
-    {
-        CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
-        if (r == CDBEnv::RECOVER_OK)
+        if (GetBoolArg("-salvagewallet", false))
         {
-            InitWarning(strprintf(_("Warning: Wallet file corrupt, data salvaged!"
-                                         " Original %s saved as %s in %s; if"
-                                         " your balance or transactions are incorrect you should"
-                                         " restore from a backup."),
-                walletFile, "wallet.{timestamp}.bak", GetDataDir()));
+            // Recover readable keypairs:
+            if (!CWalletDB::Recover(bitdb, walletFile, true))
+                return false;
         }
-        if (r == CDBEnv::RECOVER_FAIL)
-            return InitError(strprintf(_("%s corrupt, salvage failed"), walletFile));
+
+        if (fs::exists(GetDataDir() / walletFile))
+        {
+            CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
+            if (r == CDBEnv::RECOVER_OK)
+            {
+                InitWarning(strprintf(_("Warning: Wallet file corrupt, data salvaged!"
+                                             " Original %s saved as %s in %s; if"
+                                             " your balance or transactions are incorrect you should"
+                                             " restore from a backup."),
+                    walletFile, "wallet.{timestamp}.bak", GetDataDir()));
+            }
+            if (r == CDBEnv::RECOVER_FAIL)
+                return InitError(strprintf(_("%s corrupt, salvage failed"), walletFile));
+        }
     }
 
     return true;
@@ -3665,7 +3682,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-usehd", _("Use hierarchical deterministic key generation (HD) after BIP32. Only has effect during wallet creation/first start") + " " + strprintf(_("(default: %u)"), DEFAULT_USE_HD_WALLET));
     strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
-    strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), DEFAULT_WALLET_DAT));
+    strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory). This option may be specified multiple times.") + " " + strprintf(_("(default: %s)"), DEFAULT_WALLET_DAT));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID, %i with block height, with a value of 0 if tx is no longer in chaintip)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
@@ -3874,14 +3891,24 @@ bool CWallet::InitLoadWallet()
         return true;
     }
 
-    std::string walletFile = GetArg("-wallet", DEFAULT_WALLET_DAT);
-
-    CWallet * const pwallet = CreateWalletFromFile(walletFile);
-    if (!pwallet) {
-        return false;
+    std::vector<std::string> wallet_files;
+    if (mapMultiArgs.count("-wallet")) {
+        wallet_files = mapMultiArgs.at("-wallet");
+    } else {
+        wallet_files.push_back(DEFAULT_WALLET_DAT);
     }
-    vpwallets.push_back(pwallet);
-    pwalletMain = pwallet;
+
+    for (const std::string& walletFile : wallet_files) {
+        CWallet * const pwallet = CreateWalletFromFile(walletFile);
+        if (!pwallet) {
+            return false;
+        }
+        vpwallets.push_back(pwallet);
+    }
+
+    // Keep pwalletMain as a transitional alias for the first loaded wallet
+    // so legacy callers (qt, signrawtransaction, getinfo, tests) keep working.
+    pwalletMain = vpwallets.empty() ? nullptr : vpwallets.front();
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -466,17 +466,49 @@ bool CWallet::Verify()
         wallet_files.push_back(DEFAULT_WALLET_DAT);
     }
 
-    // Reject duplicates and paths that escape the data directory before we
+    // Reject duplicates and paths that escape the wallet directory before we
     // touch the database environment.
-    std::set<std::string> wallet_file_names;
+    //
+    // Each wallet_files entry is a USER name (CLI -wallet arg, config
+    // wallet= line, or DEFAULT_WALLET_DAT). We resolve each one to two
+    // strings:
+    //   * dbFile  — the BDB-relative path bitdb.Verify() opens. For a
+    //               directory-layout wallet ("unsandbox") this is
+    //               "unsandbox/wallet.dat"; for a flat wallet
+    //               ("unsandbox.dat") it stays "unsandbox.dat".
+    //   * walletName — the user-facing name, used for log lines and
+    //               duplicate detection.
+    //
+    // Duplicate detection runs against dbFile, not walletName, so the
+    // same on-disk wallet can't be opened twice via different surface
+    // names (e.g. someone passing both "unsandbox" and "unsandbox/wallet.dat"
+    // from different code paths).
+    std::set<std::string> wallet_db_paths;
+    std::vector<std::string> wallet_db_files; // parallel to wallet_files
+    wallet_db_files.reserve(wallet_files.size());
     for (const std::string& walletFile : wallet_files) {
         fs::path walletPath(walletFile);
-        if (walletFile != walletPath.stem().string() + walletPath.extension().string()) {
-            return InitError(strprintf(_("Wallet %s resides outside data directory %s"), walletFile, GetDataDir().string()));
+        // Reject any user input that escapes a single name segment
+        // (e.g. "../foo", "sub/dir/wallet"). Directory-layout wallets
+        // are introduced by US below, not by user-supplied paths.
+        if (walletPath.has_parent_path() ||
+            walletFile != walletPath.stem().string() + walletPath.extension().string()) {
+            return InitError(strprintf(_("Wallet %s resides outside data directory %s"), walletFile, GetWalletDir().string()));
         }
-        if (!wallet_file_names.insert(walletFile).second) {
+        if (!EnsureWalletDirectoryExists(walletFile)) {
+            return InitError(strprintf(_("Failed to create wallet directory for %s"), walletFile));
+        }
+        // For directory wallets, BDB opens <walletdir>/<name>/wallet.dat;
+        // strFile passed to BDB is the path RELATIVE to the BDB env
+        // (whose home is GetWalletDir()) — i.e. "<name>/wallet.dat".
+        // WalletDataFileName is migration-aware: if a flat file already
+        // squats on a no-extension name, it returns the flat string so
+        // we keep opening that wallet without forcing a layout swap.
+        const std::string dbFile = WalletDataFileName(walletFile);
+        if (!wallet_db_paths.insert(dbFile).second) {
             return InitError(strprintf(_("Error loading wallet %s. Duplicate -wallet filename specified."), walletFile));
         }
+        wallet_db_files.push_back(dbFile);
     }
 
     if (!bitdb.Open(GetDataDir()))
@@ -498,19 +530,21 @@ bool CWallet::Verify()
         }
     }
 
-    for (const std::string& walletFile : wallet_files) {
+    for (size_t i = 0; i < wallet_files.size(); ++i) {
+        const std::string& walletFile = wallet_files[i];
+        const std::string& dbFile = wallet_db_files[i];
         LogPrintf("Using wallet %s\n", walletFile);
 
         if (GetBoolArg("-salvagewallet", false))
         {
             // Recover readable keypairs:
-            if (!CWalletDB::Recover(bitdb, walletFile, true))
+            if (!CWalletDB::Recover(bitdb, dbFile, true))
                 return false;
         }
 
-        if (fs::exists(GetDataDir() / walletFile))
+        if (fs::exists(GetDataDir() / dbFile))
         {
-            CDBEnv::VerifyResult r = bitdb.Verify(walletFile, CWalletDB::Recover);
+            CDBEnv::VerifyResult r = bitdb.Verify(dbFile, CWalletDB::Recover);
             if (r == CDBEnv::RECOVER_OK)
             {
                 InitWarning(strprintf(_("Warning: Wallet file corrupt, data salvaged!"
@@ -3899,7 +3933,14 @@ bool CWallet::InitLoadWallet()
     }
 
     for (const std::string& walletFile : wallet_files) {
-        CWallet * const pwallet = CreateWalletFromFile(walletFile);
+        // Mirror the dbFile resolution Verify() did above so the wallet
+        // we register here uses the BDB-relative path BDB will open
+        // (Verify() already mkdir'd the wallet directory if needed).
+        // strWalletFile on the CWallet instance becomes this dbFile;
+        // the user-facing name comes back via GetName() →
+        // WalletNameFromDataFilePath().
+        const std::string dbFile = WalletDataFileName(walletFile);
+        CWallet * const pwallet = CreateWalletFromFile(dbFile);
         if (!pwallet) {
             return false;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -461,7 +461,22 @@ bool CWallet::Verify()
     if (GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
         return true;
 
+    // If -walletdir was passed, validate it before any wallet open
+    // touches it. We want a clear error here rather than a confusing
+    // BDB env failure later.
+    if (IsArgSet("-walletdir")) {
+        fs::path wallet_dir = GetArg("-walletdir", "");
+        if (!fs::exists(wallet_dir)) {
+            return InitError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
+        } else if (!fs::is_directory(wallet_dir)) {
+            return InitError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), wallet_dir.string()));
+        } else if (!wallet_dir.is_absolute()) {
+            return InitError(strprintf(_("Specified -walletdir \"%s\" is a relative path"), wallet_dir.string()));
+        }
+    }
+
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
+    LogPrintf("Using wallet directory %s\n", GetWalletDir().string());
     uiInterface.InitMessage(_("Verifying wallet(s)..."));
 
     // Collect the wallet files requested on the command line. When no -wallet
@@ -3732,6 +3747,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory). This option may be specified multiple times.") + " " + strprintf(_("(default: %s)"), DEFAULT_WALLET_DAT));
+    strUsage += HelpMessageOpt("-walletdir=<dir>", _("Specify directory to hold wallets (default: <datadir>/wallets/ if it exists, otherwise <datadir>)"));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID, %i with block height, with a value of 0 if tx is no longer in chaintip)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -446,7 +446,14 @@ bool CWallet::HasWalletSpend(const uint256& txid) const
 
 void CWallet::Flush(bool shutdown)
 {
-    bitdb.Flush(shutdown);
+    // Resolve THIS wallet's env from strWalletFile (which is the
+    // BDB-relative wallet path) and flush only it. Each directory-layout
+    // wallet has its own env in the multi-env world; flushing only
+    // pwalletMain's env (or worse, all envs) would be wrong here —
+    // each CWallet::Flush call corresponds to one wallet.
+    std::string dbFilename;
+    CDBEnv* env = GetWalletEnv(GetWalletDir() / strWalletFile, dbFilename);
+    env->Flush(shutdown);
 }
 
 bool CWallet::Verify()
@@ -511,47 +518,55 @@ bool CWallet::Verify()
         wallet_db_files.push_back(dbFile);
     }
 
-    if (!bitdb.Open(GetDataDir()))
-    {
-        // try moving the database env out of the way
-        fs::path pathDatabase = GetDataDir() / "database";
-        fs::path pathDatabaseBak = GetDataDir() / strprintf("database.%d.bak", GetTime());
-        try {
-            fs::rename(pathDatabase, pathDatabaseBak);
-            LogPrintf("Moved old %s to %s. Retrying.\n", pathDatabase.string(), pathDatabaseBak.string());
-        } catch (const fs::filesystem_error&) {
-            // failure is ok (well, not really, but it's not worse than what we started with)
-        }
-
-        // try again
-        if (!bitdb.Open(GetDataDir())) {
-            // if it still fails, it probably means we can't even create the database env
-            return InitError(strprintf(_("Error initializing wallet database environment %s!"), GetDataDir()));
-        }
-    }
-
+    // Per-wallet env open + verify. In the multi-env world each wallet
+    // has its own CDBEnv living at its own directory, so the
+    // "open the env once, then verify each wallet against it" pattern
+    // becomes "for each wallet, resolve its env, open + verify". The
+    // database/ backup-and-retry recovery is now done per-env (any one
+    // env can be corrupt without affecting the others).
     for (size_t i = 0; i < wallet_files.size(); ++i) {
         const std::string& walletFile = wallet_files[i];
         const std::string& dbFile = wallet_db_files[i];
         LogPrintf("Using wallet %s\n", walletFile);
 
+        std::string dbFilename;
+        CDBEnv* env = GetWalletEnv(GetWalletDir() / dbFile, dbFilename);
+
+        if (!env->Open(false /* retry */))
+        {
+            // try moving the database env out of the way
+            fs::path pathDatabase = fs::path(env->Directory()) / "database";
+            fs::path pathDatabaseBak = fs::path(env->Directory()) / strprintf("database.%d.bak", GetTime());
+            try {
+                fs::rename(pathDatabase, pathDatabaseBak);
+                LogPrintf("Moved old %s to %s. Retrying.\n", pathDatabase.string(), pathDatabaseBak.string());
+            } catch (const fs::filesystem_error&) {
+                // failure is ok (well, not really, but it's not worse than what we started with)
+            }
+
+            // try again
+            if (!env->Open(true /* retry */)) {
+                return InitError(strprintf(_("Error initializing wallet database environment %s!"), env->Directory().string()));
+            }
+        }
+
         if (GetBoolArg("-salvagewallet", false))
         {
             // Recover readable keypairs:
-            if (!CWalletDB::Recover(bitdb, dbFile, true))
+            if (!CWalletDB::Recover(*env, dbFilename, true))
                 return false;
         }
 
-        if (fs::exists(GetDataDir() / dbFile))
+        if (fs::exists(GetWalletDir() / dbFile))
         {
-            CDBEnv::VerifyResult r = bitdb.Verify(dbFile, CWalletDB::Recover);
+            CDBEnv::VerifyResult r = env->Verify(dbFilename, CWalletDB::Recover);
             if (r == CDBEnv::RECOVER_OK)
             {
                 InitWarning(strprintf(_("Warning: Wallet file corrupt, data salvaged!"
                                              " Original %s saved as %s in %s; if"
                                              " your balance or transactions are incorrect you should"
                                              " restore from a backup."),
-                    walletFile, "wallet.{timestamp}.bak", GetDataDir()));
+                    walletFile, "wallet.{timestamp}.bak", env->Directory().string()));
             }
             if (r == CDBEnv::RECOVER_FAIL)
                 return InitError(strprintf(_("%s corrupt, salvage failed"), walletFile));
@@ -4087,22 +4102,28 @@ bool CWallet::BackupWallet(const std::string& strDest)
 {
     if (!fFileBacked)
         return false;
+    std::string dbFilename;
+    CDBEnv* env = GetWalletEnv(GetWalletDir() / strWalletFile, dbFilename);
     while (true)
     {
         {
-            LOCK(bitdb.cs_db);
-            if (!bitdb.mapFileUseCount.count(strWalletFile) || bitdb.mapFileUseCount[strWalletFile] == 0)
+            LOCK(cs_db);
+            if (!env->mapFileUseCount.count(dbFilename) || env->mapFileUseCount[dbFilename] == 0)
             {
                 // Flush log data to the dat file
-                bitdb.CloseDb(strWalletFile);
-                bitdb.CheckpointLSN(strWalletFile);
-                bitdb.mapFileUseCount.erase(strWalletFile);
+                env->CloseDb(dbFilename);
+                env->CheckpointLSN(dbFilename);
+                env->mapFileUseCount.erase(dbFilename);
 
-                // Copy wallet file
-                fs::path pathSrc = GetDataDir() / strWalletFile;
+                // Copy wallet file. Source is the actual on-disk path
+                // (resolved via WalletDataFilePath for the migration-aware
+                // flat-or-directory layout). Destination behaviour is
+                // unchanged: a directory destination gets the bare BDB
+                // filename appended.
+                fs::path pathSrc = WalletDataFilePath(strWalletFile);
                 fs::path pathDest(strDest);
                 if (fs::is_directory(pathDest))
-                    pathDest /= strWalletFile;
+                    pathDest /= dbFilename;
 
                 try {
                     if (fs::equivalent(pathSrc, pathDest)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -20,6 +20,7 @@
 #include "script/sign.h"
 #include "wallet/crypter.h"
 #include "wallet/walletdb.h"
+#include "wallet/walletutil.h"
 #include "wallet/rpcwallet.h"
 
 #include <algorithm>
@@ -616,7 +617,28 @@ public:
      */
     mutable CCriticalSection cs_wallet;
 
+    /**
+     * BDB-relative path the wallet's underlying database lives at,
+     * resolved relative to the BDB environment's home directory
+     * (which is GetDataDir() today). For flat-file wallets this is
+     * just the bare wallet name (e.g. "wallet.dat" or "unsandbox.dat").
+     * For directory-layout wallets it includes the "/wallet.dat"
+     * suffix (e.g. "unsandbox/wallet.dat") so BDB opens the file
+     * inside the wallet's own directory. Immutable after instantiation.
+     *
+     * Use GetName() (or m_name below) for anything user-facing —
+     * RPC responses, log lines, /wallet/<name>/ URL routing — so the
+     * on-disk layout never leaks into the public interface.
+     */
     const std::string strWalletFile;
+
+    /**
+     * User-facing wallet name, derived from strWalletFile at
+     * construction. For "unsandbox/wallet.dat" this is "unsandbox";
+     * for "unsandbox.dat" this is "unsandbox.dat" (flat wallets are
+     * named by their on-disk file). Surfaced via GetName().
+     */
+    const std::string m_name;
 
     void LoadKeyPool(int nIndex, const CKeyPool &keypool)
     {
@@ -643,7 +665,9 @@ public:
         SetNull();
     }
 
-    CWallet(const std::string& strWalletFileIn) : strWalletFile(strWalletFileIn)
+    CWallet(const std::string& strWalletFileIn)
+        : strWalletFile(strWalletFileIn),
+          m_name(WalletNameFromDataFilePath(strWalletFileIn))
     {
         SetNull();
         fFileBacked = true;
@@ -655,7 +679,9 @@ public:
         pwalletdbEncryption = NULL;
     }
 
-    const std::string& GetName() const { return strWalletFile; }
+    /** User-facing wallet name; safe for RPC output, log lines, and
+     *  /wallet/<name>/ URL routing. See m_name. */
+    const std::string& GetName() const { return m_name; }
 
     void SetNull()
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -655,6 +655,8 @@ public:
         pwalletdbEncryption = NULL;
     }
 
+    const std::string& GetName() const { return strWalletFile; }
+
     void SetNull()
     {
         nWalletVersion = FEATURE_BASE;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -34,6 +34,13 @@
 
 #include <boost/thread.hpp>
 
+class CWallet;
+typedef CWallet* CWalletRef;
+
+/** Global wallet registry. During the multi-wallet transition pwalletMain
+ *  remains as the first element / legacy alias; new code should look up
+ *  the request's wallet via GetWalletForJSONRPCRequest() instead. */
+extern std::vector<CWalletRef> vpwallets;
 extern CWallet* pwalletMain;
 
 /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -807,40 +807,40 @@ void ThreadFlushWalletDB()
 
         if (nLastFlushed != CWalletDB::GetUpdateCounter() && GetTime() - nLastWalletUpdate >= 2)
         {
-            TRY_LOCK(bitdb.cs_db,lockDb);
+            TRY_LOCK(cs_db, lockDb);
             if (lockDb)
             {
-                // Don't do this if any databases are in use
-                int nRefCount = 0;
-                map<string, int>::iterator mi = bitdb.mapFileUseCount.begin();
-                while (mi != bitdb.mapFileUseCount.end())
-                {
-                    nRefCount += (*mi).second;
-                    mi++;
-                }
-
-                if (nRefCount == 0)
-                {
+                // Iterate every loaded wallet, resolve each one's env via
+                // its strWalletFile (now a BDB-relative path like
+                // "<name>/wallet.dat" or "wallet.dat" — see wallet.cpp's
+                // dbFile threading for the directory-layout backport),
+                // and flush idle wallets in their own envs.
+                //
+                // We deliberately do NOT short-circuit on a global
+                // refcount-zero check: each wallet may belong to a
+                // different env in g_dbenvs, and an in-use wallet in
+                // env A shouldn't block flush of an idle wallet in env B.
+                nLastFlushed = CWalletDB::GetUpdateCounter();
+                for (CWalletRef pwallet : vpwallets) {
                     boost::this_thread::interruption_point();
-                    // Flush every loaded wallet, not just pwalletMain, so that
-                    // wallets added at runtime via loadwallet also get
-                    // periodic checkpointing.
-                    nLastFlushed = CWalletDB::GetUpdateCounter();
-                    for (CWalletRef pwallet : vpwallets) {
-                        const std::string& strFile = pwallet->strWalletFile;
-                        map<string, int>::iterator _mi = bitdb.mapFileUseCount.find(strFile);
-                        if (_mi == bitdb.mapFileUseCount.end()) continue;
+                    const std::string& strFile = pwallet->strWalletFile;
 
-                        LogPrint("db", "Flushing %s\n", strFile);
-                        int64_t nStart = GetTimeMillis();
+                    // Resolve env + BDB-relative filename for THIS wallet.
+                    std::string dbFilename;
+                    CDBEnv* env = GetWalletEnv(GetWalletDir() / strFile, dbFilename);
 
-                        // Flush wallet file so it's self contained
-                        bitdb.CloseDb(strFile);
-                        bitdb.CheckpointLSN(strFile);
+                    auto _mi = env->mapFileUseCount.find(dbFilename);
+                    if (_mi == env->mapFileUseCount.end() || _mi->second != 0) continue;
 
-                        bitdb.mapFileUseCount.erase(_mi);
-                        LogPrint("db", "Flushed %s %dms\n", strFile, GetTimeMillis() - nStart);
-                    }
+                    LogPrint("db", "Flushing %s\n", strFile);
+                    int64_t nStart = GetTimeMillis();
+
+                    // Flush wallet file so it's self contained
+                    env->CloseDb(dbFilename);
+                    env->CheckpointLSN(dbFilename);
+
+                    env->mapFileUseCount.erase(_mi);
+                    LogPrint("db", "Flushed %s %dms\n", strFile, GetTimeMillis() - nStart);
                 }
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -822,19 +822,23 @@ void ThreadFlushWalletDB()
                 if (nRefCount == 0)
                 {
                     boost::this_thread::interruption_point();
-                    const std::string& strFile = pwalletMain->strWalletFile;
-                    map<string, int>::iterator _mi = bitdb.mapFileUseCount.find(strFile);
-                    if (_mi != bitdb.mapFileUseCount.end())
-                    {
+                    // Flush every loaded wallet, not just pwalletMain, so that
+                    // wallets added at runtime via loadwallet also get
+                    // periodic checkpointing.
+                    nLastFlushed = CWalletDB::GetUpdateCounter();
+                    for (CWalletRef pwallet : vpwallets) {
+                        const std::string& strFile = pwallet->strWalletFile;
+                        map<string, int>::iterator _mi = bitdb.mapFileUseCount.find(strFile);
+                        if (_mi == bitdb.mapFileUseCount.end()) continue;
+
                         LogPrint("db", "Flushing %s\n", strFile);
-                        nLastFlushed = CWalletDB::GetUpdateCounter();
                         int64_t nStart = GetTimeMillis();
 
                         // Flush wallet file so it's self contained
                         bitdb.CloseDb(strFile);
                         bitdb.CheckpointLSN(strFile);
 
-                        bitdb.mapFileUseCount.erase(_mi++);
+                        bitdb.mapFileUseCount.erase(_mi);
                         LogPrint("db", "Flushed %s %dms\n", strFile, GetTimeMillis() - nStart);
                     }
                 }

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -9,11 +9,36 @@
 
 fs::path GetWalletDir()
 {
-    // No -walletdir support yet; every wallet lives under the data
-    // directory. Wallet-dir lookup is centralised here so the eventual
-    // -walletdir flag (mirroring Bitcoin Core's PR #11077) is a single
-    // change.
-    return GetDataDir();
+    // -walletdir=<dir> overrides the wallet location. Otherwise wallets
+    // live under <datadir>/wallets/ if that directory exists (matches
+    // Bitcoin Core's default on a fresh node), else <datadir>/ itself
+    // (matches legacy single-wallet nodes that have always kept
+    // wallet.dat at datadir root).
+    //
+    // The three-way resolution lets users migrate by creating
+    // <datadir>/wallets/ and moving their wallets in without changing
+    // any flags; legacy nodes that never created the directory keep
+    // operating exactly as before.
+    fs::path path;
+    if (IsArgSet("-walletdir")) {
+        path = GetArg("-walletdir", "");
+        if (!fs::is_directory(path)) {
+            // Fall back to default; the daemon's own validation in init.cpp
+            // logs a clearer error before we get here in practice, but in
+            // case this is called without that gate we still want a sane
+            // default rather than a non-existent path.
+            path = GetDataDir();
+        }
+    } else {
+        path = GetDataDir();
+        // Adopt the Bitcoin Core post-0.18 convention: if a "wallets"
+        // subdirectory exists, prefer it. This lets a user split chain
+        // data from wallet data by mkdir-ing wallets/ themselves.
+        if (fs::is_directory(path / "wallets")) {
+            path /= "wallets";
+        }
+    }
+    return path;
 }
 
 bool IsDirectoryWalletName(const std::string& walletName)

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -28,13 +28,32 @@ bool IsDirectoryWalletName(const std::string& walletName)
     return walletName.find('.') == std::string::npos;
 }
 
+std::string WalletDataFileName(const std::string& walletName)
+{
+    if (!IsDirectoryWalletName(walletName)) {
+        // Dot-suffixed name: always flat. Covers DEFAULT_WALLET_DAT
+        // ("wallet.dat") so a legacy single-wallet node sees zero
+        // behaviour change after upgrading to a build carrying this
+        // backport.
+        return walletName;
+    }
+    // Migration-friendly resolution for no-extension names:
+    //   1. If a regular file already sits at <walletdir>/<name>, treat
+    //      it as a flat wallet. Lets users adopt the new naming
+    //      convention (drop the .dat) WITHOUT a mkdir+mv beforehand:
+    //      mv unsandbox.dat unsandbox is enough.
+    //   2. Otherwise resolve to <name>/wallet.dat — the directory
+    //      layout new wallets default to.
+    const fs::path candidateFlat = GetWalletDir() / walletName;
+    if (fs::exists(candidateFlat) && fs::is_regular_file(candidateFlat)) {
+        return walletName;
+    }
+    return walletName + "/wallet.dat";
+}
+
 fs::path WalletDataFilePath(const std::string& walletName)
 {
-    const fs::path walletDir = GetWalletDir();
-    if (IsDirectoryWalletName(walletName)) {
-        return walletDir / walletName / "wallet.dat";
-    }
-    return walletDir / walletName;
+    return GetWalletDir() / WalletDataFileName(walletName);
 }
 
 bool EnsureWalletDirectoryExists(const std::string& walletName)
@@ -45,11 +64,18 @@ bool EnsureWalletDirectoryExists(const std::string& walletName)
     const fs::path walletPath = GetWalletDir() / walletName;
     try {
         if (!fs::exists(walletPath)) {
+            // No file or directory at this name yet — create the wallet
+            // directory. CreateWalletFromFile() will populate it.
             fs::create_directories(walletPath);
+        } else if (fs::is_regular_file(walletPath)) {
+            // A flat wallet file already squats on the name. Do NOT
+            // mkdir — the migration-friendly path in WalletDataFilePath
+            // will resolve to the flat file instead. Returning success
+            // keeps the open flow going with flat semantics.
+            return true;
         } else if (!fs::is_directory(walletPath)) {
-            // A regular file already squats on the directory name — fail
-            // hard rather than silently fall back to flat layout, which
-            // would surprise the caller.
+            // Something exotic (symlink to nothing, socket, etc.) —
+            // refuse rather than risk silent data loss.
             return false;
         }
     } catch (const fs::filesystem_error&) {

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2017-2018 The Bitcoin Core developers
+// Copyright (c) 2026 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/walletutil.h"
+
+#include "util.h"
+
+fs::path GetWalletDir()
+{
+    // No -walletdir support yet; every wallet lives under the data
+    // directory. Wallet-dir lookup is centralised here so the eventual
+    // -walletdir flag (mirroring Bitcoin Core's PR #11077) is a single
+    // change.
+    return GetDataDir();
+}
+
+bool IsDirectoryWalletName(const std::string& walletName)
+{
+    if (walletName.empty()) {
+        return false;
+    }
+    // A `.` anywhere in the name keeps the historical flat-file
+    // semantics (`unsandbox.dat`, `archive.bak`, etc.). Names without
+    // any dot are treated as directory wallets, matching how Bitcoin
+    // Core decides createwallet's on-disk layout post-PR #11687.
+    return walletName.find('.') == std::string::npos;
+}
+
+fs::path WalletDataFilePath(const std::string& walletName)
+{
+    const fs::path walletDir = GetWalletDir();
+    if (IsDirectoryWalletName(walletName)) {
+        return walletDir / walletName / "wallet.dat";
+    }
+    return walletDir / walletName;
+}
+
+bool EnsureWalletDirectoryExists(const std::string& walletName)
+{
+    if (!IsDirectoryWalletName(walletName)) {
+        return true; // flat wallets live at wallet-dir root; nothing to mkdir
+    }
+    const fs::path walletPath = GetWalletDir() / walletName;
+    try {
+        if (!fs::exists(walletPath)) {
+            fs::create_directories(walletPath);
+        } else if (!fs::is_directory(walletPath)) {
+            // A regular file already squats on the directory name — fail
+            // hard rather than silently fall back to flat layout, which
+            // would surprise the caller.
+            return false;
+        }
+    } catch (const fs::filesystem_error&) {
+        return false;
+    }
+    return true;
+}
+
+std::string WalletNameFromDataFilePath(const std::string& dataFilePath)
+{
+    // Convention from WalletDataFilePath():
+    //   directory wallet → "<name>/wallet.dat"
+    //   flat wallet      → "<name>"
+    const std::string suffix = "/wallet.dat";
+    if (dataFilePath.size() > suffix.size() &&
+        dataFilePath.compare(dataFilePath.size() - suffix.size(), suffix.size(), suffix) == 0) {
+        return dataFilePath.substr(0, dataFilePath.size() - suffix.size());
+    }
+    return dataFilePath;
+}

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -31,14 +31,23 @@ fs::path GetWalletDir();
 //! opened as a flat file in the wallet dir root.
 bool IsDirectoryWalletName(const std::string& walletName);
 
-//! Resolve a user-facing wallet name into the path BDB should open.
+//! Resolve a user-facing wallet name into the BDB-relative file string
+//! (the path passed to Db::open, evaluated relative to the BDB env's
+//! home directory which is GetWalletDir()).
 //!
-//! For directory wallets returns `<walletdir>/<name>/wallet.dat`. For flat
-//! wallets returns `<walletdir>/<name>` (where `<name>` already carries its
-//! extension, e.g. `unsandbox.dat`).
+//! For directory wallets returns `<name>/wallet.dat`. For flat wallets
+//! returns `<name>` as-is (e.g. `unsandbox.dat`).
 //!
-//! Callers must ensure the parent directory exists before opening the
-//! database; see EnsureWalletDirectoryExists() below.
+//! Migration-aware: if the user passes a no-extension name and a regular
+//! file already sits at `<walletdir>/<name>`, this returns `<name>`
+//! (flat) — so adopting the new naming convention by just dropping the
+//! `.dat` suffix doesn't need a mkdir+mv first.
+std::string WalletDataFileName(const std::string& walletName);
+
+//! Absolute path version of WalletDataFileName() — prepends GetWalletDir().
+//! Useful for fs::exists / log lines / error messages. The CDB / bitdb
+//! callsites want the relative version (WalletDataFileName) because BDB
+//! resolves paths against env home itself.
 fs::path WalletDataFilePath(const std::string& walletName);
 
 //! Create the directory for a directory-layout wallet, if needed.

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2017-2018 The Bitcoin Core developers
+// Copyright (c) 2026 The Dogecoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DOGECOIN_WALLET_WALLETUTIL_H
+#define DOGECOIN_WALLET_WALLETUTIL_H
+
+#include "fs.h"
+
+#include <string>
+
+//! Get the path of the wallet directory.
+//!
+//! Currently this just returns GetDataDir(). When `-walletdir` config support
+//! is added the lookup moves here. Centralising it now keeps every wallet
+//! callsite that needs "where does <wallet_name> live" pointed at one place,
+//! so the eventual `-walletdir` follow-up is a single-file change.
+fs::path GetWalletDir();
+
+//! True when the wallet name should be interpreted as a directory wallet
+//! (i.e. `<walletdir>/<name>/wallet.dat`).
+//!
+//! Heuristic, matching Bitcoin Core post-PR #11687:
+//!   - empty            → flat (legacy default-wallet behaviour)
+//!   - contains a `.`   → flat (e.g. `unsandbox.dat`, `legacy.bak`)
+//!   - otherwise        → directory (e.g. `unsandbox`)
+//!
+//! The dot-suffix detection preserves backwards compatibility: any wallet
+//! file users have been carrying with an explicit extension keeps being
+//! opened as a flat file in the wallet dir root.
+bool IsDirectoryWalletName(const std::string& walletName);
+
+//! Resolve a user-facing wallet name into the path BDB should open.
+//!
+//! For directory wallets returns `<walletdir>/<name>/wallet.dat`. For flat
+//! wallets returns `<walletdir>/<name>` (where `<name>` already carries its
+//! extension, e.g. `unsandbox.dat`).
+//!
+//! Callers must ensure the parent directory exists before opening the
+//! database; see EnsureWalletDirectoryExists() below.
+fs::path WalletDataFilePath(const std::string& walletName);
+
+//! Create the directory for a directory-layout wallet, if needed.
+//!
+//! No-op when walletName is a flat wallet. Returns false if the directory
+//! could not be created (filesystem error, permissions, etc.); the caller
+//! should surface this to the user as a wallet-creation failure.
+bool EnsureWalletDirectoryExists(const std::string& walletName);
+
+//! Inverse of WalletDataFilePath() — recover the user-facing wallet name
+//! from an internal BDB file path.
+//!
+//! For "unsandbox/wallet.dat" returns "unsandbox".
+//! For "unsandbox.dat" returns "unsandbox.dat" (flat file = name).
+//!
+//! Used by CWallet::GetName() so listwallets and the /wallet/<name>/ URL
+//! router speak the user-facing name regardless of on-disk layout.
+std::string WalletNameFromDataFilePath(const std::string& dataFilePath);
+
+#endif // DOGECOIN_WALLET_WALLETUTIL_H


### PR DESCRIPTION
# Multi-wallet for Dogecoin Core 1.14

Backport of Bitcoin Core 0.17/0.18 multi-wallet to Dogecoin Core 1.14:
one daemon hosts N wallets, each accessible via `/wallet/<name>/` URL
routing or `dogecoin-cli -rpcwallet=<name>`.

Branch: `feature/multi-wallet` · Tip tag: **`v1.14.99-mw3`** · 23 commits.

## What's in the PR

Five reviewable groups, each with its own tag for progressive bisect:

### 1. Multi-wallet plumbing (mw0, Bitcoin 0.17-equivalent)
14 commits introducing `vpwallets` registry, per-wallet routing,
`GetWalletForJSONRPCRequest()`, `httprpc /wallet/` prefix handler,
the four lifecycle RPCs (`listwallets` / `loadwallet` / `createwallet`
/ `unloadwallet`), and BDB lifecycle fixes for unload-reload + shutdown.
`pwalletMain` preserved as a transitional alias.

### 2. Directory wallet layout (mw1, Bitcoin 0.18-equivalent)
4 commits adding `src/wallet/walletutil.{h,cpp}` with:
- `IsDirectoryWalletName()` — dot-suffix heuristic. No dot → directory
  layout (`<walletdir>/<name>/wallet.dat`). Dot present → flat
  (`<walletdir>/<name>.dat`). DEFAULT_WALLET_DAT keeps legacy
  semantics exactly.
- `WalletDataFileName()` — migration-aware path resolution: if a
  flat file already squats on a no-extension name, returns the flat
  string so users can drop the `.dat` from conf in place without a
  mkdir+mv.
- `EnsureWalletDirectoryExists()` — mkdir for directory-layout names.
- `WalletNameFromDataFilePath()` — inverse, used by `CWallet::GetName()`
  so `listwallets` and the URL router speak user-facing names
  regardless of on-disk layout.

`CWallet` gains an `m_name` member set at construction from
`strWalletFile`; `GetName()` returns `m_name`. `Verify()`,
`InitLoadWallet`, and `createwallet` / `loadwallet` RPCs all thread
through `WalletDataFileName`.

### 3. CLI + correctness polish (mw2)
2 commits:
- `dogecoin-cli -rpcwallet=<name>` (Bitcoin PR #10817) — CLI POSTs
  to `/wallet/<name>/` instead of `/`. Closes the "every wallet RPC
  needs curl + hand-built JSON" foot-gun.
- `validateaddress` in `src/rpc/misc.cpp` — switched from
  `pwalletMain` to `GetWalletForJSONRPCRequest`. Pre-fix,
  `/wallet/<X>/validateaddress` silently queried the first-loaded
  wallet regardless of `<X>`. Was a time-bomb for MPS multi-tenant.

### 4. Per-wallet BDB env (mw3, Bitcoin PR #11687 + #11077)
2 commits:
- **`bitdb` singleton → `g_dbenvs` map.** New `GetWalletEnv(wallet_path,
  &database_filename)` returns the env for a given wallet path,
  splitting it into env-dir + bdb-relative filename and lazily
  constructing the env. Single namespace-level `cs_db` guards the
  registry. Every `bitdb.*` callsite migrated: `CWallet::Verify`,
  `CWallet::Flush`, `CWallet::BackupWallet`,
  `CWalletDB::ThreadFlushWalletDB`, `CDB::Rewrite`, `loadwallet` /
  `unloadwallet` RPCs, `WalletTestingSetup`. Result: each directory-
  layout wallet has its OWN env (separate `database/`, `db.log`,
  `.walletlock` inside the wallet's directory). `unloadwallet`
  truly releases the env. Corruption isolated per env.
- **`-walletdir=<dir>`** — wallets at arbitrary filesystem locations.
  Resolves: explicit `-walletdir` → `<datadir>/wallets/` if exists →
  `<datadir>/` (legacy). Validated at `Verify()` head.

### 5. Tests (1 commit)
5 new BOOST test cases under `wallet_tests`:
`walletutil_is_directory_wallet_name`,
`walletutil_data_file_name_resolution`,
`walletutil_name_from_data_file_path_roundtrip`,
`walletutil_ensure_directory`,
`getwalletenv_per_directory_isolation`. Plus a regression fix:
legacy `CDB(const std::string&)` ctor used to short-circuit on empty
filename; after the env refactor the empty string was resolving to
the wallet dir itself. Caught by pre-existing `wallet_tests/rescan`.

## Migration semantics for existing nodes

All five paths preserve keys:

| Starting point | Action | Result |
|---|---|---|
| Pure legacy `wallet=wallet.dat` | nothing | unchanged, flat layout |
| Multi-wallet flat `wallet=foo.dat` | nothing | unchanged, flat layout |
| Want cleaner name, no on-disk move | `mv foo.dat foo` + conf `wallet=foo` | loads as flat (migration-aware) |
| Want proper directory layout | `mkdir foo && mv foo.dat foo/wallet.dat` + conf `wallet=foo` | directory layout |
| Fresh node, multi-wallet from day one | `createwallet "foo"` | directory layout (default) |

## Verification

**Local regtest** end-to-end on the mw3 binary:
`createwallet`, `getnewaddress`, `generatetoaddress`, `getbalance`,
**`sendtoaddress`** (money-moving WRITE), `gettransaction`,
`listtransactions`, `getreceivedbyaddress`, `unloadwallet`,
`loadwallet`, balance persistence across reload, per-request
`validateaddress` correctly says `ismine: false` for cross-wallet
queries. Two wallets in same datadir each have their own
`database/` + `db.log` + `wallet.dat` after running operations.

**`-walletdir`**: pointed `walletdir=/tmp/.../mywallets`, ran with
`wallet=zeta` — wallet landed at `/tmp/.../mywallets/zeta/wallet.dat`,
datadir contained zero wallet files.

**Production**: mw1 deployed on cammy.foxhop.net 2026-06-19, serving
real DOGE payments end-to-end via the wallet beam +
`/wallet/unsandbox/` URL routing. Migrated `unsandbox.dat` →
`unsandbox/wallet.dat`, BDB keys preserved, fresh address minted via
the portal payment flow validates as `ismine: true, account:
"unsandbox-api-key", hdkeypath: m/0'/3'/69'` on this binary.

**Tests**: full `test_dogecoin` binary green; 12 wallet test cases
(7 existing + 5 new) all pass.

## Known gaps

- **Python functional tests** (`test/functional/wallet_multiwallet.py`)
  not portable as-is — dogecoin 1.14 never adopted Bitcoin Core's
  `test/functional/test_framework/` python harness. Bringing that
  framework in is its own dedicated initiative; out of scope here.
- **`getaddressinfo`** — Bitcoin 0.18 (PR #12198) split the wallet-
  context fields out of `validateaddress` into a separate RPC and
  started deprecating the combined response. We keep the legacy
  combined shape; dogecoin 1.14 clients expect it.
- **`rpc/misc.cpp` audit** — only `validateaddress` was migrated to
  the per-request wallet handle. A quick audit shows no other
  state-reading RPCs there, but a follow-up pass to confirm and
  migrate any stragglers is reasonable.

## How to review

Top-down reading order:

1. `walletutil.h` — declarations + intent comments for the directory-
   layout helpers.
2. mw3 (`14a08b99` env refactor + `3ede79f2` walletdir) — the
   structural piece; everything else stacks on top.
3. mw1 (4 commits, walletutil + threading through Verify + RPCs) —
   how the helpers connect to the wallet open path.
4. mw0 — chronological for the multi-wallet plumbing groundwork.
5. mw2 (CLI + validateaddress) — small, self-contained polish.

Hardest commits to review (in the order they were hardest to write):
`14a08b99` (env refactor — touches `CDB::CDB`, `CWallet::Verify`,
`ThreadFlushWalletDB`, `loadwallet`/`unloadwallet`),
`6b27ce83` (mw0's BDB lifecycle fix for unload/reload),
`2a8e19d4` (mw1's threading dbFile through the wallet startup loop).
