### PR TITLE
Improve inbound peer diversity/limit subnet conns

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1025,12 +1025,34 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
+InboundPeerCounts CountInboundPeers(const std::vector<CNode*>& nodes, const CAddress& addr, const CCriticalSection& vNodesLock) EXCLUSIVE_LOCKS_REQUIRED(vNodesLock)
+{
+    // Single-pass counting used by inbound admission. Within counts:
+    // nInbound counts all inbound peers.
+    // nSubnet counts only inbound peers that are:
+    //  - non-whitelisted,
+    //  - routable,
+    //  - non-Tor, and
+    //  - in addr's public subnet (/16 for IPv4, /32 for IPv6).
+    // Exclusions from nSubnet are outbound peers, whitelisted peers,
+    // non-routable peers, Tor peers, and peers outside the matched subnet.
+    int mask = addr.IsIPv4() ? 16 : 32;
+    CSubNet subnet(addr, mask);
+    InboundPeerCounts counts = {0, 0};
+    for (const CNode* pnode : nodes) {
+        if (!pnode->fInbound) continue;
+        counts.nInbound++;
+        if (!pnode->fWhitelisted && pnode->addr.IsRoutable() && !pnode->addr.IsTor() && subnet.Match(pnode->addr))
+            counts.nSubnet++;
+    }
+    return counts;
+}
+
 void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
     SOCKET hSocket = accept(hListenSocket.socket, (struct sockaddr*)&sockaddr, &len);
     CAddress addr;
-    int nInbound = 0;
     int nMaxInbound = nMaxConnections - (nMaxOutbound + nMaxFeeler);
 
     if (hSocket != INVALID_SOCKET)
@@ -1038,12 +1060,13 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
             LogPrintf("Warning: Unknown socket family\n");
 
     bool whitelisted = hListenSocket.whitelisted || IsWhitelistedRange(addr);
+
+    InboundPeerCounts counts;
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes)
-            if (pnode->fInbound)
-                nInbound++;
+        counts = CountInboundPeers(vNodes, addr, cs_vNodes);
     }
+    bool check_subnet = (!whitelisted && addr.IsRoutable());
 
     if (hSocket == INVALID_SOCKET)
     {
@@ -1082,7 +1105,16 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         return;
     }
 
