### PR TITLE
policy: make scriptSig size limit configurable

### DIFF
--- a/qa/rpc-tests/p2p-policy.py
+++ b/qa/rpc-tests/p2p-policy.py
@@ -7,7 +7,12 @@
 # Tests relay and mempool acceptance policies from p2p perspective
 """
 
+import os
+import subprocess
+
+from test_framework.address import script_to_p2sh
 from test_framework.mininode import *
+from test_framework.script import CScript, OP_DROP, OP_TRUE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
@@ -74,7 +79,8 @@ class P2PPolicyTests(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        # the fourth datadir is used only for startup-argument tests
+        self.num_nodes = 4
         self.utxo = []
 
         # a private key and corresponding address and p2pkh output script
@@ -92,10 +98,12 @@ class P2PPolicyTests(BitcoinTestFramework):
         return node
 
     def setup_network(self):
-        self.nodes = []
-
-        # a Dogecoin Core node that behaves similar to mainnet policies
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-acceptnonstdtxn=0"]))
+        # keep the original policy tests isolated on node 0
+        self.nodes = start_nodes(3, self.options.tmpdir, [
+            ["-debug", "-acceptnonstdtxn=0"],
+            ["-debug", "-acceptnonstdtxn=0", "-maxscriptsigsize=120"],
+            ["-debug", "-acceptnonstdtxn=0"],
+        ])
 
         # custom testnodes
         self.sendNode = self.create_testnode() # to send tx from
@@ -107,6 +115,8 @@ class P2PPolicyTests(BitcoinTestFramework):
         self.recvNode.wait_for_verack()
 
     def run_test(self):
+        self.run_scriptsig_size_startup_test()
+
         self.nodes[0].generate(101)
 
         ### test constants ###
@@ -169,6 +179,109 @@ class P2PPolicyTests(BitcoinTestFramework):
         change = ten - amount - relay_fee_per_byte * 225 - soft_dust_limit + koinu
         output = { self.tgtAddr : amount, self.srcAddr: change }
         self.run_relay_test(output, 64, 225)
+
+        self.run_scriptsig_size_test()
+
+    def run_scriptsig_size_startup_test(self):
+        # zero is a valid limit, despite rejecting every non-empty scriptSig
+        zero_limit_node = start_node(
+            3, self.options.tmpdir,
+            ["-debug", "-acceptnonstdtxn=0", "-maxscriptsigsize=0"])
+        try:
+            assert_equal(zero_limit_node.getblockcount(), 0)
+        finally:
+            stop_node(zero_limit_node, 3)
+
+        # test one parse error and one range error
+        expected_error = "-maxscriptsigsize must be between 0 and 1650"
+        invalid_args = [
+            "-maxscriptsigsize=not-a-number",
+            "-maxscriptsigsize=1651",
+        ]
+        binary = os.getenv("DOGECOIND", "dogecoind")
+        datadir = os.path.join(self.options.tmpdir, "node3")
+
+        for invalid_arg in invalid_args:
+            process = subprocess.Popen(
+                [binary, "-datadir=" + datadir, "-printtoconsole", invalid_arg],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True)
+            try:
+                output = process.communicate(timeout=60)[0]
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+                raise AssertionError(
+                    "dogecoind did not reject {} during startup".format(
+                        invalid_arg))
+
+            assert_equal(process.returncode, 1)
+            assert expected_error in output
+
+    def run_scriptsig_size_test(self):
+        # mine the original policy-test transactions before connecting the nodes
+        self.nodes[0].generate(1)
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        sync_blocks(self.nodes)
+
+        self.strictNode = self.create_testnode(1)
+        self.strictNode.wait_for_verack()
+
+        # relay an ordinary P2PKH transaction through the stricter node
+        ordinary_txid = self.nodes[0].sendtoaddress(
+            self.nodes[2].getnewaddress(), Decimal("1"))
+        assert_equal(self.strictNode.wait_for_tx_inv(ordinary_txid), True)
+        sync_mempools(self.nodes[1:])
+        assert ordinary_txid in self.nodes[2].getrawmempool()
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # OP_DROP removes one value and OP_TRUE makes the P2SH spend valid
+        redeem_script = CScript([OP_DROP, OP_TRUE])
+        p2sh_address = script_to_p2sh(redeem_script)
+        funding_txid = self.nodes[0].sendtoaddress(p2sh_address, Decimal("10"))
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        funding_vout = find_output(
+            self.nodes[0], funding_txid, Decimal("10"))
+
+        # push 120 bytes plus the redeem script to exceed node 1's limit
+        script_sig = CScript([bytes(120), redeem_script])
+        assert_greater_than(len(script_sig), 120)
+
+        spend_tx = CTransaction()
+        spend_tx.vin.append(CTxIn(
+            COutPoint(int(funding_txid, 16), funding_vout),
+            script_sig, 0xffffffff))
+        spend_tx.vout.append(CTxOut(
+            10 * COIN - COIN // 100, hex_str_to_bytes(self.srcOutScript)))
+        spend_tx.rehash()
+
+        # reject without punishing the peer or propagating the transaction
+        num_rejects = len(self.strictNode.rejects)
+        self.strictNode.connection.send_message(msg_tx(spend_tx))
+        assert_equal(self.strictNode.wait_for_reject(num_rejects), True)
+        assert_equal(self.strictNode.rejects[-1].code, 64) # 64 = nonstandard
+        assert_equal(self.strictNode.rejects[-1].reason, b"scriptsig-size")
+        assert_equal(self.strictNode.sync_with_ping(), True)
+        assert all(peer["banscore"] == 0
+                   for peer in self.nodes[1].getpeerinfo())
+        assert spend_tx.hash not in self.nodes[1].getrawmempool()
+        assert spend_tx.hash not in self.nodes[2].getrawmempool()
+
+        # accept and announce the transaction under default policy
+        spend_txid = self.nodes[0].sendrawtransaction(ToHex(spend_tx))
+        assert spend_txid in self.nodes[0].getrawmempool()
+        assert_equal(self.recvNode.wait_for_tx_inv(spend_txid), True)
+
+        # accept and relay a block containing the rejected transaction
+        block_hash = self.nodes[0].generate(1)[0]
+        sync_blocks(self.nodes)
+        assert spend_txid in self.nodes[1].getblock(block_hash)["tx"]
 
 
     # test mempool acceptance and relay outcomes

--- a/share/dogecoin.conf
+++ b/share/dogecoin.conf
@@ -369,6 +369,13 @@
 # (default: 20)
 #bytespersigop=1
 
+# Maximum size in bytes of any scriptSig in transactions we relay and mine
+# when standard transaction policy is enforced. A value of 0
+# rejects transactions with any non-empty scriptSig. Low values may
+# reject ordinary P2PKH, P2SH, or multisignature transactions
+# (0-1650, default: 1650)
+#maxscriptsigsize=<n>
+
 # Relay and mine data carrier transactions (default: 1)
 #datacarrier=1
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,6 +40,7 @@
 #include "ui_interface.h"
 #include "util.h"
 #include "utilmoneystr.h"
+#include "utilstrencodings.h"
 #include "validationinterface.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -480,6 +481,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-dustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered dust, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-harddustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_HARD_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
+    strUsage += HelpMessageOpt("-maxscriptsigsize=<n>", strprintf(_("Maximum size in bytes of any scriptSig in transactions we relay and mine when standard transaction policy is enforced. A value of 0 rejects transactions with any non-empty scriptSig. Low values may reject ordinary P2PKH, P2SH, or multisignature transactions (0-%u, default: %u)"), MAX_STANDARD_SCRIPTSIG_SIZE, DEFAULT_MAX_STANDARD_SCRIPTSIG_SIZE));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
     strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
@@ -1099,6 +1101,16 @@ bool AppInitParameterInteraction()
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
+
+    if (IsArgSet("-maxscriptsigsize")) {
+        uint32_t nMaxScriptSigSize;
+        if (!ParseUInt32(GetArg("-maxscriptsigsize", ""), &nMaxScriptSigSize) ||
+            nMaxScriptSigSize > MAX_STANDARD_SCRIPTSIG_SIZE) {
+            return InitError(strprintf(_("-maxscriptsigsize must be between 0 and %u"),
+                                       MAX_STANDARD_SCRIPTSIG_SIZE));
+        }
+        nMaxStandardScriptSigSize = nMaxScriptSigSize;
+    }
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -82,8 +82,8 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         // bytes of scriptSig, which we round off to 1650 bytes for some minor
         // future-proofing. That's also enough to spend a 20-of-20
         // CHECKMULTISIG scriptPubKey, though such a scriptPubKey is not
-        // considered standard.
-        if (txin.scriptSig.size() > 1650) {
+        // considered standard. Node operators may configure a stricter limit.
+        if (txin.scriptSig.size() > nMaxStandardScriptSigSize) {
             reason = "scriptsig-size";
             return false;
         }
@@ -209,6 +209,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 
 CFeeRate incrementalRelayFee = CFeeRate(DEFAULT_INCREMENTAL_RELAY_FEE);
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
+unsigned int nMaxStandardScriptSigSize = DEFAULT_MAX_STANDARD_SCRIPTSIG_SIZE;
 CAmount nDustLimit = DEFAULT_DUST_LIMIT;
 CAmount nHardDustLimit = DEFAULT_HARD_DUST_LIMIT;
 

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -32,6 +32,10 @@ static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = (unsigned int) RECOMMENDED_MIN_TX_FEE;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
+/** Maximum configurable scriptSig size for transactions we're willing to relay/mine */
+static const unsigned int MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
+/** Default maximum scriptSig size for transactions we're willing to relay/mine */
+static const unsigned int DEFAULT_MAX_STANDARD_SCRIPTSIG_SIZE = MAX_STANDARD_SCRIPTSIG_SIZE;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
@@ -130,6 +134,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
 extern CFeeRate incrementalRelayFee;
 extern CFeeRate dustRelayFee;
 extern unsigned int nBytesPerSigOp;
+extern unsigned int nMaxStandardScriptSigSize;
 extern CAmount nDustLimit;
 extern CAmount nHardDustLimit;
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -777,4 +777,53 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
+BOOST_AUTO_TEST_CASE(test_IsStandard_scriptSig_size)
+{
+    struct MaxScriptSigSizeRestorer {
+        const unsigned int previous;
+
+        MaxScriptSigSizeRestorer() : previous(nMaxStandardScriptSigSize) {}
+        ~MaxScriptSigSizeRestorer() { nMaxStandardScriptSigSize = previous; }
+    } restoreMaxScriptSigSize;
+
+    CMutableTransaction t;
+    t.vin.resize(1);
+    // Default-initialized script bytes are OP_0 and therefore push-only.
+    t.vin[0].scriptSig.resize(DEFAULT_MAX_STANDARD_SCRIPTSIG_SIZE);
+    t.vout.resize(1);
+    t.vout[0].nValue = COIN;
+
+    CKey key;
+    key.MakeNewKey(true);
+    t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+
+    std::string reason;
+
+    // Default limit:
+    nMaxStandardScriptSigSize = DEFAULT_MAX_STANDARD_SCRIPTSIG_SIZE;
+    BOOST_CHECK(IsStandardTx(t, reason));
+
+    t.vin[0].scriptSig.push_back(OP_0);
+    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK_EQUAL(reason, "scriptsig-size");
+
+    // Custom limit:
+    nMaxStandardScriptSigSize = 100;
+    t.vin[0].scriptSig.resize(nMaxStandardScriptSigSize);
+    BOOST_CHECK(IsStandardTx(t, reason));
+
+    t.vin[0].scriptSig.push_back(OP_0);
+    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK_EQUAL(reason, "scriptsig-size");
+
+    // Zero limit:
+    nMaxStandardScriptSigSize = 0;
+    t.vin[0].scriptSig.clear();
+    BOOST_CHECK(IsStandardTx(t, reason));
+
+    t.vin[0].scriptSig.push_back(OP_0);
+    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK_EQUAL(reason, "scriptsig-size");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Hi all,

## What this changes

Dogecoin currently treats a transaction as non-standard when one of its `scriptSig`s is larger than 1,650 bytes. This PR simply exposes that limit as a local policy option:

`-maxscriptsigsize=<n>`

The default remains 1,650, so nothing changes unless a node operator chooses a lower value. Values above 1,650 are not accepted, which makes the option tighten-only.

The check remains in `IsStandardTx()`. It does not change transaction validity, block validity, script execution, or consensus rules. A node may choose not to accept or relay a transaction and must still accept a valid block containing that transaction.

The option is content-agnostic. It only compares the existing `scriptSig.size()` value and does not search transactions for protocol names, strings, or payload patterns. Of course, this also means it does not promise to block any particular protocol. I am aware that protocols can change their encoding or move data elsewhere; the option only lets an individual node apply a local byte-size policy (which is what I want to use it for).

## Why

This tries to follow the alternative Patrick described in his review of [#3844](https://github.com/dogecoin/dogecoin/pull/3844#pullrequestreview-2866505912): extend local standardness control to `scriptSig`, where inscriptions are mostly
stored, while leaving the choice to each node operator.

I used a separate option rather than reusing `-datacarriersize`. That option currently applies to data-carrier outputs and defaults to 83 bytes, while `scriptSig` has an existing 1,650-byte standardness ceiling and is also used by ordinary P2PKH, P2SH, and multisignature spends. Applying the same default to both would change existing `scriptSig` flexibility, which this PR is intended to preserve.

I tried to keep the implementation small. The existing rejection reason is unchanged, and the default behavior remains the same. No default change is proposed here. If operators eventually find lower values useful, changing the default would be a separate discussion.

I made sure that help text and sample configuration warn that low values may reject ordinary transactions. The `share/dogecoin.conf` entry was regenerated from the new help text with `contrib/devtools/gen-dogecoin-conf.sh`.

## Tests

The unit test (I revised them a few times with the help of AI tools as I kept reinventing the wheel or making things too complicated) covers:

- the existing 1,650-byte default boundary;
- a configured lower boundary;
- a zero limit; and
- restoring the global policy value after the test.

The functional test covers:

- startup validation;
- ordinary transaction relay through a stricter node;
- `scriptsig-size` rejection for an oversized transaction;
- no peer banscore;
- no relay to the downstream node; and
- acceptance of a later block containing the transaction that was locally
  rejected from the mempool.

I tested this version with a native Linux build:

- `make check`
- `transaction_tests/test_IsStandard_scriptSig_size`
- `qa/rpc-tests/p2p-policy.py`

The functional test was run twice with fresh regtest directories and ports.

I also cross-compiled the Win64 binaries and ran `p2p-policy.py` against them under Wine. The functional test passed twice with fresh test directories.

## Historical sanity check

I also ran a separate scan of 497,440 contiguous mainnet blocks covering almost exactly one year (with a lot of help from AI tools). The research tooling and results are not part of this commit. There was also interest in on-chain measurement of `OP_RETURN` and `scriptSig` usage in the [#3876 discussion](https://github.com/dogecoin/dogecoin/pull/3876#issuecomment-3236352049).

As one example, a 1,500-byte setting would have size-selected 528,261 of the 14,188,641 non-coinbase transactions in that period. None of the inputs over 1,500 bytes matched the study's recognized ordinary signature or multisignature shapes. The largest ordinary-shaped input observed was 1,173 bytes.

I do not think this establishes an ideal setting (I had naively expected it to, at least for my node, tbh). Historical block inclusion also does not prove that every transaction was previously relayed. The scan is mainly a sanity check that the
option selects what its size rule predicts, and that substantially lower values begin to affect recognizable ordinary transaction shapes.

## Supporting research

Evidence database SHA-256:

`1ce38f634f490ac7ea542d9ba7fbfbaf3ac72eeadb3e496b1c6ba52a38765b2e`

Audited reproducibility bundle:

`dogecoin-scriptsig-study-one-year-audited-reproducibility.zip`

Bundle SHA-256:

`821b44432f36dc50fa566b717f29aa6e5ea87afc7b0cc2c6a5eb661509fb62ea`

Full report and bundle: 
[dogecoin-scriptsig-study-one-year-audited-reproducibility.zip](https://github.com/user-attachments/files/30377450/dogecoin-scriptsig-study-one-year-audited-reproducibility.zip)
