### PR TITLE
ci: try multiple SDK_URL mirrors when installing the macOS SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
       CACHE_NONCE: "1"
       WINEDEBUG: fixme-all
       WINEPREFIX: /tmp/wineprefix/
-      SDK_URL: https://depends.dogecoincore.org
+      # Space-separated list of SDK mirrors, tried in order. dogecoincore is
+      # primary; additional entries are fallbacks for when it is unreachable
+      # (e.g. expired TLS cert). Downloaded tarball is checksum-verified after
+      # fetch regardless of which mirror served it.
+      # TODO(revert): trim back to the dogecoincore mirror once its certificate
+      # is renewed.
+      SDK_URL: "https://depends.dogecoincore.org https://bitcoincore.org/depends-sources/sdks"
 
     strategy:
       fail-fast: false
@@ -252,9 +258,21 @@ jobs:
         run: |
           mkdir -p ./depends/sdk-sources
           mkdir -p ./depends/SDKs
-          echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c || \
-          curl --location --fail $SDK_URL/${{ env.sdk-filename }} -o depends/sdk-sources/${{ env.sdk-filename }} &&\
-          echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c
+          if ! echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c; then
+            fetched=0
+            for base in $SDK_URL; do
+              echo "Fetching ${{ env.sdk-filename }} from $base"
+              if curl --location --fail "$base/${{ env.sdk-filename }}" -o depends/sdk-sources/${{ env.sdk-filename }}; then
+                fetched=1
+                break
+              fi
+            done
+            if [ "$fetched" != 1 ]; then
+              echo "error: could not download ${{ env.sdk-filename }} from any SDK_URL mirror" >&2
+              exit 1
+            fi
+            echo "${{ matrix.sdk-shasum }}  depends/sdk-sources/${{ env.sdk-filename }}" | sha256sum -c
+          fi
           tar -C depends/SDKs -xf depends/sdk-sources/${{ env.sdk-filename }}
 
       - name: Dependency cache


### PR DESCRIPTION
## Background

This stacks on #4020. That PR repoints dead package source URLs in `depends`, but the macOS CI job was still failing — for a different reason, at an earlier stage.

## Root cause

The macOS job fetches the SDK tarball in the `Install SDK` workflow step, using a hand-rolled `curl` in `ci.yml` rather than `depends/funcs.mk`:

```sh
curl --location --fail "$SDK_URL/MacOSX10.11.sdk.tar.gz" -o depends/sdk-sources/MacOSX10.11.sdk.tar.gz
```

with `SDK_URL: https://depends.dogecoincore.org`. That host is currently serving an **expired TLS certificate** (`notAfter=Jun 7 23:28:44 2026`), so `curl` aborts with exit 60 (`SSL certificate problem: certificate has expired`) and the step dies before `depends` ever runs. Because this fetch lives in the workflow and not in `depends`, it is upstream of everything #4020 touches and cannot be fixed there.

## Change

Make `SDK_URL` a space-separated list of mirrors and try each in order, mirroring the `FALLBACK_DOWNLOAD_PATH` pattern already used in `depends`:

```yaml
SDK_URL: "https://depends.dogecoincore.org https://bitcoincore.org/depends-sources/sdks"
```

- The cached-SDK fast path (checksum already matches → skip download entirely) is preserved.
- The tarball is checksum-verified **after** fetch regardless of which mirror served it, so a mirror serving a wrong-but-same-named file is caught rather than trusted.
- A total miss exits non-zero with an explicit message, replacing the previous `&&`/`||` chain that obscured which stage failed.
- The primary mirror is deliberately left **first**, so CI returns to it automatically once its certificate is renewed, with no further commit.

## Verification

The fallback mirror was confirmed to serve the exact pinned asset, not merely to respond:

```
$ curl -sL https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz -o sdk.tar.gz
$ sha256sum sdk.tar.gz
bec9d089ebf2e2dd59b1a811a38ec78ebd5da18cbbcd6ab39d1e59f64ac5033f
```

which matches the `sdk-shasum` pinned in the matrix. End-to-end, the `x86_64-macos` job's `Install SDK` step now reports **success** and proceeds to `Build depends`, where it previously exited 1 with `could not download MacOSX10.11.sdk.tar.gz from any SDK_URL mirror`.

Note that `https://bitcoincore.org/depends-sources/MacOSX10.11.sdk.tar.gz` (without the `/sdks` path segment) returns 404 — the SDKs live under the `sdks/` subdirectory. Getting that path wrong is what made an earlier revision of this change still fail.

## Scope

This restores the macOS job without depending on the broken host, but the underlying issue is the expired certificate on `depends.dogecoincore.org`. Renewing it fixes both this step and the `depends` fallback at the source; a `TODO(revert)` is left in `ci.yml` to trim `SDK_URL` back to the single mirror at that point.

A single-entry `SDK_URL` collapses to the original behavior, so anyone overriding it sees no change.
