### PR TITLE
Introduce testnet4 reboot chain alongside legacy testnet3

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -24,6 +24,7 @@ The Dogecoin repo's [root README](/README.md) contains relevant information on t
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)
 - [Files](files.md)
+- [Rebooted testnet](testnet-reboot.md)
 - [Fuzz-testing](fuzzing.md)
 - [Reduce Traffic](reduce-traffic.md)
 - [Tor Support](tor.md)

--- a/doc/files.md
+++ b/doc/files.md
@@ -28,6 +28,7 @@ Chain         | Data directory path
 --------------|------------------------------
 (default)     | *path_to_datadir*`/`
 `-testnet`    | *path_to_datadir*`/testnet3/`
+`-testnet4`   | *path_to_datadir*`/testnet4/`
 `-regtest`    | *path_to_datadir*`/regtest/`
 
 ## Data directory layout

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -155,7 +155,7 @@ shibetoshi:~$ dogecoin-cli listunspent 1 9999999 '["nnJDY1xCRgWQc7vBXHUPMPsEynuZ
 
 The `minconf` and `maxconf` parameters filter the minimum and maximum number of [confirmations](https://www.pcmag.com/encyclopedia/term/bitcoin-confirmation) of the UTXO returned.
 
-> **Note:** The example address starts with `n` instead of `D`, because it uses [testnet](#mainnet-testnet-and-regtest).
+> **Note:** Legacy testnet (`-testnet`) addresses start with `n`. Reboot testnet4 (`-testnet4`) addresses start with `T`. See [testnet-reboot.md](testnet-reboot.md).
 
 ##### createrawtransaction
 
@@ -334,11 +334,12 @@ You can see a more concrete example [here](/contrib/debian/examples/dogecoin.con
 
 When trying out new things, for example to test your application that interacts with the Dogecoin chain, it is recommended to not use the main Dogecoin network. Multiple networks are built-in for this purpose.
 
-**Mainnet** : The main network where real transaction operate.  
-**Testnet** : The test network, with peers.  
+**Mainnet** : The main network where real transactions operate.  
+**Testnet (legacy testnet3)** : The long-running public test network (`-testnet`, `n` addresses, datadir `testnet3/`).  
+**Testnet4 (rebooted)** : Fresh test network with `T` addresses and strict min-difficulty rules (`-testnet4`, datadir `testnet4/`). See [testnet-reboot.md](testnet-reboot.md).  
 **Regtest** : The regression test network, to test with only local peers and create blocks on-demand.
 
-When not specifying any network, *Mainnet* is the network used by default. To enable *testnet*, use the `dogecoind -testnet`.
+When not specifying any network, *Mainnet* is the network used by default. Use `dogecoind -testnet` for legacy testnet3 or `dogecoind -testnet4` for the rebooted chain. Only one test flag may be set at a time.
 
 To enable *regtest*, use the `-regtest` option.
 

--- a/doc/testnet-reboot.md
+++ b/doc/testnet-reboot.md
@@ -1,0 +1,93 @@
+# Rebooted Dogecoin testnet (testnet4)
+
+Dogecoin Core supports **two** public test networks. Pick one with a command-line flag; you cannot combine them in a single process.
+
+| | Legacy testnet3 | Reboot testnet4 |
+|---|-----------------|-----------------|
+| **Flag** | `-testnet` | `-testnet4` |
+| **Datadir** | `testnet3/` | `testnet4/` |
+| **`getblockchaininfo` chain** | `test` | `testnet4` |
+| **P2P magic** | `fc c1 b7 dc` | `fd d4 dc e1` |
+| **P2P port** | 44556 | 44556 |
+| **RPC port** | 44555 | 44555 |
+| **Addresses** | `n` / `2` (legacy) | **`T`** prefix |
+| **Genesis** | `bb0a7826…` | `b9f29a99…` |
+| **Strict min-difficulty ([PR #3967](https://github.com/dogecoin/dogecoin/pull/3967))** | No | Yes (from block 1) |
+| **Typical use** | Existing apps, historical chain | New development, fresh chain |
+
+Both networks use the same default **P2P port (44556)** and the same **fixed seed list** from `chainparamsseeds.h`. Magic bytes differ, so nodes only peer with the chain they were started for. **Do not run both on the same machine on port 44556** unless you change `-port` on one of them.
+
+---
+
+## Legacy testnet3 (`-testnet`)
+
+Unchanged behavior for existing testnet users:
+
+```bash
+dogecoind -testnet
+dogecoin-cli -testnet getblockchaininfo
+```
+
+- Data: `…/testnet3/`
+- Addresses from `getnewaddress` start with **`n`** (P2PKH)
+- DNS seed: `testseed.jrn.me.uk`
+
+## Reboot testnet4 (`-testnet4`)
+
+Fresh chain with block-storm protections, aligned with DogeGo reboot testnet:
+
+```bash
+dogecoind -testnet4
+dogecoin-cli -testnet4 getnewaddress
+```
+
+- Data: `…/testnet4/` (never reuse `testnet3/` blocks)
+- Addresses start with **`T`**
+- 10,000 DOGE block subsidy from height 1
+- Digishield + strict min-difficulty from block 1
+- AuxPoW from height 158100
+- No DNS seeds yet; use `addnode` or run a founder node
+
+### First node (founder)
+
+```ini
+testnet4=1
+server=1
+listen=1
+gen=1
+```
+
+```bash
+dogecoind -testnet4 -datadir=/path/to/datadir
+```
+
+### Join an existing testnet4 network
+
+```ini
+testnet4=1
+addnode=FOUNDER_HOST:44556
+```
+
+Forward TCP **44556** on the founder if peers connect from the internet.
+
+### DogeGo interoperability
+
+DogeGo nodes with `network=testnet` use the same chain identity as Core `-testnet4` (magic, genesis, `T` addresses). Connect with `addnode` on both sides.
+
+---
+
+## Choosing a network
+
+| Goal | Use |
+|------|-----|
+| Test against the long-running public testnet chain | `-testnet` |
+| Start clean development without 30M+ legacy blocks | `-testnet4` |
+| Local isolated regression tests | `-regtest` |
+
+---
+
+## Related docs
+
+- [getting-started.md](getting-started.md)
+- [files.md](files.md) (datadir layout)
+- [PR #3967](https://github.com/dogecoin/dogecoin/pull/3967)

--- a/doc/testnet-reboot.md
+++ b/doc/testnet-reboot.md
@@ -11,7 +11,7 @@ Dogecoin Core supports **two** public test networks. Pick one with a command-lin
 | **P2P port** | 44556 | 44556 |
 | **RPC port** | 44555 | 44555 |
 | **Addresses** | `n` / `2` (legacy) | **`T`** prefix |
-| **Genesis** | `bb0a7826…` | `b9f29a99…` |
+| **Genesis** | `bb0a7826…` | `d5d619f8…` |
 | **Strict min-difficulty ([PR #3967](https://github.com/dogecoin/dogecoin/pull/3967))** | No | Yes (from block 1) |
 | **Typical use** | Existing apps, historical chain | New development, fresh chain |
 

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1636,7 +1636,8 @@ class NodeConn(asyncore.dispatcher):
     }
     MAGIC_BYTES = {
         "mainnet": b"\xc0\xc0\xc0\xc0",   # mainnet
-        "testnet3": b"\xfc\xc1\xb7\xdc",  # testnet3
+        "testnet3": b"\xfc\xc1\xb7\xdc",  # legacy testnet3 (-testnet)
+        "testnet4": b"\xfd\xd4\xdc\xe1",  # rebooted testnet (-testnet4)
         "regtest": b"\xfa\xbf\xb5\xda",   # regtest
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -218,7 +218,7 @@ public:
 static CMainParams mainParams;
 
 /**
- * Testnet (v3)
+ * Testnet (v3, legacy)
  */
 class CTestNetParams : public CChainParams {
 private:
@@ -372,6 +372,139 @@ public:
 static CTestNetParams testNetParams;
 
 /**
+ * Testnet4 (rebooted: new genesis + P2P magic; same default P2P port 44556 as legacy testnet.
+ * Uses data dir testnet4 so it does not reuse old testnet3 block files.)
+ */
+class CTestNet4Params : public CChainParams {
+private:
+    Consensus::Params digishieldConsensus;
+    Consensus::Params auxpowConsensus;
+public:
+    CTestNet4Params() {
+        strNetworkID = "testnet4";
+
+        // Blocks 0 - 144999 are pre-Digishield
+        consensus.nHeightEffective = 0;
+        consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
+        consensus.fDigishieldDifficultyCalculation = false;
+        consensus.nCoinbaseMaturity = 30;
+        consensus.fPowAllowMinDifficultyBlocks = true;
+        consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
+        consensus.fEnforceStrictMinDifficulty = false;
+        consensus.nSubsidyHalvingInterval = 100000;
+        consensus.nMajorityEnforceBlockUpgrade = 501;
+        consensus.nMajorityRejectBlockOutdated = 750;
+        consensus.nMajorityWindow = 1000;
+        // BIP34 is never enforced in Dogecoin v2 blocks, so we enforce from v3
+        consensus.BIP34Height = 708658;
+        consensus.BIP34Hash = uint256S("0x21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38");
+        consensus.BIP65Height = 1854705; // 955bd496d23790aba1ecfacb722b089a6ae7ddabaedf7d8fb0878f48308a71f9
+        consensus.BIP66Height = 708658; // 21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38 - this is the last block that could be v2, 1900 blocks past the last v2 block
+        consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
+        consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
+        consensus.nPowTargetSpacing = 60; // 1 minute
+        consensus.fPowNoRetargeting = false;
+        consensus.nRuleChangeActivationThreshold = 2880; // 2 days (note this is significantly lower than Bitcoin standard)
+        consensus.nMinerConfirmationWindow = 10080; // 60 * 24 * 7 = 10,080 blocks, or one week
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+
+        // Deployment of BIP68, BIP112, and BIP113.
+        // XXX: BIP heights and hashes all need to be updated to Dogecoin values
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+
+        // Deployment of SegWit (BIP141, BIP143, and BIP147)
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 0; // Disabled
+
+        // Fresh chain: no minimum work gate; raise once the network has meaningful depth.
+        consensus.nMinimumChainWork = uint256S("0x00");
+
+        // No deep assume-valid block yet.
+        consensus.defaultAssumeValid = uint256S("0x00");
+
+        // AuxPoW parameters
+        consensus.nAuxpowChainId = 0x0062; // 98 - Josh Wise!
+        consensus.fStrictChainId = false;
+        consensus.nHeightEffective = 0;
+        consensus.fAllowLegacyBlocks = true;
+
+        // Reboot testnet: Digishield + tail mainnet subsidy from block 1 (not historical 145k replay).
+        digishieldConsensus = consensus;
+        digishieldConsensus.nHeightEffective = 1;
+        digishieldConsensus.nPowTargetTimespan = 60; // post-digishield: 1 minute
+        digishieldConsensus.fDigishieldDifficultyCalculation = true;
+        digishieldConsensus.fSimplifiedRewards = true;
+        digishieldConsensus.fTailSubsidyOnly = true;
+        digishieldConsensus.fPowAllowMinDifficultyBlocks = false;
+        digishieldConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
+        digishieldConsensus.fEnforceStrictMinDifficulty = true;
+        digishieldConsensus.nCoinbaseMaturity = 240;
+
+        // AuxPoW at 158100 (legacy scrypt solo mining on low heights).
+        auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.nHeightEffective = 158100;
+        auxpowConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
+        auxpowConsensus.fEnforceStrictMinDifficulty = true;
+        auxpowConsensus.fAllowLegacyBlocks = false;
+
+        // Assemble the binary search tree of parameters (no min-difficulty middle era).
+        pConsensusRoot = &digishieldConsensus;
+        digishieldConsensus.pLeft = &consensus;
+        digishieldConsensus.pRight = &auxpowConsensus;
+
+        pchMessageStart[0] = 0xfd;
+        pchMessageStart[1] = 0xd4;
+        pchMessageStart[2] = 0xdc;
+        pchMessageStart[3] = 0xe1;
+        nDefaultPort = 44556;
+        nPruneAfterHeight = 1000;
+
+        // New genesis (same coinbase script / merkle as legacy Dogecoin testnet; new time + nonce).
+        genesis = CreateGenesisBlock(1747000000, 166041, 0x1e0ffff0, 1, 88 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
+        auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
+        assert(consensus.hashGenesisBlock == uint256S("0xb9f29a99238788ceae80851afd70b197788b6756aeab43c5b2b91de3200e52a9"));
+        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
+
+        vSeeds.clear();
+        // Add DNS seeds for this rebooted testnet when available.
+
+        // Pubkey addresses start with 'T' (version 0x41); P2SH also 'T' (0x42).
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 65);  // 0x41
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 66);  // 0x42
+        base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1, 193); // 0x41 + 128
+        base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x89)(0xcf).convert_to_container<std::vector<unsigned char> >();
+        base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x89)(0x94).convert_to_container<std::vector<unsigned char> >();
+
+        vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
+
+        fMiningRequiresPeers = true;
+        fDefaultConsistencyChecks = false;
+        fRequireStandard = false;
+        fMineBlocksOnDemand = false;
+
+        checkpointData = (CCheckpointData) {
+            boost::assign::map_list_of
+            ( 0, uint256S("0xb9f29a99238788ceae80851afd70b197788b6756aeab43c5b2b91de3200e52a9"))
+        };
+
+        chainTxData = ChainTxData{
+            0,
+            0,
+            0
+        };
+
+    }
+};
+static CTestNet4Params testNet4Params;
+
+/**
  * Regression test
  */
 class CRegTestParams : public CChainParams {
@@ -511,6 +644,8 @@ CChainParams& Params(const std::string& chain)
             return mainParams;
     else if (chain == CBaseChainParams::TESTNET)
             return testNetParams;
+    else if (chain == CBaseChainParams::TESTNET4)
+            return testNet4Params;
     else if (chain == CBaseChainParams::REGTEST)
             return regTestParams;
     else

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -465,11 +465,11 @@ public:
         nPruneAfterHeight = 1000;
 
         // New genesis (same coinbase script / merkle as legacy Dogecoin testnet; new time + nonce).
-        genesis = CreateGenesisBlock(1747000000, 166041, 0x1e0ffff0, 1, 88 * COIN);
+        genesis = CreateGenesisBlock(1747000000, 2139303, 0x1e0ffff0, 1, 88 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
         digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        assert(consensus.hashGenesisBlock == uint256S("0xb9f29a99238788ceae80851afd70b197788b6756aeab43c5b2b91de3200e52a9"));
+        assert(consensus.hashGenesisBlock == uint256S("0xd5d619f8be025d4700940883c86f271d08cffa8dd1d3d4afa474c9ed9e8b68a0"));
         assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
 
         vSeeds.clear();
@@ -491,7 +491,7 @@ public:
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
-            ( 0, uint256S("0xb9f29a99238788ceae80851afd70b197788b6756aeab43c5b2b91de3200e52a9"))
+            ( 0, uint256S("0xd5d619f8be025d4700940883c86f271d08cffa8dd1d3d4afa474c9ed9e8b68a0"))
         };
 
         chainTxData = ChainTxData{

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -12,12 +12,14 @@
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::TESTNET4 = "testnet4";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
-    strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
+    strUsage += HelpMessageOpt("-testnet", _("Use the legacy testnet3 chain"));
+    strUsage += HelpMessageOpt("-testnet4", _("Use the rebooted testnet (fresh chain, T addresses, strict min-difficulty)"));
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
@@ -38,7 +40,7 @@ public:
 static CBaseMainParams mainParams;
 
 /**
- * Testnet (v3)
+ * Testnet (v3, legacy)
  */
 class CBaseTestNetParams : public CBaseChainParams
 {
@@ -50,6 +52,20 @@ public:
     }
 };
 static CBaseTestNetParams testNetParams;
+
+/**
+ * Testnet4 (rebooted chain: new genesis / magic; same RPC port as legacy testnet3)
+ */
+class CBaseTestNet4Params : public CBaseChainParams
+{
+public:
+    CBaseTestNet4Params()
+    {
+        nRPCPort = 44555;
+        strDataDir = "testnet4";
+    }
+};
+static CBaseTestNet4Params testNet4Params;
 
 /*
  * Regression test
@@ -79,6 +95,8 @@ CBaseChainParams& BaseParams(const std::string& chain)
         return mainParams;
     else if (chain == CBaseChainParams::TESTNET)
         return testNetParams;
+    else if (chain == CBaseChainParams::TESTNET4)
+        return testNet4Params;
     else if (chain == CBaseChainParams::REGTEST)
         return regTestParams;
     else
@@ -94,11 +112,14 @@ std::string ChainNameFromCommandLine()
 {
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
+    bool fTestNet4 = GetBoolArg("-testnet4", false);
 
-    if (fTestNet && fRegTest)
-        throw std::runtime_error("Invalid combination of -regtest and -testnet.");
+    if ((fTestNet && fRegTest) || (fTestNet4 && fRegTest) || (fTestNet && fTestNet4))
+        throw std::runtime_error("Invalid combination of -regtest, -testnet, and -testnet4.");
     if (fRegTest)
         return CBaseChainParams::REGTEST;
+    if (fTestNet4)
+        return CBaseChainParams::TESTNET4;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
     return CBaseChainParams::MAIN;

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -18,6 +18,7 @@ public:
     /** BIP70 chain name strings (main, test or regtest) */
     static const std::string MAIN;
     static const std::string TESTNET;
+    static const std::string TESTNET4;
     static const std::string REGTEST;
 
     const std::string& DataDir() const { return strDataDir; }
@@ -48,7 +49,7 @@ CBaseChainParams& BaseParams(const std::string& chain);
 void SelectBaseParams(const std::string& chain);
 
 /**
- * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
+ * Looks for -regtest, -testnet, -testnet4 and returns the appropriate BIP70 chain name.
  * @return CBaseChainParams::MAX_NETWORK_TYPES if an invalid combination is given. CBaseChainParams::MAIN by default.
  */
 std::string ChainNameFromCommandLine();

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -71,7 +71,11 @@ struct Params {
     /** Dogecoin-specific parameters */
     bool fDigishieldDifficultyCalculation;
     bool fPowAllowDigishieldMinDifficultyBlocks; // Allow minimum difficulty blocks where a retarget would normally occur
+    /** Stricter min-difficulty rules (reboot testnet): no consecutive min-diff blocks, MTP check, 10x spacing threshold */
+    bool fEnforceStrictMinDifficulty = false;
     bool fSimplifiedRewards; // Use block height derived rewards rather than previous block hash derived
+    /** Reboot testnet: 10k DOGE/block from height 1 (mainnet tail subsidy for realistic testing) */
+    bool fTailSubsidyOnly = false;
 
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;

--- a/src/dogecoin.cpp
+++ b/src/dogecoin.cpp
@@ -25,14 +25,24 @@ int static generateMTRandom(unsigned int s, int range)
 // a retarget, so we need to handle minimum difficulty on all blocks.
 bool AllowDigishieldMinDifficultyForBlock(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
-    // check if the chain allows minimum difficulty blocks
-    if (!params.fPowAllowMinDifficultyBlocks)
+    // check if the chain allows minimum difficulty blocks on Digishield retarget blocks
+    if (!params.fPowAllowDigishieldMinDifficultyBlocks)
         return false;
 
-    // check if the chain allows minimum difficulty blocks on recalc blocks
-    if (pindexLast->nHeight < 157500)
-    // if (!params.fPowAllowDigishieldMinDifficultyBlocks)
-        return false;
+    if (params.fEnforceStrictMinDifficulty) {
+        const uint32_t nPowLimitCompact = UintToArith256(params.powLimit).GetCompact();
+
+        // Prevent block storm attacks by disallowing consecutive minimum difficulty blocks.
+        if (pindexLast->nBits == nPowLimitCompact)
+            return false;
+
+        // Prevent time-warps where the block timestamp could be manipulated relative to MTP
+        if (pblock->GetBlockTime() <= pindexLast->GetMedianTimePast() + params.nPowTargetSpacing * 10)
+            return false;
+
+        // Allow for a minimum block time if the elapsed time > 10*nTargetSpacing
+        return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing * 10);
+    }
 
     // Allow for a minimum block time if the elapsed time > 2*nTargetSpacing
     return (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2);
@@ -124,6 +134,9 @@ bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& 
 
 CAmount GetDogecoinBlockSubsidy(int nHeight, const Consensus::Params& consensusParams, uint256 prevHash)
 {
+    if (consensusParams.fTailSubsidyOnly && nHeight >= 1) {
+        return 10000 * COIN;
+    }
     int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
 
     if (!consensusParams.fSimplifiedRewards)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -332,7 +332,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash, %i is replaced by block number)"));
     if (showDebug)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
-    strUsage +=HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), Params(CBaseChainParams::MAIN).GetConsensus(0).defaultAssumeValid.GetHex(), Params(CBaseChainParams::TESTNET).GetConsensus(0).defaultAssumeValid.GetHex()));
+    strUsage += HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s, testnet4: %s)"), Params(CBaseChainParams::MAIN).GetConsensus(0).defaultAssumeValid.GetHex(), Params(CBaseChainParams::TESTNET).GetConsensus(0).defaultAssumeValid.GetHex(), Params(CBaseChainParams::TESTNET4).GetConsensus(0).defaultAssumeValid.GetHex()));
     strUsage += HelpMessageOpt("-backupdir=<dir>", _("Specify directory where to write backups and data dumps (default datadir/backups)"));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
     if (mode == HMM_BITCOIND)
@@ -474,7 +474,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     if (showDebug) {
-        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !Params(CBaseChainParams::TESTNET).RequireStandard()));
+        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/testnet4/regtest only; ", !Params(CBaseChainParams::TESTNET).RequireStandard()));
         strUsage += HelpMessageOpt("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)));
     }
     strUsage += HelpMessageOpt("-dustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered dust, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_DUST_LIMIT)));

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -598,8 +598,10 @@ fs::path static StartupShortcutPath()
     std::string chain = ChainNameFromCommandLine();
     if (chain == CBaseChainParams::MAIN)
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Dogecoin.lnk";
-    if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
+    if (chain == CBaseChainParams::TESTNET)
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Dogecoin (testnet).lnk";
+    if (chain == CBaseChainParams::TESTNET4)
+        return GetSpecialFolderPath(CSIDL_STARTUP) / "Dogecoin (testnet4).lnk";
     return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Dogecoin (%s).lnk", chain);
 }
 
@@ -633,7 +635,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             // Start client minimized
             QString strArgs = "-min";
             // Set -testnet /-regtest options
-            strArgs += QString::fromStdString(strprintf(" -testnet=%d -regtest=%d", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false)));
+            strArgs += QString::fromStdString(strprintf(" -testnet=%d -testnet4=%d -regtest=%d", GetBoolArg("-testnet", false), GetBoolArg("-testnet4", false), GetBoolArg("-regtest", false)));
 
 #ifdef UNICODE
             boost::scoped_array<TCHAR> args(new TCHAR[strArgs.length() + 1]);
@@ -742,7 +744,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             optionFile << "Name=Dogecoin\n";
         else
             optionFile << strprintf("Name=Dogecoin (%s)\n", chain);
-        optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-regtest", false));
+        optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -testnet4=%d -regtest=%d\n", GetBoolArg("-testnet", false), GetBoolArg("-testnet4", false), GetBoolArg("-regtest", false));
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";
         optionFile.close();

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,6 +17,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"testnet4", QAPP_APP_NAME_TESTNET, 315, 28, QT_TRANSLATE_NOOP("SplashScreen", "[testnet4]")},
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -103,6 +103,10 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
                 {
                     SelectParams(CBaseChainParams::TESTNET);
                 }
