### PR TITLE
random: use a steady clock for strengthening

### DIFF
--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -18,7 +18,7 @@ private:
     uint64_t bytes;
 
 public:
-    static const size_t OUTPUT_SIZE = 64;
+    static constexpr size_t OUTPUT_SIZE = 64;
 
     CSHA512();
     CSHA512& Write(const unsigned char* data, size_t len);

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -215,7 +215,7 @@ void PaperWalletDialog::setClientModel(ClientModel *_clientModel)
 
 void PaperWalletDialog::setModel(WalletModel *model)
 {
-    RandAddSeed();
+    RandAddSeedSleep();
     this->model = model;
     this->on_getNewAddress_clicked();
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -279,6 +279,14 @@ namespace {
 
 class RNGState {
     Mutex m_mutex;
+    /* The RNG state consists of 256 bits of entropy, taken from the output of
+     * one operation's SHA512 output, and fed as input to the next one.
+     * Carrying 256 bits of entropy should be sufficient to guarantee
+     * unpredictability as long as any entropy source was ever unpredictable
+     * to an attacker. To protect against situations where an attacker might
+     * observe the RNG's state, fresh entropy is always mixed when
+     * GetStrongRandBytes is called.
+     */
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -275,13 +275,14 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
 
 namespace {
 
-struct RNGState {
+class RNGState {
     Mutex m_mutex;
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
     std::unique_ptr<Mutex[]> m_mutex_openssl;
 
+public:
     RNGState() noexcept
     {
         InitHardwareRand();
@@ -339,6 +340,8 @@ struct RNGState {
         memory_cleanse(buf, 64);
         return ret;
     }
+
+    Mutex& GetOpenSSLMutex(int i) { return m_mutex_openssl[i]; }
 };
 
 RNGState& GetRNGState() noexcept
@@ -355,9 +358,9 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THRE
     RNGState& rng = GetRNGState();
 
     if (mode & CRYPTO_LOCK) {
-        rng.m_mutex_openssl[i].lock();
+        rng.GetOpenSSLMutex(i).lock();
     } else {
-        rng.m_mutex_openssl[i].unlock();
+        rng.GetOpenSSLMutex(i).unlock();
     }
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -70,7 +70,6 @@ static inline int64_t GetPerformanceCounter()
 #endif
 }
 
-
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
@@ -79,13 +78,24 @@ static void RDRandInit()
 {
     uint32_t eax, ebx, ecx, edx;
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
-        LogPrintf("Using RdRand as an additional entropy source\n");
         rdrand_supported = true;
     }
     hwrand_initialized.store(true);
 }
+
+static void RDRandReport()
+{
+    assert(hwrand_initialized.load(std::memory_order_relaxed));
+    if (rdrand_supported) {
+        // This must be done in a separate function, as HWRandInit() may be indirectly called
+        // from global constructors, before logging is initialized.
+        LogPrintf("Using RdRand as an additional entropy source\n");
+    }
+}
+
 #else
 static void RDRandInit() {}
+static void RDRandReport() {}
 #endif
 
 static bool GetHWRand(unsigned char* ent32) {
@@ -273,8 +283,64 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+namespace {
+struct RNGState {
+    Mutex m_mutex;
+    unsigned char m_state[32] = {0};
+    uint64_t m_counter = 0;
+
+    explicit RNGState() {
+        RDRandInit();
+    }
+};
+
+RNGState& GetRNGState()
+{
+    // This C++11 idiom relies on the guarantee that static variable are initialized
+    // on first call, even when multiple parallel calls are permitted.
+    static std::unique_ptr<RNGState> g_rng{new RNGState()};
+    return *g_rng;
+}
+}
+
+static void AddDataToRng(void* data, size_t len);
+
+void RandAddSeedSleep()
+{
+    int64_t nPerfCounter1 = GetPerformanceCounter();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    int64_t nPerfCounter2 = GetPerformanceCounter();
+
+    // Combine with and update state
+    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1));
+    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2));
+
+    memory_cleanse(&nPerfCounter1, sizeof(nPerfCounter1));
+    memory_cleanse(&nPerfCounter2, sizeof(nPerfCounter2));
+}
+
+static void AddDataToRng(void* data, size_t len) {
+    RNGState& rng = GetRNGState();
+
+    CSHA512 hasher;
+    hasher.Write((const unsigned char*)&len, sizeof(len));
+    hasher.Write((const unsigned char*)data, len);
+    unsigned char buf[64];
+    {
+        std::unique_lock<Mutex> lock(rng.m_mutex);
+        hasher.Write(rng.m_state, sizeof(rng.m_state));
+        hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
+        ++rng.m_counter;
+        hasher.Finalize(buf);
+        memcpy(rng.m_state, buf + 32, 32);
+    }
+    memory_cleanse(buf, 64);
+}
+
 void GetStrongRandBytes(unsigned char* out, int num)
 {
+    RNGState& rng = GetRNGState();
+
     assert(num <= 32);
     CSHA512 hasher;
     unsigned char buf[64];
@@ -291,6 +357,16 @@ void GetStrongRandBytes(unsigned char* out, int num)
     // Third source: HW RNG, if available.
     if (GetHWRand(buf)) {
         hasher.Write(buf, 32);
+    }
+
+    // Combine with and update state
+    {
+        std::unique_lock<Mutex> lock(rng.m_mutex);
+        hasher.Write(rng.m_state, sizeof(rng.m_state));
+        hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
+        ++rng.m_counter;
+        hasher.Finalize(buf);
+        memcpy(rng.m_state, buf + 32, 32);
     }
 
     // Produce output
@@ -413,5 +489,8 @@ FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDete
 
 void RandomInit()
 {
-    RDRandInit();
+    // Invoke RNG code to trigger initialization (if not already performed)
+    GetRNGState();
+
+    RDRandReport();
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -142,6 +142,34 @@ static bool GetHardwareRand(unsigned char* ent32) noexcept {
     return false;
 }
 
+/** Use repeated SHA512 to strengthen the randomness in seed32, and feed into hasher. */
+static void Strengthen(const unsigned char (&seed)[32], int microseconds, CSHA512& hasher) noexcept
+{
+    CSHA512 inner_hasher;
+    inner_hasher.Write(seed, sizeof(seed));
+
+    // Hash loop
+    unsigned char buffer[64];
+    int64_t stop = GetTimeMicros() + microseconds;
+    do {
+        for (int i = 0; i < 1000; ++i) {
+            inner_hasher.Finalize(buffer);
+            inner_hasher.Reset();
+            inner_hasher.Write(buffer, sizeof(buffer));
+        }
+        // Benchmark operation and feed it into outer hasher.
+        int64_t perf = GetPerformanceCounter();
+        hasher.Write((const unsigned char*)&perf, sizeof(perf));
+    } while (GetTimeMicros() < stop);
+
+    // Produce output from inner state and feed it to outer hasher.
+    inner_hasher.Finalize(buffer);
+    hasher.Write(buffer, sizeof(buffer));
+    // Try to clean up.
+    inner_hasher.Reset();
+    memory_cleanse(buffer, sizeof(buffer));
+}
+
 static void RandAddSeedPerfmon(CSHA512& hasher)
 {
 #ifdef WIN32
@@ -433,7 +461,23 @@ static void SeedSlow(CSHA512& hasher) noexcept
     SeedTimestamp(hasher);
 }
 
-static void SeedSleep(CSHA512& hasher)
+/** Extract entropy from rng, strengthen it, and feed it into hasher. */
+static void SeedStrengthen(CSHA512& hasher, RNGState& rng) noexcept
+{
+    static std::atomic<int64_t> last_strengthen{0};
+    int64_t last_time = last_strengthen.load();
+    int64_t current_time = GetTimeMicros();
+    if (current_time > last_time + 60000000) { // Only run once a minute
+        // Generate 32 bytes of entropy from the RNG, and a copy of the entropy already in hasher.
+        unsigned char strengthen_seed[32];
+        rng.MixExtract(strengthen_seed, sizeof(strengthen_seed), CSHA512(hasher), false);
+        // Strengthen it for 10ms (100ms on first run), and feed it into hasher.
+        Strengthen(strengthen_seed, last_time == 0 ? 100000 : 10000, hasher);
+        last_strengthen = current_time;
+    }
+}
+
+static void SeedSleep(CSHA512& hasher, RNGState& rng)
 {
     // Everything that the 'fast' seeder includes
     SeedFast(hasher);
@@ -449,9 +493,12 @@ static void SeedSleep(CSHA512& hasher)
 
     // Windows performance monitor data (once every 10 minutes)
     RandAddSeedPerfmon(hasher);
+
+    // Strengthen every minute
+    SeedStrengthen(hasher, rng);
 }
 
-static void SeedStartup(CSHA512& hasher) noexcept
+static void SeedStartup(CSHA512& hasher, RNGState& rng) noexcept
 {
 #ifdef WIN32
     RAND_screen();
@@ -462,6 +509,9 @@ static void SeedStartup(CSHA512& hasher) noexcept
 
     // Windows performance monitor data.
     RandAddSeedPerfmon(hasher);
+
+    // Strengthen
+    SeedStrengthen(hasher, rng);
 }
 
 enum class RNGLevel {
@@ -486,7 +536,7 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
         SeedSlow(hasher);
         break;
     case RNGLevel::SLEEP:
-        SeedSleep(hasher);
+        SeedSleep(hasher, rng);
         break;
     }
 
@@ -494,7 +544,7 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
     if (!rng.MixExtract(out, num, std::move(hasher), false)) {
         // On the first invocation, also seed with SeedStartup().
         CSHA512 startup_hasher;
-        SeedStartup(startup_hasher);
+        SeedStartup(startup_hasher, rng);
         rng.MixExtract(out, num, std::move(startup_hasher), true);
     }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -12,7 +12,7 @@
 #include <wincrypt.h>
 #endif
 #include "util.h"     // for LogPrint()
-#include "sync.h"     // for WAIT_LOCK
+#include "sync.h"     // for LOCK
 #include "utiltime.h" // for GetTime()
 
 #include <stdlib.h>
@@ -144,18 +144,8 @@ static bool GetHardwareRand(unsigned char* ent32) {
     return false;
 }
 
-void RandAddSeed()
+static void RandAddSeedPerfmon(CSHA512& hasher)
 {
-    // Seed with CPU performance counter
-    int64_t nCounter = GetPerformanceCounter();
-    RAND_add(&nCounter, sizeof(nCounter), 1.5);
-    memory_cleanse((void*)&nCounter, sizeof(nCounter));
-}
-
-static void RandAddSeedPerfmon()
-{
-    RandAddSeed();
-
 #ifdef WIN32
     // Don't need this on Linux, OpenSSL automatically uses /dev/urandom
     // Seed with the entire set of perfmon data
@@ -179,7 +169,7 @@ static void RandAddSeedPerfmon()
     }
     RegCloseKey(HKEY_PERFORMANCE_DATA);
     if (ret == ERROR_SUCCESS) {
-        RAND_add(vData.data(), nSize, nSize / 100.0);
+        hasher.Write(vData.data(), nSize);
         memory_cleanse(vData.data(), nSize);
     } else {
         // Performance data is only a best-effort attempt at improving the
@@ -285,13 +275,6 @@ void GetOSRand(unsigned char *ent32)
 #endif
 }
 
-void GetRandBytes(unsigned char* buf, int num)
-{
-    if (RAND_bytes(buf, num) != 1) {
-        RandFailure();
-    }
-}
-
 void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
 
 namespace {
@@ -300,6 +283,7 @@ struct RNGState {
     Mutex m_mutex;
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
+    bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
     std::unique_ptr<Mutex[]> m_mutex_openssl;
 
     RNGState()
@@ -316,14 +300,6 @@ struct RNGState {
         // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
         // that the config appears to have been loaded and there are no modules/engines available.
         OPENSSL_no_config();
-
-#ifdef WIN32
-        // Seed OpenSSL PRNG with current contents of the screen
-        RAND_screen();
-#endif
-
-        // Seed OpenSSL PRNG with performance counter
-        RandAddSeed();
     }
 
     ~RNGState()
@@ -334,14 +310,19 @@ struct RNGState {
         CRYPTO_set_locking_callback(nullptr);
     }
 
-    /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher. */
-    void MixExtract(unsigned char* out, size_t num, CSHA512&& hasher)
+    /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher.
+     *
+     * If this function has never been called with strong_seed = true, false is returned.
+     */
+    bool MixExtract(unsigned char* out, size_t num, CSHA512&& hasher, bool strong_seed)
     {
         assert(num <= 32);
         unsigned char buf[64];
         static_assert(sizeof(buf) == CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
+        bool ret;
         {
-            WAIT_LOCK(m_mutex, lock);
+            LOCK(m_mutex);
+            ret = (m_strongly_seeded |= strong_seed);
             // Write the current state of the RNG into the hasher
             hasher.Write(m_state, 32);
             // Write a new counter number into the state
@@ -360,6 +341,7 @@ struct RNGState {
         // Best effort cleanup of internal state
         hasher.Reset();
         memory_cleanse(buf, 64);
+        return ret;
     }
 };
 
@@ -383,61 +365,127 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THRE
     }
 }
 
-static void AddDataToRng(void* data, size_t len, RNGState& rng);
-
-void RandAddSeedSleep()
+static void SeedTimestamp(CSHA512& hasher)
 {
-    RNGState& rng = GetRNGState();
-
-    int64_t nPerfCounter1 = GetPerformanceCounter();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    int64_t nPerfCounter2 = GetPerformanceCounter();
-
-    // Combine with and update state
-    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1), rng);
-    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2), rng);
-
-    memory_cleanse(&nPerfCounter1, sizeof(nPerfCounter1));
-    memory_cleanse(&nPerfCounter2, sizeof(nPerfCounter2));
+    int64_t perfcounter = GetPerformanceCounter();
+    hasher.Write((const unsigned char*)&perfcounter, sizeof(perfcounter));
 }
 
-static void AddDataToRng(void* data, size_t len, RNGState& rng) {
-    CSHA512 hasher;
-    hasher.Write((const unsigned char*)&len, sizeof(len));
-    hasher.Write((const unsigned char*)data, len);
-    rng.MixExtract(nullptr, 0, std::move(hasher));
+static void SeedFast(CSHA512& hasher)
+{
+    unsigned char buffer[32];
+
+    // Stack pointer to indirectly commit to thread/callstack
+    const unsigned char* ptr = buffer;
+    hasher.Write((const unsigned char*)&ptr, sizeof(ptr));
+
+    // Hardware randomness is very fast when available; use it always.
+    bool have_hw_rand = GetHardwareRand(buffer);
+    if (have_hw_rand) hasher.Write(buffer, sizeof(buffer));
+
+    // High-precision timestamp
+    SeedTimestamp(hasher);
 }
 
-void GetStrongRandBytes(unsigned char* out, int num)
+static void SeedSlow(CSHA512& hasher)
 {
+    unsigned char buffer[32];
+
+    // Everything that the 'fast' seeder includes
+    SeedFast(hasher);
+
+    // OS randomness
+    GetOSRand(buffer);
+    hasher.Write(buffer, sizeof(buffer));
+
+    // OpenSSL RNG (for now)
+    RAND_bytes(buffer, sizeof(buffer));
+    hasher.Write(buffer, sizeof(buffer));
+
+    // High-precision timestamp.
+    //
+    // Note that we also commit to a timestamp in the Fast seeder, so we indirectly commit to a
+    // benchmark of all the entropy gathering sources in this function).
+    SeedTimestamp(hasher);
+}
+
+static void SeedSleep(CSHA512& hasher)
+{
+    // Everything that the 'fast' seeder includes
+    SeedFast(hasher);
+
+    // High-precision timestamp
+    SeedTimestamp(hasher);
+
+    // Sleep for 1ms
+    MilliSleep(1);
+
+    // High-precision timestamp after sleeping (as we commit to both the time before and after, this measures the delay)
+    SeedTimestamp(hasher);
+
+    // Windows performance monitor data (once every 10 minutes)
+    RandAddSeedPerfmon(hasher);
+}
+
+static void SeedStartup(CSHA512& hasher)
+{
+#ifdef WIN32
+    RAND_screen();
+#endif
+
+    // Everything that the 'slow' seeder includes.
+    SeedSlow(hasher);
+
+    // Windows performance monitor data.
+    RandAddSeedPerfmon(hasher);
+}
+
+enum class RNGLevel {
+    FAST, //!< Automatically called by GetRandBytes
+    SLOW, //!< Automatically called by GetStrongRandBytes
+    SLEEP, //!< Called by RandAddSeedSleep()
+};
+
+static void ProcRand(unsigned char* out, int num, RNGLevel level)
+{
+    // Make sure the RNG is initialized first (as all Seed* function possibly need hwrand to be available).
     RNGState& rng = GetRNGState();
 
     assert(num <= 32);
+
     CSHA512 hasher;
-    unsigned char buf[64];
-
-    // First source: OpenSSL's RNG
-    RandAddSeedPerfmon();
-    GetRandBytes(buf, 32);
-    hasher.Write(buf, 32);
-
-    // Second source: OS RNG
-    GetOSRand(buf);
-    hasher.Write(buf, 32);
-
-    // Third source: HW RNG, if available.
-    if (GetHardwareRand(buf)) {
-        hasher.Write(buf, 32);
+    switch (level) {
+    case RNGLevel::FAST:
+        SeedFast(hasher);
+        break;
+    case RNGLevel::SLOW:
+        SeedSlow(hasher);
+        break;
+    case RNGLevel::SLEEP:
+        SeedSleep(hasher);
+        break;
     }
 
     // Combine with and update state
-    rng.MixExtract(out, num, std::move(hasher));
+    if (!rng.MixExtract(out, num, std::move(hasher), false)) {
+        // On the first invocation, also seed with SeedStartup().
+        CSHA512 startup_hasher;
+        SeedStartup(startup_hasher);
+        rng.MixExtract(out, num, std::move(startup_hasher), true);
+    }
 
-    // Produce output
-    hasher.Finalize(buf);
-    memcpy(out, buf, num);
-    memory_cleanse(buf, 64);
+    // For anything but the 'fast' level, feed the resulting RNG output (after an additional hashing step) back into OpenSSL.
+    if (level != RNGLevel::FAST) {
+        unsigned char buf[64];
+        CSHA512().Write(out, num).Finalize(buf);
+        RAND_add(buf, sizeof(buf), num);
+        memory_cleanse(buf, 64);
+    }
 }
+
+void GetRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::FAST); }
+void GetStrongRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::SLOW); }
+void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
 uint64_t GetRand(uint64_t nMax)
 {
@@ -536,8 +584,10 @@ bool Random_SanityCheck()
     if (stop == start) return false;
 
     // We called GetPerformanceCounter. Use it as entropy.
-    RAND_add((const unsigned char*)&start, sizeof(start), 1);
-    RAND_add((const unsigned char*)&stop, sizeof(stop), 1);
+    CSHA512 to_add;
+    to_add.Write((const unsigned char*)&start, sizeof(start));
+    to_add.Write((const unsigned char*)&stop, sizeof(stop));
+    GetRNGState().MixExtract(nullptr, 0, std::move(to_add), false);
 
     return true;
 }
