### PR TITLE
Relax RPC auth-scheme validation

### DIFF
--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -46,7 +46,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #same should be if we add keep-alive because this should be the std. behaviour
-        headers = {"Authorization": "Basic " + str_to_b64str(authpair), "Connection": "keep-alive"}
+        #test case-insensitive auth-schema (RFC 7235)
+        headers = {"Authorization": "basic " + str_to_b64str(authpair), "Connection": "keep-alive"}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -63,7 +64,8 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
 
         #now do the same with "Connection: close"
-        headers = {"Authorization": "Basic " + str_to_b64str(authpair), "Connection":"close"}
+        #no one should mix caps like this, but RFC 7235 says they can
+        headers = {"Authorization": "BaSiC " + str_to_b64str(authpair), "Connection":"close"}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -72,10 +74,20 @@ class HTTPBasicsTest (BitcoinTestFramework):
         assert(b'"error":null' in out1)
         assert(conn.sock==None) #now the connection must be closed after the response
 
+        #a non-Basic scheme must still be rejected
+        headers = {"Authorization": "Bearer " + str_to_b64str(authpair), "Connection":"close"}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        assert_equal(conn.getresponse().status, http.client.UNAUTHORIZED)
+        conn.close()
+
         #node1 (2nd node) is running with disabled keep-alive option
+        #RFC 7235 allows this monstrosity
         urlNode1 = urllib.parse.urlparse(self.nodes[1].url)
         authpair = urlNode1.username + ':' + urlNode1.password
-        headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
+        headers = {"Authorization": "bASIC " + str_to_b64str(authpair)}
 
         conn = http.client.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The Bitcoin Core developers
+// Copyright (c) 2026 The Dogecoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -127,12 +128,29 @@ static bool multiUserAuthorized(std::string strUserPass)
     return false;
 }
 
+static bool
+case_insensitive_equal(const char* a, const char* b, std::size_t n)
+{
+    for (std::size_t i = 0; i < n; ++i) {
+        unsigned char ac = static_cast<unsigned char>(a[i]);
+        unsigned char bc = static_cast<unsigned char>(b[i]);
+        if (ToLower(ac) != ToLower(bc))
+            return false;
+    }
+    return true;
+}
+
 static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUsernameOut)
 {
     if (strRPCUserColonPass.empty()) // Belt-and-suspenders measure if InitRPCAuthentication was not called
         return false;
-    if (strAuth.substr(0, 6) != "Basic ")
+
+    if (strAuth.size() < 6)
         return false;
+
+    if (!case_insensitive_equal(strAuth.data(), "basic", 5) || strAuth[5] != ' ')
+        return false;
+
     std::string strUserPass64 = strAuth.substr(6);
     boost::trim(strUserPass64);
     std::string strUserPass = DecodeBase64(strUserPass64);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -240,6 +240,21 @@ BOOST_AUTO_TEST_CASE(util_IsHex)
     BOOST_CHECK(!IsHex("0x0000"));
 }
 
+BOOST_AUTO_TEST_CASE(util_ToLower)
+{
+    // Locale-independent ASCII fold. std::tolower() is not: tolower('I') is
+    // 0x49 under tr_TR.UTF-8 (stays 'I') and 0xfd under tr_TR, not 0x69 ('i'),
+    // so "BASIC" would fail to match "basic". ToLower is constexpr and cannot
+    // consult a runtime locale, so ToLower('I') is always 0x69.
+    static_assert(ToLower('A') == 'a', "");
+    static_assert(ToLower('I') == 'i', "the Turkish-I case");
+    static_assert(ToLower('Z') == 'z', "");
+    static_assert(ToLower('a') == 'a', "");
+    static_assert(ToLower('i') == 'i', "");
+    static_assert(ToLower('5') == '5', "non-letters are unchanged");
+    BOOST_CHECK(ToLower('I') == 'i');
+}
+
 BOOST_AUTO_TEST_CASE(util_seed_insecure_rand)
 {
     SeedInsecureRand(true);

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2026 The Dogecoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -143,5 +144,20 @@ bool TimingResistantEqual(const T& a, const T& b)
  * @note The result must be in the range (-10^18,10^18), otherwise an overflow error will trigger.
  */
 bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out);
+
+/**
+ * Converts the given character to its lowercase equivalent.
+ * This function is locale independent. It only converts uppercase
+ * characters in the standard 7-bit ASCII range.
+ * This is a feature, not a limitation.
+ *
+ * @param[in] c     the character to convert to lowercase.
+ * @return          the lowercase equivalent of c; or the argument
+ *                  if no conversion is possible.
+ */
+constexpr unsigned char ToLower(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z' ? (c - 'A') + 'a' : c);
+}
 
 #endif // BITCOIN_UTILSTRENCODINGS_H


### PR DESCRIPTION
RFC 7235 says that the auth-scheme is case-insensitive, so we can allow `Basic` as well as `basic` and any other variation. This improves RPC interoperability slightly.

The helper method should be allocation-free. At some point we may want to reuse it elsewhere. For now it's fine where it is.