### PR TITLE
Fix `make -C depends` builds with GCC 15

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -9,7 +9,9 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared --enable-cxx --disable-replication
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
+$(package)_config_opts_linux+=--with-mutex=POSIX/pthreads/library
 $(package)_cxxflags=-std=c++11
+$(package)_cflags+=-Wno-incompatible-pointer-types
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_63_0
 $(package)_download_path=https://sourceforge.net/projects/boost/files/boost/1.63.0
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
+$(package)_patches=fix-boost-1.63-missing-headers.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,7 +26,8 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+	echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
+	patch -p1 < $($(package)_patch_dir)/fix-boost-1.63-missing-headers.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -2,7 +2,7 @@ package=expat
 $(package)_version=2.6.2
 $(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_6_2
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=9C7C1B5DCBC3C237C500A8FB1493E14D9582146DD9B42AA8D3FFB856A3B927E0
+$(package)_sha256_hash=9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0
 
 define $(package)_config_cmds
   $($(package)_autoconf)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -178,6 +178,7 @@ define $(package)_preprocess_cmds
   sed -i.old "s|X11/extensions/XIproto.h|X11/X.h|" qtbase/src/plugins/platforms/xcb/qxcbxsettings.cpp && \
   sed -i.old 's/if \[ "$$$$XPLATFORM_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/if \[ "$$$$BUILD_ON_MAC" = "yes" \]; then xspecvals=$$$$(macSDKify/' qtbase/configure && \
   sed -i.old 's/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, 0)/CGEventCreateMouseEvent(0, kCGEventMouseMoved, pos, kCGMouseButtonLeft)/' qtbase/src/plugins/platforms/cocoa/qcocoacursor.mm && \
+  sed -i.old '3i #include <stdio.h>' qtbase/src/3rdparty/xcb/xcb-util/atoms.c && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/Info.plist.lib qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f qtbase/mkspecs/macx-clang/Info.plist.app qtbase/mkspecs/macx-clang-linux/ &&\

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -21,6 +21,15 @@ define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
 
+define $(package)_preprocess_cmds
+  sed -i.old \
+    -e 's/import sys, os, py_compile, imp/import sys, os, py_compile, importlib.util/' \
+    -e "s/if hasattr(imp, 'get_tag'):/if True:/" \
+    -e 's/imp\.cache_from_source(filepath, False)/importlib.util.cache_from_source(filepath, optimization=1)/' \
+    -e 's/imp\.cache_from_source(filepath)/importlib.util.cache_from_source(filepath)/' \
+  py-compile
+endef
+
 define $(package)_postprocess_cmds
   find -name "*.pyc" -delete && \
   find -name "*.pyo" -delete

--- a/depends/patches/boost/fix-boost-1.63-missing-headers.patch
+++ b/depends/patches/boost/fix-boost-1.63-missing-headers.patch
@@ -1,0 +1,37 @@
+diff --git a/tools/build/src/engine/execcmd.c b/tools/build/src/engine/execcmd.c
+index 0f6b9c0..1111111 100644
+--- a/tools/build/src/engine/execcmd.c
++++ b/tools/build/src/engine/execcmd.c
+@@ -12,0 +13,1 @@
++#include "output.h"
+
+diff --git a/tools/build/src/engine/make.c b/tools/build/src/engine/make.c
+index 2a3b4c5..2222222 100644
+--- a/tools/build/src/engine/make.c
++++ b/tools/build/src/engine/make.c
+@@ -33,0 +34,1 @@
++#include "output.h"
+
+diff --git a/tools/build/src/engine/modules/path.c b/tools/build/src/engine/modules/path.c
+index 5f6a7b8..5555555 100644
+--- a/tools/build/src/engine/modules/path.c
++++ b/tools/build/src/engine/modules/path.c
+@@ -11,0 +12,1 @@
++#include "../filesys.h"    /* for file_query */
+
+diff --git a/tools/build/src/engine/fileunix.c b/tools/build/src/engine/fileunix.c
+index 4e5f6a7..4444444 100644
+--- a/tools/build/src/engine/fileunix.c
++++ b/tools/build/src/engine/fileunix.c
+@@ -32,0 +33,2 @@
++#include "filesys.h"    /* for filelist_empty, file_collect_archive_content_ */
++int file_collect_archive_content_( file_archive_info_t * const archive );
+
+diff --git a/tools/build/src/engine/filesys.h b/tools/build/src/engine/filesys.h
+--- a/tools/build/src/engine/filesys.h
++++ b/tools/build/src/engine/filesys.h
+@@ -97,0 +98,1 @@
++int filelist_empty( FILELIST * list );
+
+@@ -102,0 +104,1 @@
++int file_collect_archive_content_( file_archive_info_t * const archive );


### PR DESCRIPTION
This version of GCC, shipped with newer Linux releases, is stricter so we need to patch some dependencies and relax some new compiler options for others.

The approach here should preserve the same behavior.

This PR applies cleanly atop #4020 ; we should merge that first.