@@ -554,7 +604,7 @@ FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDete
 void RandomInit()
 {
     // Invoke RNG code to trigger initialization (if not already performed)
-    GetRNGState();
+    ProcRand(nullptr, 0, RNGLevel::FAST);
 
     ReportHardwareRand();
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -75,7 +75,6 @@ static inline int64_t GetPerformanceCounter()
 }
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
 static void InitHardwareRand()
@@ -84,12 +83,10 @@ static void InitHardwareRand()
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
         rdrand_supported = true;
     }
-    hwrand_initialized.store(true);
 }
 
 static void ReportHardwareRand()
 {
-    assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
         // This must be done in a separate function, as HWRandInit() may be indirectly called
         // from global constructors, before logging is initialized.
@@ -109,7 +106,6 @@ static void ReportHardwareRand() {}
 
 static bool GetHardwareRand(unsigned char* ent32) {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-    assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
         uint8_t ok;
         // Not all assemblers support the rdrand instruction, write it in hex.

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -162,13 +162,13 @@ static void RandAddSeedPerfmon()
     if (ret == ERROR_SUCCESS) {
         RAND_add(vData.data(), nSize, nSize / 100.0);
         memory_cleanse(vData.data(), nSize);
-        LogPrint("rand", "%s: %lu bytes\n", __func__, nSize);
     } else {
-        static bool warned = false; // Warn only once
-        if (!warned) {
-            LogPrintf("%s: Warning: RegQueryValueExA(HKEY_PERFORMANCE_DATA) failed with code %i\n", __func__, ret);
-            warned = true;
-        }
+        // Performance data is only a best-effort attempt at improving the
+        // situation when the OS randomness (and other sources) aren't
+        // adequate. As a result, failure to read it is isn't considered critical,
+        // so we don't call RandFailure().
+        // TODO: Add logging when the logger is made functional before global
+        // constructors have been invoked.
     }
 #endif
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -11,8 +11,9 @@
 #include "compat.h" // for Windows API
 #include <wincrypt.h>
 #endif
-#include "util.h"             // for LogPrint()
-#include "utilstrencodings.h" // for GetTime()
+#include "util.h"     // for LogPrint()
+#include "sync.h"     // for WAIT_LOCK
+#include "utiltime.h" // for GetTime()
 
 #include <stdlib.h>
 #include <limits>
@@ -41,8 +42,11 @@
 #include <cpuid.h>
 #endif
 
+#include <boost/thread/mutex.hpp>
+
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <openssl/conf.h>
 
 static void RandFailure()
 {
@@ -288,15 +292,46 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
+
 namespace {
+
 struct RNGState {
     Mutex m_mutex;
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
+    std::unique_ptr<Mutex[]> m_mutex_openssl;
 
     RNGState()
     {
         InitHardwareRand();
+
+        // Init OpenSSL library multithreading support
+        m_mutex_openssl.reset(new Mutex[CRYPTO_num_locks()]);
+        CRYPTO_set_locking_callback(LockingCallbackOpenSSL);
+
+        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
+        // We don't use them so we don't require the config. However some of our libs may call functions
+        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
+        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
+        // that the config appears to have been loaded and there are no modules/engines available.
+        OPENSSL_no_config();
+
+#ifdef WIN32
+        // Seed OpenSSL PRNG with current contents of the screen
+        RAND_screen();
+#endif
+
+        // Seed OpenSSL PRNG with performance counter
+        RandAddSeed();
+    }
+
+    ~RNGState()
+    {
+        // Securely erase the memory used by the OpenSSL PRNG
+        RAND_cleanup();
+        // Shutdown OpenSSL library multithreading support
+        CRYPTO_set_locking_callback(nullptr);
     }
 
     /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher. */
@@ -306,7 +341,7 @@ struct RNGState {
         unsigned char buf[64];
         static_assert(sizeof(buf) == CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
         {
-            LOCK(m_mutex);
+            WAIT_LOCK(m_mutex, lock);
             // Write the current state of the RNG into the hasher
             hasher.Write(m_state, 32);
             // Write a new counter number into the state
@@ -335,6 +370,17 @@ RNGState& GetRNGState()
     static std::unique_ptr<RNGState> g_rng{new RNGState()};
     return *g_rng;
 }
+}
+
+void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
+{
+    RNGState& rng = GetRNGState();
+
+    if (mode & CRYPTO_LOCK) {
+        rng.m_mutex_openssl[i].lock();
+    } else {
+        rng.m_mutex_openssl[i].unlock();
+    }
 }
 
 static void AddDataToRng(void* data, size_t len, RNGState& rng);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -298,6 +298,34 @@ struct RNGState {
     {
         InitHardwareRand();
     }
+
+    /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher. */
+    void MixExtract(unsigned char* out, size_t num, CSHA512&& hasher)
+    {
+        assert(num <= 32);
+        unsigned char buf[64];
+        static_assert(sizeof(buf) == CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
+        {
+            LOCK(m_mutex);
+            // Write the current state of the RNG into the hasher
+            hasher.Write(m_state, 32);
+            // Write a new counter number into the state
+            hasher.Write((const unsigned char*)&m_counter, sizeof(m_counter));
+            ++m_counter;
+            // Finalize the hasher
+            hasher.Finalize(buf);
+            // Store the last 32 bytes of the hash output as new RNG state.
+            memcpy(m_state, buf + 32, 32);
+        }
+        // If desired, copy (up to) the first 32 bytes of the hash output as output.
+        if (num) {
+            assert(out != nullptr);
+            memcpy(out, buf, num);
+        }
+        // Best effort cleanup of internal state
+        hasher.Reset();
+        memory_cleanse(buf, 64);
+    }
 };
 
 RNGState& GetRNGState()
@@ -309,38 +337,29 @@ RNGState& GetRNGState()
 }
 }
 
-static void AddDataToRng(void* data, size_t len);
+static void AddDataToRng(void* data, size_t len, RNGState& rng);
 
 void RandAddSeedSleep()
 {
+    RNGState& rng = GetRNGState();
+
     int64_t nPerfCounter1 = GetPerformanceCounter();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     int64_t nPerfCounter2 = GetPerformanceCounter();
 
     // Combine with and update state
-    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1));
-    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2));
+    AddDataToRng(&nPerfCounter1, sizeof(nPerfCounter1), rng);
+    AddDataToRng(&nPerfCounter2, sizeof(nPerfCounter2), rng);
 
     memory_cleanse(&nPerfCounter1, sizeof(nPerfCounter1));
     memory_cleanse(&nPerfCounter2, sizeof(nPerfCounter2));
 }
 
-static void AddDataToRng(void* data, size_t len) {
-    RNGState& rng = GetRNGState();
-
+static void AddDataToRng(void* data, size_t len, RNGState& rng) {
     CSHA512 hasher;
     hasher.Write((const unsigned char*)&len, sizeof(len));
     hasher.Write((const unsigned char*)data, len);
-    unsigned char buf[64];
-    {
-        LOCK(rng.m_mutex);
-        hasher.Write(rng.m_state, sizeof(rng.m_state));
-        hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
-        ++rng.m_counter;
-        hasher.Finalize(buf);
-        memcpy(rng.m_state, buf + 32, 32);
-    }
-    memory_cleanse(buf, 64);
+    rng.MixExtract(nullptr, 0, std::move(hasher));
 }
 
 void GetStrongRandBytes(unsigned char* out, int num)
@@ -366,14 +385,7 @@ void GetStrongRandBytes(unsigned char* out, int num)
     }
 
     // Combine with and update state
-    {
-        LOCK(rng.m_mutex);
-        hasher.Write(rng.m_state, sizeof(rng.m_state));
-        hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
-        ++rng.m_counter;
-        hasher.Finalize(buf);
-        memcpy(rng.m_state, buf + 32, 32);
-    }
+    rng.MixExtract(out, num, std::move(hasher));
 
     // Produce output
     hasher.Finalize(buf);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -20,6 +20,8 @@
 #include <chrono>
 #include <thread>
 
+#include <support/allocators/secure.h>
+
 #ifndef WIN32
 #include <sys/time.h>
 #endif
@@ -348,8 +350,8 @@ RNGState& GetRNGState() noexcept
 {
     // This C++11 idiom relies on the guarantee that static variable are initialized
     // on first call, even when multiple parallel calls are permitted.
-    static std::unique_ptr<RNGState> g_rng{new RNGState()};
-    return *g_rng;
+    static std::vector<RNGState, secure_allocator<RNGState>> g_rng(1);
+    return g_rng[0];
 }
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -291,10 +291,11 @@ void GetRandBytes(unsigned char* buf, int num)
 namespace {
 struct RNGState {
     Mutex m_mutex;
-    unsigned char m_state[32] = {0};
-    uint64_t m_counter = 0;
+    unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
+    uint64_t m_counter GUARDED_BY(m_mutex) = 0;
 
-    explicit RNGState() {
+    RNGState()
+    {
         InitHardwareRand();
     }
 };
@@ -332,7 +333,7 @@ static void AddDataToRng(void* data, size_t len) {
     hasher.Write((const unsigned char*)data, len);
     unsigned char buf[64];
     {
-        std::unique_lock<Mutex> lock(rng.m_mutex);
+        LOCK(rng.m_mutex);
         hasher.Write(rng.m_state, sizeof(rng.m_state));
         hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
         ++rng.m_counter;
@@ -366,7 +367,7 @@ void GetStrongRandBytes(unsigned char* out, int num)
 
     // Combine with and update state
     {
-        std::unique_lock<Mutex> lock(rng.m_mutex);
+        LOCK(rng.m_mutex);
         hasher.Write(rng.m_state, sizeof(rng.m_state));
         hasher.Write((const unsigned char*)&rng.m_counter, sizeof(rng.m_counter));
         ++rng.m_counter;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -54,7 +54,7 @@ static void RandFailure()
     abort();
 }
 
-static inline int64_t GetPerformanceCounter()
+static inline int64_t GetPerformanceCounter() noexcept
 {
     // Read the hardware time stamp counter when available.
     // See https://en.wikipedia.org/wiki/Time_Stamp_Counter for more information.
@@ -104,7 +104,7 @@ static void InitHardwareRand() {}
 static void ReportHardwareRand() {}
 #endif
 
-static bool GetHardwareRand(unsigned char* ent32) {
+static bool GetHardwareRand(unsigned char* ent32) noexcept {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
     if (rdrand_supported) {
         uint8_t ok;
@@ -282,7 +282,7 @@ struct RNGState {
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
     std::unique_ptr<Mutex[]> m_mutex_openssl;
 
-    RNGState()
+    RNGState() noexcept
     {
         InitHardwareRand();
 
@@ -310,7 +310,7 @@ struct RNGState {
      *
      * If this function has never been called with strong_seed = true, false is returned.
      */
-    bool MixExtract(unsigned char* out, size_t num, CSHA512&& hasher, bool strong_seed)
+    bool MixExtract(unsigned char* out, size_t num, CSHA512&& hasher, bool strong_seed) noexcept
     {
         assert(num <= 32);
         unsigned char buf[64];
@@ -341,7 +341,7 @@ struct RNGState {
     }
 };
 
-RNGState& GetRNGState()
+RNGState& GetRNGState() noexcept
 {
     // This C++11 idiom relies on the guarantee that static variable are initialized
     // on first call, even when multiple parallel calls are permitted.
@@ -361,13 +361,28 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THRE
     }
 }
 
-static void SeedTimestamp(CSHA512& hasher)
+/* A note on the use of noexcept in the seeding functions below:
+ *
+ * None of the RNG code should ever throw any exception, with the sole exception
+ * of MilliSleep in SeedSleep, which can (and does) support interruptions which
+ * cause a boost::thread_interrupted to be thrown.
+ *
+ * This means that SeedSleep, and all functions that invoke it are throwing.
+ * However, we know that GetRandBytes() and GetStrongRandBytes() never trigger
+ * this sleeping logic, so they are noexcept. The same is true for all the
+ * GetRand*() functions that use GetRandBytes() indirectly.
+ *
+ * TODO: After moving away from interruptible boost-based thread management,
+ * everything can become noexcept here.
+ */
+
+static void SeedTimestamp(CSHA512& hasher) noexcept
 {
     int64_t perfcounter = GetPerformanceCounter();
     hasher.Write((const unsigned char*)&perfcounter, sizeof(perfcounter));
 }
 
-static void SeedFast(CSHA512& hasher)
+static void SeedFast(CSHA512& hasher) noexcept
 {
     unsigned char buffer[32];
 
@@ -383,7 +398,7 @@ static void SeedFast(CSHA512& hasher)
     SeedTimestamp(hasher);
 }
 
-static void SeedSlow(CSHA512& hasher)
+static void SeedSlow(CSHA512& hasher) noexcept
 {
     unsigned char buffer[32];
 
@@ -423,7 +438,7 @@ static void SeedSleep(CSHA512& hasher)
     RandAddSeedPerfmon(hasher);
 }
 
-static void SeedStartup(CSHA512& hasher)
+static void SeedStartup(CSHA512& hasher) noexcept
 {
 #ifdef WIN32
     RAND_screen();
@@ -479,11 +494,11 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
     }
 }
 
-void GetRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::FAST); }
-void GetStrongRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::SLOW); }
+void GetRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::FAST); }
+void GetStrongRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::SLOW); }
 void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
-uint64_t GetRand(uint64_t nMax)
+uint64_t GetRand(uint64_t nMax) noexcept
 {
     if (nMax == 0)
         return 0;
@@ -498,12 +513,12 @@ uint64_t GetRand(uint64_t nMax)
     return (nRand % nMax);
 }
 
-int GetRandInt(int nMax)
+int GetRandInt(int nMax) noexcept
 {
     return GetRand(nMax);
 }
 
-uint256 GetRandHash()
+uint256 GetRandHash() noexcept
 {
     uint256 hash;
     GetRandBytes((unsigned char*)&hash, sizeof(hash));
@@ -517,7 +532,7 @@ void FastRandomContext::RandomSeed()
     requires_seed = false;
 }
 
-uint256 FastRandomContext::rand256()
+uint256 FastRandomContext::rand256() noexcept
 {
     if (bytebuf_size < 32) {
         FillByteBuffer();
@@ -537,7 +552,7 @@ std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
     return ret;
 }
 
-FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(const uint256& seed) noexcept : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
 {
     rng.SetKey(seed.begin(), 32);
 }
@@ -588,7 +603,7 @@ bool Random_SanityCheck()
     return true;
 }
 
-FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(bool fDeterministic) noexcept : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
 {
     if (!fDeterministic) {
         return;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -500,17 +500,7 @@ void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
 uint64_t GetRand(uint64_t nMax) noexcept
 {
-    if (nMax == 0)
-        return 0;
-
-    // The range of the random source must be a multiple of the modulus
-    // to give every possible output value an equal possibility
-    uint64_t nRange = (std::numeric_limits<uint64_t>::max() / nMax) * nMax;
-    uint64_t nRand = 0;
-    do {
-        GetRandBytes((unsigned char*)&nRand, sizeof(nRand));
-    } while (nRand >= nRange);
-    return (nRand % nMax);
+    return FastRandomContext().randrange(nMax);
 }
 
 int GetRandInt(int nMax) noexcept

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -74,7 +74,7 @@ static inline int64_t GetPerformanceCounter()
 static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
-static void RDRandInit()
+static void InitHardwareRand()
 {
     uint32_t eax, ebx, ecx, edx;
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
@@ -83,7 +83,7 @@ static void RDRandInit()
     hwrand_initialized.store(true);
 }
 
-static void RDRandReport()
+static void ReportHardwareRand()
 {
     assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
@@ -94,11 +94,16 @@ static void RDRandReport()
 }
 
 #else
-static void RDRandInit() {}
-static void RDRandReport() {}
+/* Access to other hardware random number generators could be added here later,
+ * assuming it is sufficiently fast (in the order of a few hundred CPU cycles).
+ * Slower sources should probably be invoked separately, and/or only from
+ * RandAddSeedSleep (which is called during idle background operation).
+ */
+static void InitHardwareRand() {}
+static void ReportHardwareRand() {}
 #endif
 
-static bool GetHWRand(unsigned char* ent32) {
+static bool GetHardwareRand(unsigned char* ent32) {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
     assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
@@ -290,7 +295,7 @@ struct RNGState {
     uint64_t m_counter = 0;
 
     explicit RNGState() {
-        RDRandInit();
+        InitHardwareRand();
     }
 };
 
@@ -355,7 +360,7 @@ void GetStrongRandBytes(unsigned char* out, int num)
     hasher.Write(buf, 32);
 
     // Third source: HW RNG, if available.
-    if (GetHWRand(buf)) {
+    if (GetHardwareRand(buf)) {
         hasher.Write(buf, 32);
     }
 
@@ -492,5 +497,5 @@ void RandomInit()
     // Invoke RNG code to trigger initialization (if not already performed)
     GetRNGState();
 
-    RDRandReport();
+    ReportHardwareRand();
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -12,7 +12,7 @@
 #include <wincrypt.h>
 #endif
 #include "util.h"     // for LogPrint()
-#include "sync.h"     // for LOCK
+#include "sync.h"     // for CMutexLock
 #include "utiltime.h" // for GetTime()
 
 #include <stdlib.h>
@@ -306,7 +306,9 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
 namespace {
 
 class RNGState {
-    Mutex m_mutex;
+    /* Upstream uses sync.h's non-recursive Mutex, which this tree does not have.
+     * CWaitableCriticalSection is the same AnnotatedMixin<boost::mutex>. */
+    CWaitableCriticalSection m_mutex;
     /* The RNG state consists of 256 bits of entropy, taken from the output of
      * one operation's SHA512 output, and fed as input to the next one.
      * Carrying 256 bits of entropy should be sufficient to guarantee
@@ -318,7 +320,7 @@ class RNGState {
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
-    std::unique_ptr<Mutex[]> m_mutex_openssl;
+    std::unique_ptr<CWaitableCriticalSection[]> m_mutex_openssl;
 
 public:
     RNGState() noexcept
@@ -326,7 +328,7 @@ public:
         InitHardwareRand();
 
         // Init OpenSSL library multithreading support
-        m_mutex_openssl.reset(new Mutex[CRYPTO_num_locks()]);
+        m_mutex_openssl.reset(new CWaitableCriticalSection[CRYPTO_num_locks()]);
         CRYPTO_set_locking_callback(LockingCallbackOpenSSL);
 
         // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
@@ -356,7 +358,8 @@ public:
         static_assert(sizeof(buf) == CSHA512::OUTPUT_SIZE, "Buffer needs to have hasher's output size");
         bool ret;
         {
-            LOCK(m_mutex);
+            /* LOCK() is hardcoded to CCriticalSection here; CMutexLock is already generic. */
+            CMutexLock<CWaitableCriticalSection> lock(m_mutex, "m_mutex", __FILE__, __LINE__);
             ret = (m_strongly_seeded |= strong_seed);
             // Write the current state of the RNG into the hasher
             hasher.Write(m_state, 32);
@@ -379,7 +382,7 @@ public:
         return ret;
     }
 
-    Mutex& GetOpenSSLMutex(int i) { return m_mutex_openssl[i]; }
+    CWaitableCriticalSection& GetOpenSSLMutex(int i) { return m_mutex_openssl[i]; }
 };
 
 RNGState& GetRNGState() noexcept

--- a/src/random.h
+++ b/src/random.h
@@ -14,6 +14,49 @@
 #include <limits>
 
 /**
+ * Overall design of the RNG and entropy sources.
+ *
+ * We maintain a single global 256-bit RNG state for all high-quality randomness.
+ * The following (classes of) functions interact with that state by mixing in new
+ * entropy, and optionally extracting random output from it:
+ *
+ * - The GetRand*() class of functions, as well as construction of FastRandomContext objects,
+ *   perform 'fast' seeding, consisting of mixing in:
+ *   - A stack pointer (indirectly committing to calling thread and call stack)
+ *   - A high-precision timestamp (rdtsc when available, c++ high_resolution_clock otherwise)
+ *   - Hardware RNG (rdrand) when available.
+ *   These entropy sources are very fast, and only designed to protect against situations
+ *   where a VM state restore/copy results in multiple systems with the same randomness.
+ *   FastRandomContext on the other hand does not protect against this once created, but
+ *   is even faster (and acceptable to use inside tight loops).
+ *
+ * - The GetStrongRand*() class of function perform 'slow' seeding, including everything
+ *   that fast seeding includes, but additionally:
+ *   - OS entropy (/dev/urandom, getrandom(), ...). The application will terminate if
+ *     this entropy source fails.
+ *   - Bytes from OpenSSL's RNG (which itself may be seeded from various sources)
+ *   - Another high-precision timestamp (indirectly committing to a benchmark of all the
+ *     previous sources).
+ *   These entropy sources are slower, but designed to make sure the RNG state contains
+ *   fresh data that is unpredictable to attackers.
+ *
+ * - RandAddSeedSleep() seeds everything that fast seeding includes, but additionally:
+ *   - A high-precision timestamp before and after sleeping 1ms.
+ *   - (On Windows) Once every 10 minutes, performance monitoring data from the OS.
+ *   These just exploit the fact the system is idle to improve the quality of the RNG
+ *   slightly.
+ *
+ * On first use of the RNG (regardless of what function is called first), all entropy
+ * sources used in the 'slow' seeder are included, but also:
+ * - (On Windows) Performance monitoring data from the OS.
+ * - (On Windows) Through OpenSSL, the screen contents.
+ *
+ * When mixing in new entropy, H = SHA512(entropy || old_rng_state) is computed, and
+ * (up to) the first 32 bytes of H are produced as output, while the last 32 bytes
+ * become the new RNG state.
+*/
+
+/**
  * Generate random data via the internal PRNG.
  *
  * These functions are designed to be fast (sub microsecond), but do not necessarily

--- a/src/random.h
+++ b/src/random.h
@@ -43,6 +43,7 @@
  * - RandAddSeedSleep() seeds everything that fast seeding includes, but additionally:
  *   - A high-precision timestamp before and after sleeping 1ms.
  *   - (On Windows) Once every 10 minutes, performance monitoring data from the OS.
+ -   - Once every minute, strengthen the entropy for 10 ms using repeated SHA512.
  *   These just exploit the fact the system is idle to improve the quality of the RNG
  *   slightly.
  *
@@ -50,6 +51,7 @@
  * sources used in the 'slow' seeder are included, but also:
  * - (On Windows) Performance monitoring data from the OS.
  * - (On Windows) Through OpenSSL, the screen contents.
+ * - Strengthen the entropy for 100 ms using repeated SHA512.
  *
  * When mixing in new entropy, H = SHA512(entropy || old_rng_state) is computed, and
  * (up to) the first 32 bytes of H are produced as output, while the last 32 bytes

--- a/src/random.h
+++ b/src/random.h
@@ -21,10 +21,10 @@
  *
  * Thread-safe.
  */
-void GetRandBytes(unsigned char* buf, int num);
-uint64_t GetRand(uint64_t nMax);
-int GetRandInt(int nMax);
-uint256 GetRandHash();
+void GetRandBytes(unsigned char* buf, int num) noexcept;
+uint64_t GetRand(uint64_t nMax) noexcept;
+int GetRandInt(int nMax) noexcept;
+uint256 GetRandHash() noexcept;
 
 /**
  * Gather entropy from various sources, feed it into the internal PRNG, and
@@ -34,7 +34,7 @@ uint256 GetRandHash();
  *
  * Thread-safe.
  */
-void GetStrongRandBytes(unsigned char* buf, int num);
+void GetStrongRandBytes(unsigned char* buf, int num) noexcept;
 
 /**
  * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
@@ -78,13 +78,13 @@ private:
     }
 
 public:
-    explicit FastRandomContext(bool fDeterministic = false);
+    explicit FastRandomContext(bool fDeterministic = false) noexcept;
 
     /** Initialize with explicit seed (only for testing) */
-    explicit FastRandomContext(const uint256& seed);
+    explicit FastRandomContext(const uint256& seed) noexcept;
 
     /** Generate a random 64-bit integer. */
-    uint64_t rand64()
+    uint64_t rand64() noexcept
     {
         if (bytebuf_size < 8) FillByteBuffer();
         uint64_t ret = ReadLE64(bytebuf + 64 - bytebuf_size);
@@ -93,7 +93,7 @@ public:
     }
 
     /** Generate a random (bits)-bit integer. */
-    uint64_t randbits(int bits) {
+    uint64_t randbits(int bits) noexcept {
         if (bits == 0) {
             return 0;
         } else if (bits > 32) {
@@ -108,7 +108,7 @@ public:
     }
 
     /** Generate a random integer in the range [0..range). */
-    uint64_t randrange(uint64_t range)
+    uint64_t randrange(uint64_t range) noexcept
     {
         --range;
         int bits = CountBits(range);
@@ -122,19 +122,19 @@ public:
     std::vector<unsigned char> randbytes(size_t len);
 
     /** Generate a random 32-bit integer. */
-    uint32_t rand32() { return randbits(32); }
+    uint32_t rand32() noexcept { return randbits(32); }
 
     /** generate a random uint256. */
-    uint256 rand256();
+    uint256 rand256() noexcept;
 
     /** Generate a random boolean. */
-    bool randbool() { return randbits(1); }
+    bool randbool() noexcept { return randbits(1); }
 
     // Compatibility with the C++11 UniformRandomBitGenerator concept
     typedef uint64_t result_type;
     static constexpr uint64_t min() { return 0; }
     static constexpr uint64_t max() { return std::numeric_limits<uint64_t>::max(); }
-    inline uint64_t operator()() { return rand64(); }
+    inline uint64_t operator()() noexcept { return rand64(); }
 };
 
 /* Number of random bytes returned by GetOSRand.

--- a/src/random.h
+++ b/src/random.h
@@ -140,7 +140,12 @@ void GetOSRand(unsigned char *ent32);
  */
 bool Random_SanityCheck();
 
-/** Initialize the RNG. */
+/**
+ * Initialize global RNG state and log any CPU features that are used.
+ *
+ * Calling this function is optional. RNG state will be initialized when first
+ * needed if it is not called.
+ */
 void RandomInit();
 
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -13,11 +13,13 @@
 #include <stdint.h>
 #include <limits>
 
-/* Seed OpenSSL PRNG with additional entropy data */
-void RandAddSeed();
-
 /**
- * Functions to gather random data via the OpenSSL PRNG
+ * Generate random data via the internal PRNG.
+ *
+ * These functions are designed to be fast (sub microsecond), but do not necessarily
+ * meaningfully add entropy to the PRNG state.
+ *
+ * Thread-safe.
  */
 void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);
@@ -25,14 +27,26 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
- * Function to gather random data from multiple sources, failing whenever any
- * of those source fail to provide a result.
+ * Gather entropy from various sources, feed it into the internal PRNG, and
+ * generate random data using it.
+ *
+ * This function will cause failure whenever the OS RNG fails.
+ *
+ * Thread-safe.
  */
 void GetStrongRandBytes(unsigned char* buf, int num);
 
 /**
+ * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
+ *
+ * Thread-safe.
+ */
+void RandAddSeedSleep();
+
+/**
  * Fast randomness source. This is seeded once with secure random data, but
- * is completely deterministic and insecure after that.
+ * is completely deterministic and does not gather more entropy after that.
+ *
  * This class is not thread-safe.
  */
 class FastRandomContext {

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -5,6 +5,7 @@
 
 #include "scheduler.h"
 
+#include "random.h"
 #include "reverselock.h"
 
 #include <assert.h>
@@ -38,6 +39,11 @@ void CScheduler::serviceQueue()
     // is called.
     while (!shouldStop()) {
         try {
+            if (!shouldStop() && taskQueue.empty()) {
+                reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
+                // Use this chance to get more entropy
+                RandAddSeedSleep();
+            }
             while (!shouldStop() && taskQueue.empty()) {
                 // Wait until there is something to do.
                 newTaskScheduled.wait(lock);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -123,57 +123,6 @@ bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
 CTranslationInterface translationInterface;
 
-/** Init OpenSSL library multithreading support */
-static CCriticalSection** ppmutexOpenSSL;
-void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
-{
-    if (mode & CRYPTO_LOCK) {
-        ENTER_CRITICAL_SECTION(*ppmutexOpenSSL[i]);
-    } else {
-        LEAVE_CRITICAL_SECTION(*ppmutexOpenSSL[i]);
-    }
-}
-
-// Init
-class CInit
-{
-public:
-    CInit()
-    {
-        // Init OpenSSL library multithreading support
-        ppmutexOpenSSL = (CCriticalSection**)OPENSSL_malloc(CRYPTO_num_locks() * sizeof(CCriticalSection*));
-        for (int i = 0; i < CRYPTO_num_locks(); i++)
-            ppmutexOpenSSL[i] = new CCriticalSection();
-        CRYPTO_set_locking_callback(locking_callback);
-
-        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
-        // We don't use them so we don't require the config. However some of our libs may call functions
-        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
-        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
-        // that the config appears to have been loaded and there are no modules/engines available.
-        OPENSSL_no_config();
-
-#ifdef WIN32
-        // Seed OpenSSL PRNG with current contents of the screen
-        RAND_screen();
-#endif
-
-        // Seed OpenSSL PRNG with performance counter
-        RandAddSeed();
-    }
-    ~CInit()
-    {
-        // Securely erase the memory used by the PRNG
-        RAND_cleanup();
-        // Shutdown OpenSSL library multithreading support
-        CRYPTO_set_locking_callback(NULL);
-        for (int i = 0; i < CRYPTO_num_locks(); i++)
-            delete ppmutexOpenSSL[i];
-        OPENSSL_free(ppmutexOpenSSL);
-    }
-}
-instance_of_cinit;
-
 /**
  * LogPrintf() has been broken a couple of times now
  * by well-meaning people adding mutexes in the most straightforward way.


### PR DESCRIPTION
do not merge before #3522. one commit on top.

Strengthen() bounded its hash loop with GetTimeMicros() and SeedStrengthen()
gated itself on the same wall clock, so an ntp step backwards suppresses
periodic strengthening until real time catches up, and a step forward triggers
it early. the gate covers a minute; the loop is 100ms on first run and 10ms
after.

GetTimeMicros() is boost's microsec_clock::universal_time() and is not mockable;
GetMockableTimeMicros() is the mockable one and random.cpp never called it, so
no test drove either path through SetMockTime.

adapted from bitcoin 1111e2f8b4, which does this for Strengthen() only. the gate
arrived with 1d207bc46f "Add hash strengthening to the RNG" and upstream took it
out again in d61f2bb076 "Run background seeding periodically instead of
unpredictably", so 1111e2f8b4 had nothing to change there. it carries the same
defect here, and the commit message says which half is upstream.

kept the int microseconds signature rather than the duration-typed api. the
SteadyClock alias that api uses lives in bitcoin's util/time.h; the equivalent
here is utiltime.h, which is chrono-free, so taking the duration form means
defining the alias in this tree and changing four call sites for no behavioural
gain.

builds clean, random_tests pass, full unit suite reports no errors.
