### PR TITLE
depends: update libevent to 2.1.13-stable

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -1,8 +1,8 @@
 package=libevent
-$(package)_version=2.1.12-stable
+$(package)_version=2.1.13-stable
 $(package)_download_path=https://github.com/libevent/libevent/releases/download/release-$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+$(package)_sha256_hash=f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c
 $(package)_patches = glibc_compatibility.patch
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -5,10 +5,6 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c
 $(package)_patches = glibc_compatibility.patch
 
-define $(package)_preprocess_cmds
-  ./autogen.sh
-endef
-
 define $(package)_set_vars
   $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
   $(package)_config_opts_release=--disable-debug-mode

--- a/depends/patches/libevent/glibc_compatibility.patch
+++ b/depends/patches/libevent/glibc_compatibility.patch
@@ -3,12 +3,12 @@ Avoid getrandom@GLIBC_2.25 symbol.
 --- old/config.h.in
 +++ new/config.h.in
 @@ -101,9 +101,6 @@
- /* Define to 1 if you have the `getprotobynumber' function. */
+ /* Define to 1 if you have the 'getprotobynumber' function. */
  #undef HAVE_GETPROTOBYNUMBER
  
--/* Define to 1 if you have the `getrandom' function. */
+-/* Define to 1 if you have the 'getrandom' function. */
 -#undef HAVE_GETRANDOM
 -
- /* Define to 1 if you have the `getservbyname' function. */
+ /* Define to 1 if you have the 'getservbyname' function. */
  #undef HAVE_GETSERVBYNAME
  


### PR DESCRIPTION
`depends` pins libevent **2.1.12-stable (2020-07-05)**. **2.1.13-stable** was released **2026-07-01** carrying seven security advisories. Four are in `evhttp`, which the RPC server is built on.

| Advisory | Issue |
|---|---|
| GHSA-2gmv-p5m7-98p6 | HTTP trailers permitted header smuggling |
| GHSA-q39v-w2g7-gr8j | header parsing permitted request smuggling |
| GHSA-jcwh-pvf2-73p2 | CRLF and NUL handling allowed parser mismatch |
| GHSA-cvq5-vrvr-j338 | AF_UNIX heap out-of-bound write (`-DNDEBUG` builds) |
| GHSA-c2pj-cg4r-88c8 | dangling pointer in `evbuffer_add_reference` |
| GHSA-58rx-7448-jw47 | OOB write in evdns `dnsname_to_labels` |
| GHSA-fj29-64w6-73h6, GHSA-45c6-qx49-89m8 | evtag/evrpc — **not used by this tree** |

## Reachability

Worth being precise, because it decides how much the parser bugs matter. libevent parses the request line, headers and body **before** handing anything to the registered callback:

```
httpserver.cpp:427   evhttp_set_gencb(http, http_request_cb, NULL)
httpserver.cpp:251   http_request_cb()
httprpc.cpp:150      HTTPReq_JSONRPC()
httprpc.cpp:158      req->GetHeader("authorization")
httprpc.cpp:166      RPCAuthorized()
```

Authentication is step four. Everything libevent parses, it parses before that — so the three parser advisories are reachable by **anyone who can open a connection to the RPC port, with no credentials**.

That isn't critical standing alone: RPC binds localhost and requires auth for any action. But it removes the "authenticated attacker only" mitigation, and request smuggling is specifically an attack against a proxy in front of a backend — a common way RPC gets exposed.

## `glibc_compatibility.patch` had to be regenerated

It **fails** against 2.1.13. The cause is cosmetic — a newer autoconf writes `'getrandom'` where the old one wrote `` `getrandom' `` — so the context lines no longer match. The hunk is otherwise identical, at the same offset, removing the same two lines.

**This is the important part to verify, because a silently-skipped patch is exactly how `getrandom@GLIBC_2.25` would sneak in and fail symbol-check.** Applied against a pristine 2.1.13 tree:

```
BEFORE patch:  HAVE_GETRANDOM occurrences: 1
AFTER  patch:  HAVE_GETRANDOM occurrences: 0
```

and `getprotobynumber` (line 101) now sits directly above `getservbyname` (line 104) — the block is gone, `HAVE_GETRANDOM` stays undefined, and libevent never calls `getrandom()`.

Note GitHub renders the patch file itself as a diff, so lines beginning with `-` (which are *instructions to delete*) look like removals. `-#undef HAVE_GETRANDOM` is byte-identical in both versions; only the quote character above it changed.

## Second commit: a dead `preprocess_cmds`

`libevent.mk` defined `$(package)_preprocess_cmds` **twice**. The second (applying the patch) silently replaced the first (running `./autogen.sh`), so `autogen.sh` has never run.

Removed rather than merged, because merging would break things: the patch edits `config.h.in`, and `autogen.sh` runs `autoheader`, which regenerates `config.h.in`. The override wasn't merely redundant — it was the only reason the patch worked. Nothing needs `autogen.sh` anyway; the tarball ships both `configure` and `config.h.in`.

No functional change: the commands that ran before are the commands that run now.

## Hash

Not copied. `depends` fetched the tarball from the release URL and verified it against the new pin itself:

```
Fetching libevent-2.1.13-stable.tar.gz from https://github.com/libevent/...
...libevent-2.1.13-stable.tar.gz.temp: OK
```

As a control, 2.1.12 hashes to the `92e6de1b…` already pinned here — which validates the method, not just the result. **Please confirm `f7e9383b…` against the upstream GPG signature before merge**; a hash computed from a download is only as good as the download.

`libevent.mk` is byte-identical on `master`, `1.21-dev` and `1.14-maint` (same blob), so this cherry-picks to all three unchanged.