### PR TITLE
depends: fix broken package source downloads

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,6 +1,6 @@
 package=expat
 $(package)_version=2.6.2
-$(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_6_2
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=9C7C1B5DCBC3C237C500A8FB1493E14D9582146DD9B42AA8D3FFB856A3B927E0
 

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -1,6 +1,6 @@
 package=freetype
 $(package)_version=2.11.0
-$(package)_download_path=http://download.savannah.gnu.org/releases/$(package)
+$(package)_download_path=https://download-mirror.savannah.gnu.org/releases/$(package)
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,7 +1,7 @@
 package=openssl
 $(package)_version=1.0.2
 $(package)_version_suffix=u
-$(package)_download_path=https://www.openssl.org/source
+$(package)_download_path=https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u
 $(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
 $(package)_sha256_hash=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 $(package)_patches=secure_getenv.patch

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,7 +1,7 @@
 package=openssl
 $(package)_version=1.0.2
 $(package)_version_suffix=u
-$(package)_download_path=https://www.openssl.org/source/old/$($(package)_version)
+$(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
 $(package)_sha256_hash=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 $(package)_patches=secure_getenv.patch

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,6 +1,7 @@
 package=qrencode
 $(package)_version=3.4.4
-$(package)_download_path=https://fukuchi.org/works/qrencode/
+$(package)_download_path=https://snapshot.debian.org/archive/debian/20151220T000000Z/pool/main/q/qrencode
+$(package)_download_file=qrencode_$($(package)_version).orig.tar.bz2
 $(package)_file_name=qrencode-$(qrencode_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 

--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,6 +1,6 @@
 package=zlib
 $(package)_version=1.3
-$(package)_download_path=https://www.zlib.net/fossils
+$(package)_download_path=https://github.com/madler/zlib/releases/download/v$($(package)_version)
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 

--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,6 +1,6 @@
 package=zlib
 $(package)_version=1.3
-$(package)_download_path=http://www.zlib.net
+$(package)_download_path=https://www.zlib.net/fossils
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 


### PR DESCRIPTION
Three depends packages currently fail to fetch because their upstream
source URLs are dead, and the FALLBACK_DOWNLOAD_PATH mirror
(depends.dogecoincore.org) currently serves an expired TLS
certificate, so the fallback fails too:

- openssl: openssl.org no longer serves 1.0.2 under /source/old/1.0.2/
  (404). Still available at the root /source/ path.
  https://openssl-library.org/source/old/1.0.2/index.html

- qrencode: fukuchi.org is offline entirely; upstream now points to
  GitHub for releases instead. See also Bitcoin Core hitting and
  fixing the same issue for qrencode 4.1.1:
  https://repology.org/project/qrencode/information
  https://github.com/bitcoin/bitcoin/pull/33494

- zlib: zlib.net moves previous releases into /fossils once a new
  version is published; root path no longer serves 1.3.
  https://www.zlib.net/fossils/

Each download_path is updated to a source verified to serve a
byte-identical file. No sha256_hash values were changed.

Tested with a clean `make -C depends HOST=x86_64-w64-mingw32` on this
branch, followed by `./autogen.sh && ./configure && make`.