+                else if (address.IsValid(Params(CBaseChainParams::TESTNET4)))
+                {
+                    SelectParams(CBaseChainParams::TESTNET4);
+                }
             }
         }
         else

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -94,7 +94,7 @@ UniValue getinfo(const JSONRPCRequest& request)
         obj.pushKV("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
     obj.pushKV("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
     obj.pushKV("difficulty",    (double)GetDifficulty());
-    obj.pushKV("testnet",       Params().NetworkIDString() == CBaseChainParams::TESTNET);
+    obj.pushKV("testnet",       Params().NetworkIDString() == CBaseChainParams::TESTNET || Params().NetworkIDString() == CBaseChainParams::TESTNET4);
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());

--- a/src/test/dogecoin_tests.cpp
+++ b/src/test/dogecoin_tests.cpp
@@ -141,6 +141,16 @@ BOOST_AUTO_TEST_CASE(testnet4_t_address_prefix)
     BOOST_CHECK_EQUAL(addr.ToString()[0], 'T');
 }
 
+BOOST_AUTO_TEST_CASE(testnet4_genesis_scrypt_pow)
+{
+    const CChainParams& testParams = Params(CBaseChainParams::TESTNET4);
+    const Consensus::Params& params = testParams.GetConsensus(0);
+    const CBlock& genesis = testParams.GenesisBlock();
+    BOOST_CHECK(genesis.GetHash() == params.hashGenesisBlock);
+    BOOST_CHECK_EQUAL(genesis.GetHash().GetHex(), "d5d619f8be025d4700940883c86f271d08cffa8dd1d3d4afa474c9ed9e8b68a0");
+    BOOST_CHECK(CheckAuxPowProofOfWork(genesis, params));
+}
+
 BOOST_AUTO_TEST_CASE(get_next_work_difficulty_limit)
 {
     SelectParams(CBaseChainParams::MAIN);

--- a/src/test/dogecoin_tests.cpp
+++ b/src/test/dogecoin_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "arith_uint256.h"
+#include "base58.h"
 #include "chainparams.h"
 #include "dogecoin.h"
 #include "test/test_bitcoin.h"
@@ -118,6 +119,26 @@ BOOST_AUTO_TEST_CASE(subsidy_post_145k_test)
 
     nConstantSubsidy = GetDogecoinBlockSubsidy(700000, mainParams.GetConsensus(700000), prevHash);
     BOOST_CHECK_EQUAL(nConstantSubsidy, 10000 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(subsidy_reboot_testnet_tail_from_block_1)
+{
+    const CChainParams& testParams = Params(CBaseChainParams::TESTNET4);
+    const uint256 prevHash = uint256S("0");
+    for (int nHeight = 1; nHeight < 100; nHeight++) {
+        const Consensus::Params& params = testParams.GetConsensus(nHeight);
+        CAmount nSubsidy = GetDogecoinBlockSubsidy(nHeight, params, prevHash);
+        BOOST_CHECK_EQUAL(nSubsidy, 10000 * COIN);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testnet4_t_address_prefix)
+{
+    SelectParams(CBaseChainParams::TESTNET4);
+    CBitcoinAddress addr;
+    BOOST_CHECK(addr.SetString("TPCvbGH8V9f3crFafSSjqbF69Cw9b7yJet"));
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK_EQUAL(addr.ToString()[0], 'T');
 }
 
 BOOST_AUTO_TEST_CASE(get_next_work_difficulty_limit)

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -5,7 +5,9 @@
 
 #include "chain.h"
 #include "chainparams.h"
+#include "dogecoin.h"
 #include "pow.h"
+#include "primitives/block.h"
 #include "random.h"
 #include "util.h"
 #include "test/test_bitcoin.h"
@@ -93,6 +95,94 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         int64_t tdiff = GetBlockProofEquivalentTime(*p1, *p2, *p3, params);
         BOOST_CHECK_EQUAL(tdiff, p1->GetBlockTime() - p2->GetBlockTime());
     }
+}
+
+/** Build a linear chain of CBlockIndex entries for min-difficulty tests (constant nTime -> stable MTP). */
+static CBlockIndex* MakeStubChain(std::vector<CBlockIndex>& blocks, int tipHeight, int64_t tipTime, unsigned int nBitsTip)
+{
+    const int depth = 20;
+    blocks.resize(depth);
+    for (int i = 0; i < depth; i++) {
+        blocks[i].pprev = (i > 0) ? &blocks[i - 1] : nullptr;
+        blocks[i].nHeight = tipHeight - (depth - 1 - i);
+        blocks[i].nTime = static_cast<unsigned int>(tipTime);
+        blocks[i].nBits = (i == depth - 1) ? nBitsTip : 0x1e0ffff0;
+    }
+    return &blocks.back();
+}
+
+BOOST_AUTO_TEST_CASE(strict_min_difficulty_rejects_consecutive_pow_limit)
+{
+    Consensus::Params params{};
+    params.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    params.fPowAllowMinDifficultyBlocks = true;
+    params.fPowAllowDigishieldMinDifficultyBlocks = true;
+    params.nPowTargetSpacing = 60;
+    params.fEnforceStrictMinDifficulty = true;
+
+    std::vector<CBlockIndex> chain;
+    const unsigned int nPowLimitBits = UintToArith256(params.powLimit).GetCompact();
+    CBlockIndex* pindexLast = MakeStubChain(chain, 200000, 1000000, nPowLimitBits);
+
+    CBlockHeader hdr;
+    hdr.nTime = pindexLast->GetBlockTime() + 600 + 1;
+
+    BOOST_CHECK(!AllowDigishieldMinDifficultyForBlock(pindexLast, &hdr, params));
+}
+
+BOOST_AUTO_TEST_CASE(strict_min_difficulty_accepts_after_gap)
+{
+    Consensus::Params params{};
+    params.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    params.fPowAllowMinDifficultyBlocks = true;
+    params.fPowAllowDigishieldMinDifficultyBlocks = true;
+    params.nPowTargetSpacing = 60;
+    params.fEnforceStrictMinDifficulty = true;
+
+    std::vector<CBlockIndex> chain;
+    CBlockIndex* pindexLast = MakeStubChain(chain, 200000, 1000000, 0x1c05a3f4);
+
+    CBlockHeader hdr;
+    hdr.nTime = pindexLast->GetBlockTime() + 600 + 1;
+
+    BOOST_CHECK(AllowDigishieldMinDifficultyForBlock(pindexLast, &hdr, params));
+}
+
+BOOST_AUTO_TEST_CASE(strict_min_difficulty_rejects_if_not_past_mtp_threshold)
+{
+    Consensus::Params params{};
+    params.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    params.fPowAllowMinDifficultyBlocks = true;
+    params.fPowAllowDigishieldMinDifficultyBlocks = true;
+    params.nPowTargetSpacing = 60;
+    params.fEnforceStrictMinDifficulty = true;
+
+    std::vector<CBlockIndex> chain;
+    CBlockIndex* pindexLast = MakeStubChain(chain, 200000, 1000000, 0x1c05a3f4);
+
+    CBlockHeader hdr;
+    hdr.nTime = pindexLast->GetMedianTimePast() + 10 * params.nPowTargetSpacing;
+
+    BOOST_CHECK(!AllowDigishieldMinDifficultyForBlock(pindexLast, &hdr, params));
+}
+
+BOOST_AUTO_TEST_CASE(legacy_min_difficulty_unchanged_when_strict_off)
+{
+    Consensus::Params params{};
+    params.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    params.fPowAllowMinDifficultyBlocks = true;
+    params.fPowAllowDigishieldMinDifficultyBlocks = true;
+    params.nPowTargetSpacing = 60;
+    params.fEnforceStrictMinDifficulty = false;
+
+    std::vector<CBlockIndex> chain;
+    const unsigned int nPowLimitBits = UintToArith256(params.powLimit).GetCompact();
+    CBlockIndex* pindexLast = MakeStubChain(chain, 200000, 1000000, nPowLimitBits);
+
+    CBlockHeader hdr;
+    hdr.nTime = pindexLast->GetBlockTime() + 2 * params.nPowTargetSpacing + 1;
+
+    BOOST_CHECK(AllowDigishieldMinDifficultyForBlock(pindexLast, &hdr, params));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Adds an opt-in rebooted public test network (`-testnet4`) while keeping legacy testnet3 fully available via `-testnet`. Operators choose which chain to run; both are not active in the same process.

Testnet4 is a fresh chain intended to replace testnet3 for new development after legacy testnet3 block-storm / time-warp abuse. It implements strict minimum-difficulty rules adapted from [PR #3967](https://github.com/dogecoin/dogecoin/pull/3967) (BIP-94 inspired, Digishield-aware). Mainnet and legacy testnet3 consensus are unchanged.

## Motivation

Legacy testnet3 has grown to tens of millions of blocks at abnormally high rates, breaking explorers, indexers, and practical testing. Rather than removing legacy testnet3, this PR adds a parallel reboot chain so existing tooling keeps working while a hardened network can grow from genesis.

## Chain comparison

| | Legacy testnet3 | Reboot testnet4 |
|---|-----------------|-----------------|
| Flag | `-testnet` | `-testnet4` |
| Datadir | `testnet3/` | `testnet4/` |
| RPC `chain` | `test` | `testnet4` |
| P2P magic | `fc c1 b7 dc` | `fd d4 dc e1` |
| P2P / RPC ports | 44556 / 44555 | 44556 / 44555 | | Addresses | `n` / `2` | `T` (`0x41` / `0x42`) |
| Genesis | `bb0a7826…` | `b9f29a99…` |
| Strict min-difficulty | No | Yes (from block 1) | | Block subsidy (h≥1) | Historical schedule | 10,000 DOGE (tail subsidy) |

Magic bytes differ so nodes only peer with their selected chain despite sharing port 44556 and the same fixed seed list from `chainparamsseeds.h`.

## Implementation

- New `CTestNet4Params` and `-testnet4` chain selection (`CBaseChainParams::TESTNET4`)
- Consensus: `fEnforceStrictMinDifficulty` and `fTailSubsidyOnly` (testnet4 only)
- `AllowDigishieldMinDifficultyForBlock()`: strict rules when `fEnforceStrictMinDifficulty` is set (no consecutive min-diff blocks, MTP check, 10× spacing threshold)
- Qt: testnet4 network styling, payment URI detection for `T` addresses, autostart flags
- Docs: `doc/testnet-reboot.md`, updates to `getting-started.md` and `files.md`
- Unit tests for strict min-difficulty, testnet4 subsidy, and `T` address prefix

## Breaking changes

- **None for legacy testnet3** (`-testnet` behavior preserved)
- **None for mainnet**
- Testnet4 is additive; users must pass `-testnet4` explicitly to join the new chain

## Test plan

- [ ] `dogecoind -testnet` syncs legacy testnet3; `getblockchaininfo` reports `"chain": "test"`
- [ ] `dogecoind -testnet4` starts from testnet4 genesis; `getblockchaininfo` reports `"chain": "testnet4"`
- [ ] `getnewaddress` on testnet4 returns `T…` addresses; testnet3 still returns `n…` addresses
- [ ] `-testnet` and `-testnet4` together are rejected at startup
- [ ] Run unit tests: `test_dogecoin`, `pow_tests` (strict min-difficulty cases)
- [ ] Two testnet4 nodes peer via `addnode` and advance the chain
- [ ] (Optional) DogeGo reboot node peers with Core `-testnet4` on port 44556

## References

- #3967 (strict min-difficulty rules)
- #3971 (testnet block generation speed)
- Maintainer note on testnet4 direction (#3967)