-    if (nInbound >= nMaxInbound)
+    // Enforce per-public-subnet inbound limits (IPv4 /16, IPv6 /32).
+    // Do not apply to whitelisted or non-routable addresses.
+    if (check_subnet && counts.nSubnet >= DEFAULT_MAX_INBOUND_PER_SUBNET) {
+        LogPrintf("connection from %s dropped: too many inbound from same /%d\n",
+                  addr.ToString(), addr.IsIPv4() ? 16 : 32);
+        CloseSocket(hSocket);
+        return;
+    }
+
+    if (counts.nInbound >= nMaxInbound)
     {
         if (!AttemptToEvictConnection()) {
             // No connection to evict, disconnect the new connection

--- a/src/net.h
+++ b/src/net.h
@@ -73,6 +73,8 @@ static const bool DEFAULT_UPNP = USE_UPNP;
 #else
 static const bool DEFAULT_UPNP = false;
 #endif
+/** Maximum concurrent inbound connections allowed per public subnet (IPv4 /16, IPv6 /32). */
+static const unsigned int DEFAULT_MAX_INBOUND_PER_SUBNET = 4;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -414,6 +416,28 @@ void Discover(boost::thread_group& threadGroup);
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
+
+/**
+ * Counts of inbound peers relevant to connection acceptance decisions.
+ * Produced by CountInboundPeers in a single pass over the node list.
+ */
+struct InboundPeerCounts {
+    int nInbound;           //!< total inbound peers
+    unsigned int nSubnet;   //!< inbound, non-whitelisted, routable peers in addr's /16 (IPv4) or /32 (IPv6)
+};
+
+/**
+ * Count inbound peers and how many of those share the same public subnet as
+ * addr (IPv4 /16 or IPv6 /32) in a single pass. Whitelisted peers are excluded
+ * from nSubnet since they do not consume limited slots and should not block
+ * non-whitelisted peers in the same subnet.
+ *
+ * Caller must hold vNodesLock before passing nodes to this function. Locking
+ * externally ensures nInbound and nSubnet are counted from the same consistent
+ * snapshot of the peer list; locking inside the function would require two
+ * separate lock acquisitions and allow the peer list to change between counts.
+ */
+InboundPeerCounts CountInboundPeers(const std::vector<CNode*>& nodes, const CAddress& addr, const CCriticalSection& vNodesLock) EXCLUSIVE_LOCKS_REQUIRED(vNodesLock);
 
 struct CombinerAll
 {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -213,4 +213,212 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
     BOOST_CHECK(1);
 }
 
+static CAddress MakeAddr(const char* ipstr, unsigned short port = 22556)
+{
+    CService svc;
+    Lookup(ipstr, svc, port, false);
+    return CAddress(svc, NODE_NETWORK);
+}
+
+// Verify that the subnet counting logic identifies peers in the same public /16.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_ipv4_same_subnet_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    // Four inbound peers from 8.8.8.x (same /16 = 8.8.0.0/16, Google DNS range)
+    CAddress addr1 = MakeAddr("8.8.8.1");
+    CAddress addr2 = MakeAddr("8.8.8.2");
+    CAddress addr3 = MakeAddr("8.8.8.3");
+    CAddress addr4 = MakeAddr("8.8.8.4");
+    CAddress addr5 = MakeAddr("8.8.8.5");
+
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", true));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", true));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", true));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", true));
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        // A fifth peer from same /16 should be counted at the limit
+        counts = CountInboundPeers(nodes, addr5, cs_nodes);
+    }
+    BOOST_CHECK_EQUAL(counts.nSubnet, 4U);
+    BOOST_CHECK(counts.nSubnet >= DEFAULT_MAX_INBOUND_PER_SUBNET);
+}
+
+// Verify that peers from a different /16 are not counted toward the limit.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_ipv4_different_subnet_not_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    CAddress addr1 = MakeAddr("8.8.8.1");
+    CAddress addr2 = MakeAddr("8.8.8.2");
+    CAddress addr3 = MakeAddr("8.8.8.3");
+    CAddress addr4 = MakeAddr("8.8.8.4");
+
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", true));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", true));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", true));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", true));
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    // A peer from a completely different /16 should see count zero
+    CAddress addr_other = MakeAddr("1.2.3.4");
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        counts = CountInboundPeers(nodes, addr_other, cs_nodes);
+    }
+    BOOST_CHECK_EQUAL(counts.nSubnet, 0U);
+    BOOST_CHECK(counts.nSubnet < DEFAULT_MAX_INBOUND_PER_SUBNET);
+}
+
+// Verify that whitelisted peers are excluded from the limited-peer count,
+// so whitelisted nodes in a subnet do not consume quota that would block
+// non-whitelisted peers from the same subnet.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_whitelisted_not_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    CAddress addr1 = MakeAddr("8.8.8.1");
+    CAddress addr2 = MakeAddr("8.8.8.2");
+    CAddress addr3 = MakeAddr("8.8.8.3");
+    CAddress addr4 = MakeAddr("8.8.8.4");
+    CAddress addr5 = MakeAddr("8.8.8.5");
+
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", true));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", true));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", true));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", true));
+
+    // Mark two of them as whitelisted
+    n3->fWhitelisted = true;
+    n4->fWhitelisted = true;
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        // Fifth peer from same /16: only 2 non-whitelisted match, under limit
+        counts = CountInboundPeers(nodes, addr5, cs_nodes);
+    }
+    BOOST_CHECK_EQUAL(counts.nSubnet, 2U);
+    BOOST_CHECK(counts.nSubnet < DEFAULT_MAX_INBOUND_PER_SUBNET);
+}
+
+// Verify that outbound peers in the same /16 are not counted toward the
+// inbound subnet limit.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_outbound_not_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    CAddress addr1 = MakeAddr("8.8.8.1");
+    CAddress addr2 = MakeAddr("8.8.8.2");
+    CAddress addr3 = MakeAddr("8.8.8.3");
+    CAddress addr4 = MakeAddr("8.8.8.4");
+    CAddress addr5 = MakeAddr("8.8.8.5");
+
+    // All four are outbound (fInbound = false)
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", false));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", false));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", false));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", false));
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        counts = CountInboundPeers(nodes, addr5, cs_nodes);
+    }
+    BOOST_CHECK_EQUAL(counts.nSubnet, 0U);
+    BOOST_CHECK(counts.nSubnet < DEFAULT_MAX_INBOUND_PER_SUBNET);
+}
+
+// Verify that non-routable addresses (e.g. RFC1918) are ignored by the
+// per-subnet counter, so private-range nodes don't affect public subnet limits.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_private_addr_not_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    // Use 192.168.1.x — RFC1918 (non-routable)
+    CAddress addr1 = MakeAddr("192.168.1.1");
+    CAddress addr2 = MakeAddr("192.168.1.2");
+    CAddress addr3 = MakeAddr("192.168.1.3");
+    CAddress addr4 = MakeAddr("192.168.1.4");
+    CAddress addr5 = MakeAddr("192.168.1.5");
+
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", true));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", true));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", true));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", true));
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    // Incoming from the same private range — count should be 0 since non-routable
+    // nodes are skipped by the counter (and AcceptConnection skips the check entirely
+    // for non-routable incoming addresses)
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        counts = CountInboundPeers(nodes, addr5, cs_nodes);
+    }
+    BOOST_CHECK_EQUAL(counts.nSubnet, 0U);
+}
+
+// Verify that IPv6 peers in the same public /32 are counted correctly.
+BOOST_AUTO_TEST_CASE(inbound_subnet_limit_ipv6_same_subnet_counted)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    NodeId id = 0;
+    int height = 0;
+
+    // 2600:1400::/32 is a real public range (Akamai).
+    // Build four addresses in 2600:1400::/32, one more to test against.
+    CAddress addr1 = MakeAddr("2600:1400:0:1::1");
+    CAddress addr2 = MakeAddr("2600:1400:0:2::1");
+    CAddress addr3 = MakeAddr("2600:1400:0:3::1");
+    CAddress addr4 = MakeAddr("2600:1400:0:4::1");
+    CAddress addr5 = MakeAddr("2600:1400:0:5::1");
+
+    std::unique_ptr<CNode> n1(new CNode(id++, NODE_NETWORK, height, hSocket, addr1, 0, 0, "", true));
+    std::unique_ptr<CNode> n2(new CNode(id++, NODE_NETWORK, height, hSocket, addr2, 0, 0, "", true));
+    std::unique_ptr<CNode> n3(new CNode(id++, NODE_NETWORK, height, hSocket, addr3, 0, 0, "", true));
+    std::unique_ptr<CNode> n4(new CNode(id++, NODE_NETWORK, height, hSocket, addr4, 0, 0, "", true));
+
+    std::vector<CNode*> nodes = {n1.get(), n2.get(), n3.get(), n4.get()};
+
+    CCriticalSection cs_nodes;
+    InboundPeerCounts counts;
+    {
+        LOCK(cs_nodes);
+        counts = CountInboundPeers(nodes, addr5, cs_nodes);
+    }
+
+    // All four addresses are in 2600:1400::/32, so nSubnet should equal 4
+    // and be at the limit.
+    BOOST_CHECK_EQUAL(counts.nSubnet, 4U);
+    BOOST_CHECK(counts.nSubnet >= DEFAULT_MAX_INBOUND_PER_SUBNET);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Nodes with many inbound connections from the same /16 (IPv4) or /32 (IPv6) gain little additional network diversity from further peers in that range. Cap inbound connections per public subnet at DEFAULT_MAX_INBOUND_PER_SUBNET (4); whitelisted peers and non-routable addresses are exempt.

Extract CountInboundPeers returning InboundPeerCounts, counting nInbound and nSubnet in a single pass under cs_vNodes. Add robustness tests covering same- subnet counting, cross-subnet isolation, whitelisted peers, outbound peers, non-routable addresses, and IPv6 /32 grouping.